### PR TITLE
Add missing archive types in QuickLook plist

### DIFF
--- a/QuickLookExtension/Info.plist
+++ b/QuickLookExtension/Info.plist
@@ -11,6 +11,8 @@
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>public.archive</string>
+				<string>org.7-zip.7-zip-archive</string>
+				<string>org.7-zip.lha-archive</string>
 				<string>public.bzip2-archive</string>
 				<string>com.microsoft.cab</string>
 				<string>public.cpio-archive</string>


### PR DESCRIPTION
Me again, another small fix: QuickLook in finder does not work with z7 archives (and apparently amiga archives)

I'm just trying to fix things as I notice them, sorry for the PR flood :)