### PR TITLE
fix: remove application from dock after close button pressed

### DIFF
--- a/Config/Changelog.json
+++ b/Config/Changelog.json
@@ -95,6 +95,25 @@
                     "pr": 77
                 },
                 {
+                    "type": "feat",
+                    "title": {
+                        "en": "New option to quit on last window closed",
+                        "zh-Hans": "新增“关闭最后一个窗口时退出”选项",
+                        "fr": "Nouvelle option pour quitter à la fermeture de la dernière fenêtre",
+                        "de": "Neue Option zum Beenden beim Schließen des letzten Fensters",
+                        "it": "Nuova opzione per uscire alla chiusura dell’ultima finestra",
+                        "ja": "最後のウィンドウを閉じたときに終了する新オプション",
+                        "fa": "گزینه جدید برای خروج هنگام بسته شدن آخرین پنجره",
+                        "pl": "Nowa opcja zamykania aplikacji po zamknięciu ostatniego okna",
+                        "pt-BR": "Nova opção para encerrar ao fechar a última janela",
+                        "ru": "Новая опция выхода при закрытии последнего окна",
+                        "uk": "Нова опція виходу після закриття останнього вікна",
+                        "es-MX": "Nueva opción para salir al cerrar la última ventana",
+                        "ko": "마지막 창 닫기 시 종료하는 새 옵션"
+                    },
+                    "pr": 89
+                },
+                {
                     "type": "fix",
                     "title": {
                         "en": "Up/down keys not working when preview is opened",

--- a/MacPacker/AppDelegate.swift
+++ b/MacPacker/AppDelegate.swift
@@ -19,8 +19,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     @AppStorage("welcomeScreenShownInVersion") private var welcomeScreenShownInVersion = "0.0"
     @AppStorage("updateBetaChannelOn") var updateBetaChannelOn: Bool = false
     @AppStorage("checkForUpdates") var checkForUpdates: SettingUpdateCheck = .automatically
+    @AppStorage(Keys.quitOnLastWindowClosed) var quitOnLastWindowClosed: Bool = false
     private var archiveWindowManager: ArchiveWindowManager? = nil
     
+    private static var isRunningInPreview: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
     #if !STORE
     let updaterController: SPUStandardUpdaterController
     #endif
@@ -31,14 +35,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         #if !STORE
         // If you want to start the updater manually, pass false to startingUpdater and call .startUpdater() later
         // This is where you can also pass an updater delegate if you need one
-        updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        updaterController = SPUStandardUpdaterController(startingUpdater: !Self.isRunningInPreview, updaterDelegate: nil, userDriverDelegate: nil)
         appState = AppState(updaterController: updaterController)
         #else
         appState = AppState()
         #endif
         
         super.init()
+        if !Self.isRunningInPreview {
         TailBeat.start()
+        }
     }
     
     public func application(_ application: NSApplication, open urls: [URL]) {
@@ -82,6 +88,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
     
     public func applicationDidFinishLaunching(_ notification: Notification) {
+        guard !Self.isRunningInPreview else { return }
         Logger.log("finish launching")
         
         archiveWindowManager = ArchiveWindowManager(appState: appState)
@@ -98,6 +105,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
     
     public func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        guard !Self.isRunningInPreview else { return true }
         if !hasVisibleWindows {
             archiveWindowManager?.openArchiveWindow()
             NSApp.activate(ignoringOtherApps: true)
@@ -106,10 +114,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
     
     public func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        return true
+        if quitOnLastWindowClosed {
+            return true
+        }
+        return false
     }
 
     public func applicationWillTerminate(_ notification: Notification) {
+        guard !Self.isRunningInPreview else { return }
         CacheCleaner().clean()
     }
     

--- a/MacPacker/AppDelegate.swift
+++ b/MacPacker/AppDelegate.swift
@@ -105,6 +105,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         return true
     }
     
+    public func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return true
+    }
+
     public func applicationWillTerminate(_ notification: Notification) {
         CacheCleaner().clean()
     }

--- a/MacPacker/Features/Settings/GeneralSettingsView.swift
+++ b/MacPacker/Features/Settings/GeneralSettingsView.swift
@@ -15,12 +15,13 @@ struct GeneralSettingsView: View {
     @AppStorage(Keys.showColumnUncompressedSize) var showUncompressedSize: Bool = true
     @AppStorage(Keys.showColumnModificationDate) var showModificationDate: Bool = true
     @AppStorage(Keys.showColumnPosixPermissions) var showPermissions: Bool = false
+    @AppStorage(Keys.quitOnLastWindowClosed) var quitOnLastWindowClosed: Bool = false
     
     var body: some View {
         VStack(spacing: 8) {
             HStack(alignment: .top) {
                 Text("Columns:", comment: "Let's the user choose to show or hide columns in the archive window")
-                    .frame(width: 160, alignment: .trailing)
+                    .frame(width: 200, alignment: .trailing)
                 
                 VStack(alignment: .leading) {
                     Toggle(isOn: $showCompressedSize) {
@@ -45,7 +46,7 @@ struct GeneralSettingsView: View {
             
             HStack(alignment: .top) {
                 Text("Breadcrumb position:", comment: "Allows the user to change the breadcrumb position to either top or bottom of the archive window")
-                    .frame(width: 160, alignment: .trailing)
+                    .frame(width: 200, alignment: .trailing)
                 
                 HStack {
                     Picker(String(""), selection: $breadcrumbPosition) {
@@ -55,6 +56,17 @@ struct GeneralSettingsView: View {
                         }
                     }
                 }
+                .frame(width: 240, alignment: .leading)
+            }
+            
+            HStack(alignment: .top) {
+                Text("Quit on last window closed:", comment: "Quit the app when the last archive window is closed")
+                    .frame(width: 200, alignment: .trailing)
+                
+                HStack {
+                    Toggle(isOn: $quitOnLastWindowClosed) {}
+                }
+                .padding(.leading, 8)
                 .frame(width: 240, alignment: .leading)
             }
         }

--- a/MacPacker/Localizable.xcstrings
+++ b/MacPacker/Localizable.xcstrings
@@ -3210,6 +3210,9 @@
         }
       }
     },
+    "Quit on last window closed:" : {
+      "comment" : "Quit the app when the last archive window is closed"
+    },
     "Refresh" : {
       "comment" : "A button to refresh the list of supported file formats.",
       "localizations" : {

--- a/Modules/Sources/Core/AppStorageKeys.swift
+++ b/Modules/Sources/Core/AppStorageKeys.swift
@@ -8,6 +8,7 @@
 public enum Keys {
     // general settings
     public static let settingBreadcrumbPosition = "settingBreadcrumbPosition"
+    public static let quitOnLastWindowClosed = "quitOnLastWindowClosed"
     
     // table settings
     public static let showColumnCompressedSize = "showColumnCompressedSize"


### PR DESCRIPTION
## Summary 
When close button pressed on active window, the application will stay in dock. This PR makes changes for current behaviour, terminating application after close pressed