### PR TITLE
core: Re-enable macOS 13 as minimum deployment target

### DIFF
--- a/MacPacker.xcodeproj/project.pbxproj
+++ b/MacPacker.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		259511052E9C52A30065F366 /* TailBeatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 259511042E9C52A30065F366 /* TailBeatKit */; };
 		259511072E9C56B20065F366 /* TailBeatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 259511062E9C56B20065F366 /* TailBeatKit */; };
 		259511092E9C56BC0065F366 /* TailBeatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 259511082E9C56BC0065F366 /* TailBeatKit */; };
+		25A286382EA510CC00271329 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 25A286372EA510CC00271329 /* KeyboardShortcuts */; };
+		25A2863A2EA510E000271329 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 25A286392EA510E000271329 /* KeyboardShortcuts */; };
 		25C0A8C42A78DE62002C1C2A /* MacPackerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C0A8C32A78DE62002C1C2A /* MacPackerUITests.swift */; };
 		25C0A8C62A78DE62002C1C2A /* MacPackerUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C0A8C52A78DE62002C1C2A /* MacPackerUITestsLaunchTests.swift */; };
 		25C764252E6C6D5300464CF5 /* XADMasterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 25C764242E6C6D5300464CF5 /* XADMasterSwift */; };
@@ -205,6 +207,7 @@
 				25CD1EBD2D829DEA007B53EE /* SWCompression in Frameworks */,
 				2592CEDF2AD4F77E008DEFF8 /* ZIPFoundation in Frameworks */,
 				259511052E9C52A30065F366 /* TailBeatKit in Frameworks */,
+				25A2863A2EA510E000271329 /* KeyboardShortcuts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,6 +226,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25E426CA2E6BEB3800F10BE5 /* XADMasterSwift in Frameworks */,
+				25A286382EA510CC00271329 /* KeyboardShortcuts in Frameworks */,
 				25CD1EBB2D829CBB007B53EE /* BitByteData in Frameworks */,
 				259511032E9C529A0065F366 /* TailBeatKit in Frameworks */,
 				25C764252E6C6D5300464CF5 /* XADMasterSwift in Frameworks */,
@@ -355,6 +359,7 @@
 				25CD1EBE2D829DEA007B53EE /* BitByteData */,
 				25C764262E6C6D6200464CF5 /* XADMasterSwift */,
 				259511042E9C52A30065F366 /* TailBeatKit */,
+				25A286392EA510E000271329 /* KeyboardShortcuts */,
 			);
 			productName = MacPacker;
 			productReference = 254BB5592ABBE8430059A1D5 /* MacPacker.app */;
@@ -412,6 +417,7 @@
 				25E426C92E6BEB3800F10BE5 /* XADMasterSwift */,
 				25C764242E6C6D5300464CF5 /* XADMasterSwift */,
 				259511022E9C529A0065F366 /* TailBeatKit */,
+				25A286372EA510CC00271329 /* KeyboardShortcuts */,
 			);
 			productName = MacPacker;
 			productReference = 25C0A8A42A78DE5F002C1C2A /* MacPacker.app */;
@@ -504,6 +510,7 @@
 				25CD1EB92D829CBB007B53EE /* XCRemoteSwiftPackageReference "BitByteData" */,
 				25C764232E6C6D5300464CF5 /* XCRemoteSwiftPackageReference "XADMasterSwift" */,
 				2567C8262E8F429B008E1BD8 /* XCRemoteSwiftPackageReference "tailbeat-swift" */,
+				25A286362EA510CC00271329 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
 			);
 			productRefGroup = 25C0A8A52A78DE5F002C1C2A /* Products */;
 			projectDirPath = "";
@@ -647,7 +654,7 @@
 				CODE_SIGN_ENTITLEMENTS = FinderExtension/FinderExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -662,8 +669,8 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker.FinderExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -681,7 +688,7 @@
 				CODE_SIGN_ENTITLEMENTS = FinderExtension/FinderExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -696,8 +703,8 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker.FinderExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -716,7 +723,7 @@
 				CODE_SIGN_ENTITLEMENTS = MacPacker/MacPacker.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"MacPacker/Preview Content\"";
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -735,8 +742,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				OTHER_SWIFT_FLAGS = "-DSTORE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker;
 				PRODUCT_NAME = MacPacker;
@@ -754,7 +761,7 @@
 				CODE_SIGN_ENTITLEMENTS = MacPacker/MacPacker.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"MacPacker/Preview Content\"";
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -773,8 +780,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				OTHER_SWIFT_FLAGS = "-DSTORE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker;
 				PRODUCT_NAME = MacPacker;
@@ -789,7 +796,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = QuickLookExtension/QuickLookExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -816,8 +823,8 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker.QuickLookExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -837,7 +844,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = QuickLookExtension/QuickLookExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -864,8 +871,8 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker.QuickLookExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1002,7 +1009,7 @@
 				CODE_SIGN_ENTITLEMENTS = MacPacker/MacPacker.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"MacPacker/Preview Content\"";
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1021,8 +1028,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1040,7 +1047,7 @@
 				CODE_SIGN_ENTITLEMENTS = MacPacker/MacPacker.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"MacPacker/Preview Content\"";
 				DEVELOPMENT_TEAM = ZJ2TSMMJWF;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1059,8 +1066,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sarensx.MacPacker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1238,6 +1245,14 @@
 				minimumVersion = 0.9.17;
 			};
 		};
+		25A286362EA510CC00271329 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
 		25C764232E6C6D5300464CF5 /* XCRemoteSwiftPackageReference "XADMasterSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sarensw/XADMasterSwift";
@@ -1304,6 +1319,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2567C8262E8F429B008E1BD8 /* XCRemoteSwiftPackageReference "tailbeat-swift" */;
 			productName = TailBeatKit;
+		};
+		25A286372EA510CC00271329 /* KeyboardShortcuts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 25A286362EA510CC00271329 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			productName = KeyboardShortcuts;
+		};
+		25A286392EA510E000271329 /* KeyboardShortcuts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 25A286362EA510CC00271329 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			productName = KeyboardShortcuts;
 		};
 		25C764242E6C6D5300464CF5 /* XADMasterSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/MacPacker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MacPacker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a61fad1a3d49a9dba86808c61ce5ede5b7398f2e85214b01e72141e1c7f18b70",
+  "originHash" : "66bad199834c57403b468650cf79370ca6acbd7b6113f80406926d3649d1721e",
   "pins" : [
     {
       "identity" : "bitbytedata",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "cdcdc5177ad536cfb11b95c620f926a81014b7fe",
         "version" : "2.0.4"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
       }
     },
     {

--- a/MacPacker/CHANGELOG.md
+++ b/MacPacker/CHANGELOG.md
@@ -1,5 +1,6 @@
 v0.11
 - fix: Crash when using the open with option
+- core: Re-enable macOS 13 as minimum deployment target
 
 v0.10
 - feat: Quick Look extension

--- a/MacPacker/Core/ArchiveWindow.swift
+++ b/MacPacker/Core/ArchiveWindow.swift
@@ -12,6 +12,9 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
     let archiveState: ArchiveState
     let appDelegate: AppDelegate
     
+    let archiveService = ArchiveService()
+    let contentService: ArchiveContentService = ArchiveContentService()
+    
     var willCloseHandler: (() -> Void)?
     
     init(archiveState: ArchiveState, appDelegate: AppDelegate) {
@@ -25,9 +28,23 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
         
         window.delegate = self
         
+        if #unavailable(macOS 14) {
+            // we have to use a classic toolbar for macOS 13 based on NSToolbar
+            // > no need for an else here as SwiftUIs .toolbar() loads the
+            //   toolbar in ContentView
+            let toolbar = NSToolbar(identifier: "ArchiveWindowToolbar")
+            toolbar.delegate = self
+            toolbar.displayMode = .iconOnly
+            window.toolbar = toolbar
+            
+            window.title = Bundle.main.appName
+        }
+        
+        window.toolbarStyle = .unified
+        
         // show the content view
         let contentView = ContentView()
-            .environment(AppState.shared)
+            .environmentObject(AppState.shared)
             .environmentObject(appDelegate)
             .environmentObject(archiveState)
         

--- a/MacPacker/Core/Extensions/Bool+Extensions.swift
+++ b/MacPacker/Core/Extensions/Bool+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  Bool+Extensions.swift
+//  MacPacker
+//
+//  Created by Stephan Arenswald on 20.10.25.
+//
+//  Inspired by https://www.avanderlee.com/swiftui/conditional-view-modifier/
+//
+
+extension Bool {
+    static var macOS13: Bool {
+        if #available(macOS 14, *) {
+            return false   // On macOS 14 or later
+        } else {
+            return true    // On macOS 13 or earlier
+        }
+    }
+}

--- a/MacPacker/Core/Extensions/View+Extensions.swift
+++ b/MacPacker/Core/Extensions/View+Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  View+Extensions.swift
+//  MacPacker
+//
+//  Created by Stephan Arenswald on 20.10.25.
+//
+//  Taken from https://www.avanderlee.com/swiftui/conditional-view-modifier/
+//
+
+import SwiftUI
+
+extension View {
+    /// Applies the given transform if the given condition evaluates to `true`.
+    /// - Parameters:
+    ///   - condition: The condition to evaluate.
+    ///   - transform: The transform to apply to the source `View`.
+    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
+    @ViewBuilder func `if`<Content: View>(_ condition: @autoclosure () -> Bool, transform: (Self) -> Content) -> some View {
+        if condition() {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/MacPacker/Features/ArchiveContentViewer/ArchiveView.swift
+++ b/MacPacker/Features/ArchiveContentViewer/ArchiveView.swift
@@ -56,7 +56,7 @@ struct ArchiveView: View {
                 self.drop(state.openWithUrls[0])
             }
         }
-        .onChange(of: selection) {
+        .onChange(of: selection) { _ in
             print("selection changed: \(String(describing: selection))")
             if let indexes = selection,
                 let archive = state.archive {
@@ -67,14 +67,6 @@ struct ArchiveView: View {
                     state.selectedItems.append(archiveItem)
                 }
             }
-        }
-        .onKeyPress(.space) {
-            if let archive = state.archive,
-               let selectedItem = state.selectedItems.first,
-               let url = archive.extractFileToTemp(selectedItem) {
-                appDelegate.openPreviewerWindow(for: url)
-            }
-            return .handled
         }
     }
     

--- a/MacPacker/Features/ArchiveContentViewer/ContentView.swift
+++ b/MacPacker/Features/ArchiveContentViewer/ContentView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
     
     // environment
     @Environment(\.openWindow) var openWindow
-    @Environment(AppState.self) var state: AppState
+    @EnvironmentObject var state: AppState
     @EnvironmentObject var archiveState: ArchiveState
     
     // state
@@ -57,12 +57,14 @@ struct ContentView: View {
                 BreadcrumbView(archive: archiveState.archive ?? nil)
             }
         }
-        .toolbar {
-            ArchiveContentToolbarView(
-                archiveState: archiveState
-            )
+        .if(!.macOS13) { view in
+            view.toolbar {
+                ArchiveContentToolbarView(
+                    archiveState: archiveState
+                )
+            }
         }
-        .navigationTitle(archiveState.archive == nil ? "MacPacker" : archiveState.archive!.name)
+        .navigationTitle(archiveState.archive == nil ? Bundle.main.appName : archiveState.archive!.name)
         .environmentObject(archiveState)
     }
     

--- a/MacPacker/Features/Header/ArchiveWindowController+Toolbar.swift
+++ b/MacPacker/Features/Header/ArchiveWindowController+Toolbar.swift
@@ -1,0 +1,366 @@
+//
+//  Toolbar.swift
+//  MacPacker
+//
+//  Created by Stephan Arenswald on 20.10.25.
+//
+//  This extension is only valid for macOS 13 support. Starting
+//  with macOS 14, we're relying on the .toolbar() view modifier
+//  to render a SwiftUI based toolbar.
+//
+
+import AppKit
+import SwiftUI
+
+extension NSToolbarItem.Identifier {
+    static let preview = NSToolbarItem.Identifier("preview")
+    static let extractSelected = NSToolbarItem.Identifier("extractSelected")
+    static let extractAll = NSToolbarItem.Identifier("extractAll")
+    static let more = NSToolbarItem.Identifier("more")
+}
+
+extension ArchiveWindowController: NSToolbarDelegate {
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return [.preview, .extractSelected, .extractAll, .more]
+    }
+    
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return [.preview, .extractSelected, .extractAll, .more]
+    }
+    
+    func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
+        switch itemIdentifier {
+            
+        case .preview: // preview selected item
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.label = NSLocalizedString("Preview", comment: "Button in the tooblar that allows the user to preview the selected file.")
+            item.image = NSImage(systemSymbolName: "doc.text.magnifyingglass", accessibilityDescription: "")
+            item.action = #selector(previewSelected)
+            item.isBordered = true
+            return item
+            
+        case .extractSelected: // extract the selected item
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.label = NSLocalizedString("Extract selected", comment: "Button in the tooblar that allows the user to extract the selected files.")
+            item.image = NSImage(named: "custom.document.badge.arrow.down")
+            item.action = #selector(extractSelected)
+            item.isBordered = true
+            return item
+            
+        case .extractAll: // extract the full archive
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.label = NSLocalizedString("Extract archive", comment: "Button in the toolbar that allows the user to extract the full archive to a target directory.")
+            item.image = NSImage(named: "custom.shippingbox.badge.arrow.down")
+            item.action = #selector(extractAll)
+            item.isBordered = true
+            return item
+            
+        case .more: // the more menu
+            let item = NSMenuToolbarItem(itemIdentifier: itemIdentifier)
+            item.label = NSLocalizedString("More", comment: "The 'More' menu in the archive window")
+            item.image = NSImage(systemSymbolName: "ellipsis", accessibilityDescription: "")
+            item.menu = buildMoreMenu()
+            return item
+            
+        default:
+            return nil
+        }
+    }
+    
+    //
+    // MARK: Drop down menu builders
+    //
+    
+    func buildMoreMenu() -> NSMenu {
+        let menu = NSMenu()
+        
+        // Settings
+        let settingsItem = NSMenuItem()
+        settingsItem.title = NSLocalizedString("Settings...", comment: "Used to open the settings/preferences window")
+        settingsItem.image = NSImage(systemSymbolName: "gear", accessibilityDescription: nil)
+        settingsItem.action = Selector(("showSettingsWindow:"))
+        menu.addItem(settingsItem)
+        
+        menu.addItem(.separator())
+        
+        // Archive info
+        let archiveInfoItem = NSMenuItem(
+            title: NSLocalizedString("Archive info", comment: "Used to open Quick Look feature for the current archive file"),
+            action: #selector(showArchiveInfoWindow),
+            keyEquivalent: "")
+        archiveInfoItem.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: nil)
+        menu.addItem(archiveInfoItem)
+        
+        menu.addItem(.separator())
+        
+        // Send a smile menu
+        let sendASmileMenuItem = NSMenuItem(
+            title: NSLocalizedString("Send a smile", comment: "This is the menu in the 'More' menu of the archive window to give customers a hint on how to support the developer. The user has the option to open the MacPacker repository on GitHub or leave a review in the App Store."),
+            action: nil,
+            keyEquivalent: "")
+        sendASmileMenuItem.image = NSImage(systemSymbolName: "face.smiling", accessibilityDescription: nil)
+        sendASmileMenuItem.submenu = buildSendASmileMenu()
+        menu.addItem(sendASmileMenuItem)
+        
+        // Go here to... menu
+        let goHereToMenuItem = NSMenuItem(
+            title: NSLocalizedString("Go here to ...", comment: "This is the menu in the 'More' menu of the archive window to give customers a hint what they can do to reach the dev. A submenu will open with links to GitHub, a bug report form, and a mail to the developer."),
+            action: nil,
+            keyEquivalent: "")
+        goHereToMenuItem.image = NSImage(systemSymbolName: "exclamationmark.bubble", accessibilityDescription: nil)
+        goHereToMenuItem.submenu = buildGoHereToMenu()
+        menu.addItem(goHereToMenuItem)
+        
+        menu.addItem(.separator())
+        
+        // More apps menu
+        let moreAppsMenu = NSMenuItem(
+            title: NSLocalizedString("More Apps", comment: "Hint to the user that the submenu contains links for more apps that they might like."),
+            action: nil,
+            keyEquivalent: "")
+        moreAppsMenu.image = NSImage(systemSymbolName: "plus.square.dashed", accessibilityDescription: nil)
+        moreAppsMenu.submenu = buildMoreAppsMenu()
+        menu.addItem(moreAppsMenu)
+        
+        // website
+        let websiteItem = NSMenuItem(
+            title: NSLocalizedString("Website", comment: "Hint to the user that the button links to the app's website."),
+            action: #selector(visitWebsite),
+            keyEquivalent: "")
+        websiteItem.image = NSImage(systemSymbolName: "link", accessibilityDescription: nil)
+        menu.addItem(websiteItem)
+        
+        // github
+        let githubItem = NSMenuItem(
+            title: Constants.otherAppGitHub,
+            action: #selector(visitGitHub),
+            keyEquivalent: "")
+        githubItem.image = NSImage(systemSymbolName: "link", accessibilityDescription: nil)
+        menu.addItem(githubItem)
+        
+        // about MacPacker window
+        let aboutItem = NSMenuItem(
+            title: NSLocalizedString("About \(Bundle.main.appName)", comment: ""),
+            action: #selector(showAboutPanel),
+            keyEquivalent: "")
+        aboutItem.image = NSImage(systemSymbolName: "info.square", accessibilityDescription: nil)
+        menu.addItem(aboutItem)
+        
+        return menu
+    }
+    
+    func buildSendASmileMenu() -> NSMenu {
+        let menu = NSMenu()
+        
+        let starItem = NSMenuItem(
+            title: NSLocalizedString("Star the repository on GitHub", comment: "Opens the GitHub page of the MacPacker repository for the user to star it."),
+            action: #selector(visitGitHub),
+            keyEquivalent: "")
+        menu.addItem(starItem)
+        
+        #if STORE
+        let writeReviewItem = NSMenuItem(
+            title: NSLocalizedString("Leave a review in the App Store", comment: "Opens the App Store review page for the MacPacker app for the user to write a review."),
+            action: #selector(writeReview),
+            keyEquivalent: "")
+        menu.addItem(writeReviewItem)
+        #endif
+        
+        return menu
+    }
+    
+    func buildGoHereToMenu() -> NSMenu {
+        let menu = NSMenu()
+        
+        // request a feature
+        let requestFeatureItem = NSMenuItem(
+            title: NSLocalizedString("... request a Feature", comment: "This is the second part of the text 'Go here to ...'. It is used in the archive window 'More' menu and shall give users a hint about the secondary options to reach out to the dev."),
+            action: #selector(requestFeature),
+            keyEquivalent: "")
+        requestFeatureItem.image = NSImage(systemSymbolName: "shippingbox", accessibilityDescription: nil)
+        menu.addItem(requestFeatureItem)
+        
+        // raise a bug
+        let raiseBugItem = NSMenuItem(
+            title: NSLocalizedString("... raise a Bug", comment: "This is the second part of the text 'Go here to ...'. It is used in the archive window 'More' menu and shall give users a hint about the secondary options to reach out to the dev."),
+            action: #selector(raiseBug),
+            keyEquivalent: "")
+        raiseBugItem.image = NSImage(systemSymbolName: "ladybug", accessibilityDescription: nil)
+        menu.addItem(raiseBugItem)
+        
+        // send a mail
+        let sendMailItem = NSMenuItem(
+            title: NSLocalizedString("... send a mail to \(Constants.supportMail)", comment: "This is the second part of the text 'Go here to ...'. It is used in the archive window 'More' menu and shall give users a hint about the secondary options to reach out to the dev."),
+            action: #selector(sendMail),
+            keyEquivalent: "")
+        sendMailItem.image = NSImage(systemSymbolName: "mail", accessibilityDescription: nil)
+        menu.addItem(sendMailItem)
+        
+        return menu
+    }
+    
+    func buildMoreAppsMenu() -> NSMenu {
+        let menu = NSMenu()
+        
+        let fileFilletItem = NSMenuItem(
+            title: Constants.otherAppFileFillet,
+            action: #selector(openFileFilletWebsite),
+            keyEquivalent: "")
+        fileFilletItem.image = .menuIcon(named: "FileFillet", pointSize: 16)
+        menu.addItem(fileFilletItem)
+        
+        return menu
+    }
+    
+    //
+    // MARK: Toolbar button actions
+    //
+    
+    @objc func previewSelected() {
+        if let archive = archiveState.archive,
+           let selectedItem = archiveState.selectedItems.first,
+           let url = archive.extractFileToTemp(selectedItem) {
+            appDelegate.openPreviewerWindow(for: url)
+        }
+    }
+    
+    @objc func extractSelected() {
+        let openPanel = NSOpenPanel()
+        openPanel.allowsMultipleSelection = false
+        openPanel.allowedContentTypes = [.folder]
+        openPanel.canChooseFiles = false
+        openPanel.canChooseDirectories = true
+        openPanel.canCreateDirectories = true
+        openPanel.begin { response in
+            if response == .OK,
+               let destinationURL = openPanel.url {
+                if let archive = self.archiveState.archive {
+                    self.archiveService.extract(
+                        archive: archive,
+                        items: self.archiveState.selectedItems,
+                        to: destinationURL)
+                }
+            }
+        }
+    }
+    
+    @objc func extractAll() {
+        let openPanel = NSOpenPanel()
+        openPanel.allowsMultipleSelection = false
+        openPanel.allowedContentTypes = [.folder]
+        openPanel.canChooseFiles = false
+        openPanel.canChooseDirectories = true
+        openPanel.canCreateDirectories = true
+        openPanel.begin { response in
+            if response == .OK,
+               let destinationURL = openPanel.url {
+                if let archive = self.archiveState.archive {
+                    self.archiveService.extract(
+                        archive: archive,
+                        to: destinationURL)
+                }
+            }
+        }
+    }
+    
+    @objc func showSettingsWindow() {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+    
+    @objc func showArchiveInfoWindow() {
+        if let url = archiveState.archive?.url {
+            contentService.openGetInfoWnd(for: [url])
+        }
+    }
+    
+    @objc func writeReview() {
+        if let url = URL(string: "https://apps.apple.com/app/id6473273874?action=write-review") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc func requestFeature() {
+        if let url = URL(string: "https://github.com/sarensw/MacPacker/issues/new?assignees=&labels=enhancement&projects=&template=&title=") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc func raiseBug() {
+        if let url = URL(string: "https://github.com/sarensw/MacPacker/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc func sendMail() {
+        if let url = URL(string: "mailto:\(Constants.supportMail)") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc func openFileFilletWebsite() {
+        if let url = URL(string: "https://filefillet.com/?utm_source=macpacker&utm_content=moremenu&utm_medium=ui") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc func visitWebsite() {
+        if let url = URL(string: "https://macpacker.app/?utm_source=macpacker&utm_content=moremenu&utm_medium=ui") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc func visitGitHub() {
+        if let url = URL(string: "https://github.com/sarensw/MacPacker/") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc func showAboutPanel() {
+        appDelegate.openAboutWindow()
+    }
+}
+
+struct MenuButtonStyle: ButtonStyle {
+    @State var isHovering = false
+//    var statusItem: NSStatusItem
+    
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            Spacer()
+                .frame(width: 10)
+            configuration.label
+                .foregroundStyle(isHovering ? .white : .primary)
+            Spacer()
+        }
+        .padding(.vertical, 3)
+        .background(
+            withAnimation {
+                isHovering ? Color(red: 0.243, green: 0.573, blue: 0.988) : .clear
+            }
+        )
+        .onHover(perform: { hovering in
+            if !configuration.isPressed {
+                isHovering = hovering
+            }
+        })
+//        .onChange(of: configuration.isPressed) { pressed in
+//            if pressed {
+//                Task(priority: .high) {
+//                    for _ in 0..<2 {
+//                        isHovering = false
+//                        usleep(75000)
+//                        isHovering = true
+//                        usleep(75000)
+//                    }
+//                    isHovering = false
+//                    
+//                    DispatchQueue.main.async {
+//                        statusItem.menu?.cancelTracking()
+//                    }
+//                }
+//            }
+//        }
+        .cornerRadius(5)
+        .padding(.horizontal, 5)
+    }
+}

--- a/MacPacker/MacPackerApp.swift
+++ b/MacPacker/MacPackerApp.swift
@@ -40,6 +40,7 @@ struct MacPackerApp: App {
     var body: some Scene {
         Settings {
             PreferencesView()
+                .environmentObject(appDelegate)
         }
         .commands {
             CommandGroup(replacing: .appInfo) {
@@ -55,7 +56,6 @@ struct MacPackerApp: App {
             }
 #endif
         }
-        .environmentObject(appDelegate)
     }
 }
 
@@ -128,9 +128,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             }
         }
         
+        #if !DEBUG
         if FIFinderSyncController.isExtensionEnabled == false {
             FIFinderSyncController.showExtensionManagementInterface()
         }
+        #endif
     }
     
     func applicationWillTerminate(_ notification: Notification) {

--- a/MacPacker/Model/AppState.swift
+++ b/MacPacker/Model/AppState.swift
@@ -6,11 +6,10 @@
 //
 
 import Foundation
-import Observation
+import KeyboardShortcuts
 import SwiftUI
 
-@Observable
-class AppState {
+class AppState: ObservableObject {
     static var shared: AppState = AppState()
     
     private init() { }
@@ -21,4 +20,22 @@ class AppState {
     
     /// Holds all archives that the app currently takes care of
     var archives: [UUID: Archive2] = [:]
+}
+
+extension KeyboardShortcuts.Name {
+    static let spacePreview = Self("spacePreview", default: .init(.space, modifiers: []))
+}
+
+extension AppState {
+    func setUpEvents() {
+        KeyboardShortcuts.onKeyUp(for: .spacePreview) {
+            print("Space Preview")
+//            if let archive = state.archive,
+//               let selectedItem = state.selectedItems.first,
+//               let url = archive.extractFileToTemp(selectedItem) {
+//                appDelegate.openPreviewerWindow(for: url)
+//            }
+//            return .handled
+        }
+    }
 }

--- a/MacPacker/Views/WelcomeView.swift
+++ b/MacPacker/Views/WelcomeView.swift
@@ -24,7 +24,10 @@ struct WhatsNewPill: View {
             case .feature:
                 Capsule()
                     .fill(.green.opacity(0.4))
-                    .stroke(.green, lineWidth: 1)
+                    .overlay(
+                        Capsule()
+                            .stroke(Color.green, lineWidth: 1)
+                    )
                     .frame(width: 32, height: 16)
                     .overlay {
                         Text(verbatim: "feat")
@@ -33,7 +36,10 @@ struct WhatsNewPill: View {
             case .bug:
                 Capsule()
                     .fill(.red.opacity(0.4))
-                    .stroke(.red, lineWidth: 1)
+                    .overlay(
+                        Capsule()
+                            .stroke(Color.red, lineWidth: 1)
+                    )
                     .frame(width: 32, height: 16)
                     .overlay {
                         Text(verbatim: "bug")
@@ -42,7 +48,10 @@ struct WhatsNewPill: View {
             case .core:
                 Capsule()
                     .fill(.blue.opacity(0.4))
-                    .stroke(.blue, lineWidth: 1)
+                    .overlay(
+                        Capsule()
+                            .stroke(Color.blue, lineWidth: 1)
+                    )
                     .frame(width: 32, height: 16)
                     .overlay {
                         Text(verbatim: "core")
@@ -59,6 +68,7 @@ struct WhatsNewPill: View {
 struct WelcomeWhatsNewView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
+            WhatsNewPill(title: "Re-enable macOS 13 as minimum deployment target", type: .core)
             WhatsNewPill(title: "Crash when using the open with option", type: .bug)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)


### PR DESCRIPTION
Enables macOS 13 as deployment target.

resolves #24 