### PR TITLE
fix: preserve symlinks and exec permissions in 7-Zip extraction (#121)

### DIFF
--- a/Config/Changelog.json
+++ b/Config/Changelog.json
@@ -55,6 +55,25 @@
                         "ko": "zip/7z 아카이브에서 \"아카이브 추출\"이 파일을 생성하지 않던 문제 수정"
                     },
                     "issues": []
+                },
+                {
+                    "type": "fix",
+                    "title": {
+                        "en": "Apps extracted from ZIP archives with the 7-Zip engine wouldn't launch because symbolic links and file permissions were lost",
+                        "zh-Hans": "修复使用 7-Zip 引擎从 ZIP 压缩包解压的应用因符号链接和文件权限丢失而无法启动的问题",
+                        "fr": "Les apps extraites d’archives ZIP avec le moteur 7-Zip ne se lançaient pas car les liens symboliques et les permissions étaient perdus",
+                        "de": "Mit der 7-Zip-Engine aus ZIP-Archiven entpackte Apps ließen sich nicht starten, weil symbolische Links und Dateiberechtigungen verloren gingen",
+                        "it": "Le app estratte da archivi ZIP con il motore 7-Zip non si avviavano perché i collegamenti simbolici e i permessi andavano persi",
+                        "ja": "7-Zip エンジンで ZIP アーカイブから解凍したアプリが、シンボリックリンクとファイル権限の消失により起動できない問題を修正",
+                        "fa": "برنامه‌های استخراج‌شده از آرشیوهای ZIP با موتور 7-Zip به‌دلیل از دست رفتن پیوندهای نمادین و مجوزهای فایل اجرا نمی‌شدند",
+                        "pl": "Aplikacje wypakowane z archiwów ZIP silnikiem 7-Zip nie uruchamiały się z powodu utraty dowiązań symbolicznych i uprawnień plików",
+                        "pt-BR": "Aplicativos extraídos de arquivos ZIP com o mecanismo 7-Zip não abriam porque links simbólicos e permissões eram perdidos",
+                        "ru": "Приложения, извлечённые из ZIP-архивов с движком 7-Zip, не запускались из-за потери символических ссылок и прав доступа",
+                        "uk": "Застосунки, розпаковані із ZIP-архівів рушієм 7-Zip, не запускалися через втрату символьних посилань і прав доступу",
+                        "es-MX": "Las apps extraídas de archivos ZIP con el motor 7-Zip no se abrían porque se perdían los enlaces simbólicos y los permisos",
+                        "ko": "7-Zip 엔진으로 ZIP 아카이브에서 추출한 앱이 심볼릭 링크와 파일 권한 손실로 인해 실행되지 않던 문제 수정"
+                    },
+                    "issues": ["121"]
                 }
             ]
         },

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -11,6 +11,8 @@
 #include <deque>
 #include <vector>
 #include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 #include "Common/MyWindows.h"
 #include "Common/MyCom.h"
@@ -257,7 +259,7 @@ public:
     // IArchiveExtractCallback
     Z7_COM7F_IMF(GetStream(UInt32 index, ISequentialOutStream **outStream, Int32 askExtractMode));
     Z7_COM7F_IMF(PrepareOperation(Int32 /* askExtractMode */)) { return S_OK; }
-    Z7_COM7F_IMF(SetOperationResult(Int32 /* opRes */)) { return S_OK; }
+    Z7_COM7F_IMF(SetOperationResult(Int32 opRes));
 
     // ICryptoGetTextPassword
     Z7_COM7F_IMF(CryptoGetTextPassword(BSTR *password));
@@ -270,6 +272,8 @@ private:
     FString _destDir;
     CMyComPtr<ISequentialOutStream> _outFileStream;
     FString _currentFilePath;
+    UInt32 _currentMode = 0;         // POSIX mode from kpidPosixAttrib; 0 if unknown
+    bool _currentIsSymlink = false;  // entry is a Unix symlink (S_IFLNK)
     std::string _password;
     bool _hasPassword;
     sz_progress_callback _progress;
@@ -281,6 +285,13 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     UInt32 index, ISequentialOutStream **outStream, Int32 askExtractMode))
 {
     *outStream = nullptr;
+
+    // Reset per-entry POSIX state. SetOperationResult only acts when GetStream
+    // fills these in below for an actually-extracted file.
+    _currentFilePath.Empty();
+    _currentMode = 0;
+    _currentIsSymlink = false;
+
     if (askExtractMode != NArchive::NExtract::NAskMode::kExtract)
         return S_OK;
 
@@ -345,8 +356,71 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
         return E_FAIL;
     }
 
+    // Capture the entry's POSIX mode so SetOperationResult can restore the exec
+    // bit and turn symlink entries (7-Zip writes them as a regular file whose
+    // contents are the link target) into real symlinks. Absent on non-Unix zips.
+    NWindows::NCOM::CPropVariant propPosix;
+    _archive->GetProperty(index, kpidPosixAttrib, &propPosix);
+    _currentMode = (propPosix.vt == VT_UI4) ? propPosix.ulVal : 0;
+    _currentIsSymlink = S_ISLNK(_currentMode);
+    _currentFilePath = fullPath;
+
     _outFileStream = outStreamRef;
     *outStream = outStreamRef.Detach();
+    return S_OK;
+}
+
+// Runs once per entry after its stream is fully written. Restores POSIX metadata
+// that the plain file-write above drops: the execute bit (chmod) and symbolic
+// links (recreated from the target bytes 7-Zip wrote). Single choke point for all
+// three sz_extract_* paths. macOS-only bridge, so FChar == char (UTF-8 paths).
+Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
+{
+    // Drop our stream reference so the file is closed/flushed before we read it
+    // back, chmod it, or replace it with a symlink.
+    _outFileStream.Release();
+
+    if (opRes != NArchive::NExtract::NOperationResult::kOK ||
+        _currentFilePath.IsEmpty()) {
+        _currentIsSymlink = false;
+        _currentMode = 0;
+        _currentFilePath.Empty();
+        return S_OK;
+    }
+
+    const char *path = _currentFilePath.Ptr();
+
+    if (_currentIsSymlink) {
+        // 7-Zip wrote the link target as this file's contents; read it back and
+        // replace the file with a real symlink.
+        std::string target;
+        int fd = open(path, O_RDONLY | O_NOFOLLOW);
+        if (fd >= 0) {
+            char buf[4096];
+            ssize_t n;
+            while ((n = read(fd, buf, sizeof(buf))) > 0)
+                target.append(buf, (size_t)n);
+            close(fd);
+        }
+        while (!target.empty() &&
+               (target.back() == '\0' || target.back() == '\n' || target.back() == '\r'))
+            target.pop_back();
+
+        if (!target.empty()) {
+            unlink(path);
+            if (symlink(target.c_str(), path) != 0)
+                errorMessage = "Failed to create symbolic link";
+        }
+    } else if ((_currentMode & 07777) != 0) {
+        // Restore stored permissions (notably the exec bit). Only when the archive
+        // carried a mode; otherwise keep the default the file was created with.
+        if (chmod(path, (mode_t)(_currentMode & 07777)) != 0)
+            errorMessage = "Failed to set file permissions";
+    }
+
+    _currentIsSymlink = false;
+    _currentMode = 0;
+    _currentFilePath.Empty();
     return S_OK;
 }
 

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -165,6 +165,53 @@ extension AllCoreTests {
             }
         }
 
+        // Regression for #121: a macOS `.app` extracted from a zip with the 7-Zip
+        // engine must keep its symbolic links and POSIX execute bit, otherwise the
+        // bundle won't launch. The fixture `zip/appbundle.zip` mimics a bundle:
+        // `payload/Contents/MacOS/bin` stored with mode 0755, and a symlink
+        // `payload/Contents/MacOS/link -> bin`. Before the fix the bridge wrote the
+        // symlink as a plain text file and dropped the exec bit.
+        @Test func extractionPreservesSymlinksAndExecBit() async throws {
+            let engine = Archive7ZipEngine()
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("appbundle.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            _ = try await engine.extract(
+                items: items,
+                from: url,
+                to: tempDir,
+                passwordResolver: { _ in nil }
+            )
+
+            let macOSDir = tempDir.appendingPathComponent("payload/Contents/MacOS")
+            let binURL = macOSDir.appendingPathComponent("bin")
+            let linkURL = macOSDir.appendingPathComponent("link")
+
+            // 1. The symlink must be a real symlink pointing at "bin" (before the fix
+            //    it was a regular file whose contents were the string "bin", so
+            //    destinationOfSymbolicLink throws and this is nil).
+            let linkDestination = try? FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path)
+            #expect(
+                linkDestination == "bin",
+                "link should be a symlink -> bin, got \(String(describing: linkDestination))"
+            )
+
+            // 2. The executable must keep its exec bit (fixture stores mode 0755).
+            let attrs = try FileManager.default.attributesOfItem(atPath: binURL.path)
+            let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+            #expect(
+                perms & 0o111 != 0,
+                "bin should keep an execute bit, got mode \(String(perms, radix: 8))"
+            )
+        }
+
         @Test func extractEmptyItemsThrows() async throws {
             let engine = Archive7ZipEngine()
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
@@ -272,6 +319,41 @@ extension AllCoreTests {
             #expect(extractResult.urls.count == 1)
             let extractedURL = try extractResult.singleURL
             #expect(FileManager.default.fileExists(atPath: extractedURL.path))
+        }
+
+        // Reference behavior for #121: the XAD engine already preserves symlinks +
+        // the exec bit. Locks that in so the 7-Zip fix has a matching baseline and
+        // XAD can't silently regress. Same fixture as the 7-Zip test.
+        @Test func extractionPreservesSymlinksAndExecBitViaXad() async throws {
+            let engine = ArchiveXadEngine()
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("appbundle.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            _ = try await engine.extract(
+                items: items,
+                from: url,
+                to: tempDir,
+                passwordResolver: { _ in nil }
+            )
+
+            let macOSDir = tempDir.appendingPathComponent("payload/Contents/MacOS")
+            let linkDestination = try? FileManager.default.destinationOfSymbolicLink(
+                atPath: macOSDir.appendingPathComponent("link").path
+            )
+            #expect(linkDestination == "bin")
+
+            let attrs = try FileManager.default.attributesOfItem(
+                atPath: macOSDir.appendingPathComponent("bin").path
+            )
+            let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+            #expect(perms & 0o111 != 0)
         }
 
         @Test func extractDirectoryItemViaXad() async throws {


### PR DESCRIPTION
## Problem
Extracting a macOS `.app` bundle from a zip with the **7-Zip engine** produced a bundle Finder refused to launch — symbolic links were written as plain files and the executable bit was dropped, so dyld/Gatekeeper rejected it. The XAD engine was unaffected. Fixes #121.

## Root cause
`Modules/Sources/CSevenZip/sevenzip_bridge.cpp` — the extract callback `CExtractCallback` wrote file bytes only. `SetOperationResult` was a no-op stub, which in stock 7-Zip is exactly where the client restores POSIX metadata after each entry's stream is written.

## Fix (one choke point, all `sz_extract_*` paths)
- `GetStream` captures each entry's `kpidPosixAttrib` (mode + `S_IFLNK` flag).
- `SetOperationResult` applies it after the stream closes:
  - regular file → `chmod` the stored mode (restores the exec bit)
  - symlink entry → read the target bytes 7-Zip wrote, `unlink`, then `symlink()`
- No Swift change.

## Scope
- **XAD** already did this (reference behavior).
- **SWCompression** is unaffected — it's an LZ4 single-stream decompressor, not a container extractor (separate, pre-existing limitation).
- Out of scope: directory perms, timestamps, xattrs.

## Tests
New `EngineTests` coverage against a ~1 KB `appbundle.zip` fixture (a `0755` file + a symlink) added to the **MacPacker-TestArchives** submodule (**pointer bumped in this PR**):
- 7-Zip: **fails before** this change (link is a plain file, mode `644`), **passes after**.
- XAD: baseline locked in so it can't silently regress.
- Full suite: **307 tests pass**.

## Manual verify
Extract `appbundle.zip` with the 7-Zip engine → `payload/Contents/MacOS/link` is a symlink → `bin`, and `bin` keeps its `x` bit. Compare against XAD — they now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)