### PR TITLE
Hold ⌥ while dropping an archive to open it in a new window

### DIFF
--- a/Config/Changelog.json
+++ b/Config/Changelog.json
@@ -36,6 +36,25 @@
                         "ko": "분할 ZIP 파일 열기"
                     },
                     "issues": ["115"]
+                },
+                {
+                    "type": "feat",
+                    "title": {
+                        "en": "Hold ⌥ while dropping an archive to open it in a new window",
+                        "zh-Hans": "拖放压缩包时按住 ⌥ 可在新窗口中打开",
+                        "fr": "Maintenez ⌥ en déposant une archive pour l’ouvrir dans une nouvelle fenêtre",
+                        "de": "⌥ beim Ablegen eines Archivs gedrückt halten, um es in einem neuen Fenster zu öffnen",
+                        "it": "Tieni premuto ⌥ mentre trascini un archivio per aprirlo in una nuova finestra",
+                        "ja": "アーカイブをドロップする際に ⌥ を押し続けると新しいウィンドウで開く",
+                        "fa": "با نگه داشتن ⌥ هنگام رها کردن آرشیو، آن را در پنجره‌ای جدید باز کنید",
+                        "pl": "Przytrzymaj ⌥ podczas upuszczania archiwum, aby otworzyć je w nowym oknie",
+                        "pt-BR": "Mantenha ⌥ pressionado ao soltar um arquivo para abri-lo em uma nova janela",
+                        "ru": "Удерживайте ⌥ при перетаскивании архива, чтобы открыть его в новом окне",
+                        "uk": "Утримуйте ⌥ під час перетягування архіву, щоб відкрити його в новому вікні",
+                        "es-MX": "Mantén presionada la tecla ⌥ al soltar un archivo para abrirlo en una ventana nueva",
+                        "ko": "아카이브를 놓을 때 ⌥ 키를 누르고 있으면 새 창에서 열립니다"
+                    },
+                    "issues": ["116"]
                 }
             ]
         },

--- a/MacPacker/Features/ArchiveContentViewer/ArchiveView.swift
+++ b/MacPacker/Features/ArchiveContentViewer/ArchiveView.swift
@@ -9,20 +9,26 @@ import Foundation
 import QuickLook
 import Core
 import SwiftUI
+import UniformTypeIdentifiers
+import tb
+
+private let log = tb.Logger(subsystem: "app.MacPacker", category: "archive")
 
 struct ArchiveView: View {
     @Environment(\.openWindow) var openWindow
+    @Environment(\.openArchiveInNewWindow) private var openArchiveInNewWindow
     @EnvironmentObject private var state: ArchiveState
-    
+
     @AppStorage(Keys.showColumnCompressedSize) var showCompressedSize: Bool = true
     @AppStorage(Keys.showColumnUncompressedSize) var showUncompressedSize: Bool = true
     @AppStorage(Keys.showColumnModificationDate) var showModificationDate: Bool = true
     @AppStorage(Keys.showColumnPosixPermissions) var showPermissions: Bool = false
-    
-    @State private var isDraggingOver = false
+
     @State private var selection: IndexSet?
     @State private var loading: Bool = false
-    
+    @State private var isDropTargeted = false
+    @State private var hintTimer: Timer?
+
     var body: some View {
         VStack {
             ArchiveTableViewRepresentable(
@@ -34,52 +40,103 @@ struct ArchiveView: View {
                 showPosixPermissionsColumn: $showPermissions
             )
         }
-        .border(isDraggingOver ? Color.blue : Color.clear, width: 2)
-        .onDrop(of: ["public.file-url"], isTargeted: $isDraggingOver) { providers -> Bool in
-            for provider in providers {
-                provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { (data, error) in
-                    if let data = data as? Data,
-                       let fileURL = URL(dataRepresentation: data, relativeTo: nil) {
-                        // Update the state variable with the accepted file URL
-                        Task {
-                            await self.drop(fileURL)
-                        }
-                    }
-                }
-            }
+        // Plain drop = add (or open, when nothing is loaded / it can't be edited).
+        // ⌥ drop = open in a new window. `isDropTargeted` (SwiftUI-managed) reliably
+        // brackets the drag, so the status-bar hint always clears when it ends.
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
+            handleDrop(providers)
             return true
         }
+        .onChange(of: isDropTargeted) { _, targeted in
+            if targeted { startHintPolling() } else { stopHintPolling() }
+        }
+        .onDisappear { stopHintPolling() }
         .onAppear {
             if state.openWithUrls.count > 0 {
-                Task {
-                    await self.drop(state.openWithUrls[0])
-                }
+                state.openDropped(url: state.openWithUrls[0])
             }
         }
         .quickLookPreview($state.previewItemUrl)
     }
-    
-    //
-    // functions
-    //
-    
-    func drop(_ url: URL) async {
-        // We have to distinguish 3 cases here.
-        // 1. No archive loaded > Check if archive,
-        // 1.1. if yes, load.
-        // 2.2. If no, create new archive and add the dropped file as first entry
-        // 2. Archive loaded > Add file to current archive
-        if state.hasArchive == false {
-            if state.isSupportedArchive(url: url) {
-                state.clean()
-                state.open(url: url)
-            } else {
-                state.create()
-                state.add(url: url)
+
+    // MARK: - Drop
+
+    /// Plain drop adds to the current editable archive (or opens it, if nothing is
+    /// loaded / it can't be edited). ⌥ drop opens the file in a new window. ⌥ is
+    /// used rather than ⌘ because a Finder ⌘-drag means "move" — a copy target would
+    /// reject it (what looked like "nothing happens"), and accepting a move risks
+    /// deleting the source file. ⌥ maps cleanly to copy.
+    private func handleDrop(_ providers: [NSItemProvider]) {
+        let flags = NSEvent.modifierFlags
+        let openInNewWindow = flags.contains(.option)
+        // Capture the "open in new window" action and state up front (on the main
+        // actor) so the async provider callbacks don't have to reach back through
+        // the view.
+        let openInNewWindowAction = openArchiveInNewWindow
+        let state = self.state
+        log.notice("File drop performed", context: [
+            "providers": "\(providers.count)",
+            "option": "\(flags.contains(.option))",
+            "command": "\(flags.contains(.command))"
+        ])
+        for provider in providers {
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { data, _ in
+                guard let data = data as? Data,
+                      let url = URL(dataRepresentation: data, relativeTo: nil) else {
+                    log.error("Drop: could not read a file URL from the dropped item")
+                    return
+                }
+                Task { @MainActor in
+                    if openInNewWindow {
+                        log.notice("Drop → open in a new window", context: ["file": url.lastPathComponent])
+                        openInNewWindowAction(url)
+                    } else if state.hasArchive, state.canBeEdited {
+                        log.notice("Drop → add to current archive", context: ["file": url.lastPathComponent])
+                        state.add(url: url)
+                    } else {
+                        log.notice("Drop → open in this window", context: ["file": url.lastPathComponent])
+                        state.openDropped(url: url)
+                    }
+                }
             }
-        } else {
-            // add to current archive
-            state.add(url: url)
         }
     }
+
+    // MARK: - Status-bar hint
+
+    /// While a file is over the window, poll ⌥ so the status-bar hint can flip
+    /// between "add" and "open in a new window". A timer (not `dropUpdated`) is used
+    /// so the flip tracks the key even when the pointer is still; it runs on the
+    /// common run-loop mode so it keeps firing during the drag.
+    private func startHintPolling() {
+        stopHintPolling(clearHint: false)
+        let state = self.state
+        // Show the hint whenever an archive is open. The default drop differs — add
+        // for an editable archive, replace for a read-only one — but ⌥ always opens a
+        // new window, so the affordance is worth advertising either way. An empty
+        // window just opens the dropped file, so no hint there.
+        guard state.hasArchive else {
+            state.dropHint = nil
+            return
+        }
+        setHint(on: state)
+        let timer = Timer(timeInterval: 0.06, repeats: true) { _ in
+            MainActor.assumeIsolated { setHint(on: state) }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        hintTimer = timer
+    }
+
+    private func stopHintPolling(clearHint: Bool = true) {
+        hintTimer?.invalidate()
+        hintTimer = nil
+        if clearHint { state.dropHint = nil }
+    }
+}
+
+/// Free function (no `self` capture) so it's safe to call from the polling timer.
+@MainActor
+private func setHint(on state: ArchiveState) {
+    let hint: ArchiveDropHint = NSEvent.modifierFlags.contains(.option) ? .openInNewWindow : .dragging
+    if state.dropHint != hint { state.dropHint = hint }
 }

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
@@ -17,23 +17,28 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
     var willCloseHandler: (() -> Void)?
     var didBecomeMain: (() -> Void)?
     
-    init(archiveState: ArchiveState, appState: AppState) {
+    init(
+        archiveState: ArchiveState,
+        appState: AppState,
+        openArchiveInNewWindow: @escaping @MainActor (URL) -> Void
+    ) {
         self.archiveState = archiveState
-        
+
         let window = ArchiveWindow()
         window.isRestorable = false
         window.center()
         super.init(window: window)
-        
+
         window.delegate = self
-        
+
         window.toolbarStyle = .unified
-        
+
         // show the content view
         let contentView = ContentView()
             .environmentObject(appState)
             .environmentObject(archiveState)
-        
+            .environment(\.openArchiveInNewWindow, openArchiveInNewWindow)
+
         window.contentView = NSHostingView(rootView: contentView)
     }
     
@@ -55,5 +60,19 @@ class ArchiveWindow: NSWindow {
             backing: .buffered,
             defer: true
         )
+    }
+}
+
+/// Lets a window's content open a *different* archive in a new window (the
+/// ⌥-drag-to-open gesture) without holding — or cycling with — the window manager.
+/// `ArchiveWindowController` injects a weakly-captured closure from the manager.
+private struct OpenArchiveInNewWindowKey: EnvironmentKey {
+    static let defaultValue: @MainActor (URL) -> Void = { _ in }
+}
+
+extension EnvironmentValues {
+    var openArchiveInNewWindow: @MainActor (URL) -> Void {
+        get { self[OpenArchiveInNewWindowKey.self] }
+        set { self[OpenArchiveInNewWindowKey.self] = newValue }
     }
 }

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindowManager.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindowManager.swift
@@ -47,7 +47,10 @@ class ArchiveWindowManager {
         // to open a new archive
         let archiveWindowController = ArchiveWindowController(
             archiveState: archiveState,
-            appState: appState
+            appState: appState,
+            openArchiveInNewWindow: { [weak self] url in
+                self?.openArchiveWindow(for: url)
+            }
         )
         windowControllers.append(archiveWindowController)
         archiveWindowController.willCloseHandler = { [weak self] in

--- a/MacPacker/Features/StatusBar/StatusBarView.swift
+++ b/MacPacker/Features/StatusBar/StatusBarView.swift
@@ -24,7 +24,9 @@ struct StatusBarView: View {
     
     var body: some View {
         HStack(alignment: .center) {
-            if archiveState.hasArchive == false {
+            if let hint = archiveState.dropHint {
+                dropHintView(hint)
+            } else if archiveState.hasArchive == false {
                 HStack(spacing: 4) {
                     Button {
                         guard let gitHubURL = URL(string: Constants.gitHubLink) else {
@@ -124,5 +126,37 @@ struct StatusBarView: View {
         }
         .padding(.windowSafeHorizontal)
         .frame(height: 27)
+    }
+
+    /// Shown only while a file is dragged over the window, replacing the normal
+    /// status info. The ⌥-held state is set apart by colour (a soft accent chip),
+    /// not by wording, so the mode change reads at a glance.
+    @ViewBuilder
+    private func dropHintView(_ hint: ArchiveDropHint) -> some View {
+        HStack(spacing: 6) {
+            Spacer(minLength: 0)
+            switch hint {
+            case .dragging:
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.up.forward.square")
+                    Text("Hold ⌥ to open in a new window",
+                         comment: "Status-bar hint shown while dragging a file over the window: holding Option opens the file in a new window instead of adding it to the current archive.")
+                }
+                .foregroundStyle(.secondary)
+            case .openInNewWindow:
+                HStack(spacing: 5) {
+                    Image(systemName: "macwindow.badge.plus")
+                    Text("Open in a new window",
+                         comment: "Status-bar hint shown while holding Option during a file drag: releasing opens the file in a new window.")
+                }
+                .fontWeight(.semibold)
+                .foregroundStyle(Color.accentColor)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+            }
+            Spacer()
+        }
+        .font(.subheadline)
     }
 }

--- a/MacPacker/Localizable.xcstrings
+++ b/MacPacker/Localizable.xcstrings
@@ -2943,6 +2943,9 @@
         }
       }
     },
+    "Hold ⌥ to open in a new window" : {
+      "comment" : "Status-bar hint shown while dragging a file over the window: holding Option opens the file in a new window instead of adding it to the current archive."
+    },
     "How to set %@ as default?" : {
       "comment" : "A button that shows a popover explaining how to set MacPacker as the default file opener.",
       "localizations" : {
@@ -3748,6 +3751,9 @@
           }
         }
       }
+    },
+    "Open in a new window" : {
+      "comment" : "Status-bar hint shown while holding Option during a file drag: releasing opens the file in a new window."
     },
     "Open..." : {
       "comment" : "A label for a button that allows the user to open an archive from disk. The order depends on the language.",

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -29,6 +29,15 @@ public enum ArchiveSortOrder: String {
     case posixPermissions
 }
 
+/// What the status bar should communicate while a file is dragged over the window.
+/// The UI maps each case to a localized, styled hint.
+public enum ArchiveDropHint: Equatable, Sendable {
+    /// A file is over the window with no modifier held — teach the ⌥ affordance.
+    case dragging
+    /// ⌥ is held — releasing will open the file in a new window.
+    case openInNewWindow
+}
+
 @MainActor
 public class ArchiveState: ObservableObject {
     @Published private(set) public var hasArchive: Bool = false
@@ -64,7 +73,10 @@ public class ArchiveState: ObservableObject {
     @Published private(set) public var progress: Int? = nil
     @Published private(set) public var error: String? = nil
     @Published public var isReloadNeeded: Bool = false
-    
+    /// Transient state shown in the status bar while a file is dragged over the
+    /// window. nil when no drag is active — the normal status-bar info shows then.
+    @Published public var dropHint: ArchiveDropHint? = nil
+
     // Listeners for non-ui
     @Published private(set) public var status: ArchiveStateStatus = .idle
     public var onStatusChange: ((ArchiveStateStatus) -> Void)?
@@ -326,7 +338,19 @@ extension ArchiveState {
         self.isReloadNeeded = true
         loadChildren()
     }
-    
+
+    /// Opens a dropped file in this window: a supported archive is opened directly;
+    /// anything else becomes the first entry of a new archive. `open`/`create` reset
+    /// the state, so this replaces whatever is currently loaded.
+    public func openDropped(url: URL) {
+        if isSupportedArchive(url: url) {
+            open(url: url)
+        } else {
+            create()
+            add(url: url)
+        }
+    }
+
     /// Saves the current changes to the file
     public func save() {
         guard let url else { return }


### PR DESCRIPTION
resolves #116
