### PR TITLE
Migrate CI to workflows-macos v0.4.5 (product-file model)

### DIFF
--- a/.github/workflows/distribute-beta.yml
+++ b/.github/workflows/distribute-beta.yml
@@ -1,7 +1,11 @@
-# ── Per-app beta distribution shell ──────────────────────────────────────────
-# Copy into each app repo at .github/workflows/distribute-beta.yml.
-# Triggered when a PR is merged to main. The `if:` gate prevents firing on
-# closed-but-unmerged PRs.
+# ── Per-app beta shell (workflows-macos v0.4.5, product-file model) ───────────
+# Fires on push to main. The orchestrator discovers Config/products/*.json and
+# cuts a beta for each product whose OWN file changed and whose version is still
+# unreleased (primary MacPacker → bare v<ver>-beta.N). Channel toggles and the
+# Finder/QuickLook extension identity live in the product file; infra only here.
+#
+# Cross-account (sarensw/MacPacker → LeanBytes/workflows-macos): `secrets: inherit`
+# forwards nothing across accounts, so the map stays explicit.
 # ─────────────────────────────────────────────────────────────────────────────
 name: Distribute Beta
 
@@ -10,12 +14,12 @@ on:
     branches: [main]
 
 permissions:
-  contents: write          # for the GH pre-release
+  contents: write          # GH pre-release + the auto-pushed beta tag
 
 jobs:
   beta:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.3.47
-    secrets: 
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.4.5
+    secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
       KEYCHAIN_PASSWORD:              ${{ secrets.KEYCHAIN_PASSWORD }}
@@ -35,22 +39,12 @@ jobs:
       AWS_ACCESS_KEY_ID:              ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY:          ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SPARKLE_ED_PRIVATE_KEY:         ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+      # v0.4.x: the beta run-tests gate files a ticket when the suite fails.
+      JIRA_API_TOKEN:                 ${{ secrets.JIRA_API_TOKEN }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
-      # ── Build toggles ──
-      build-direct: true
-      build-app-store: true
-
-      # ── Distribute toggles ──
-      distribute-app-store: true      # TestFlight
-      distribute-beta-appcast: true   # Sparkle beta channel
-
-      # ── Per-app build flags ──
-      has-finder-extension: true     # macpacker
-      has-quicklook-extension: true  # macpacker
-
-      # ── Build configuration ──
-      configuration-direct: Release
+      # The store leg MUST archive "Release Store" — the orchestrator default is
+      # "Release", which would build the wrong flavor.
       configuration-app-store: Release Store
 
       # ── Test configuration ──

--- a/.github/workflows/distribute-beta.yml
+++ b/.github/workflows/distribute-beta.yml
@@ -1,4 +1,4 @@
-# ── Per-app beta shell (workflows-macos v0.4.5, product-file model) ───────────
+# ── Per-app beta shell (workflows-macos v0.4.6, product-file model) ───────────
 # Fires on push to main. The orchestrator discovers Config/products/*.json and
 # cuts a beta for each product whose OWN file changed and whose version is still
 # unreleased (primary MacPacker → bare v<ver>-beta.N). Channel toggles and the
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   beta:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.4.5
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.4.6
     secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
@@ -43,6 +43,7 @@ jobs:
       JIRA_API_TOKEN:                 ${{ secrets.JIRA_API_TOKEN }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
+      artifact-retention-days: 90   # CI artifacts kept 90 days
       # The store leg MUST archive "Release Store" — the orchestrator default is
       # "Release", which would build the wrong flavor.
       configuration-app-store: Release Store

--- a/.github/workflows/distribute-pr.yml
+++ b/.github/workflows/distribute-pr.yml
@@ -1,4 +1,4 @@
-# ── Per-app PR shell (workflows-macos v0.4.5, product-file model) ─────────────
+# ── Per-app PR shell (workflows-macos v0.4.6, product-file model) ─────────────
 # Trigger-only: the orchestrator discovers every Config/products/<id>.json and
 # compiles each product (unsigned, fork-PR safe), then runs the Swift package
 # tests. Identity + channels live in the product files, not here.
@@ -18,8 +18,9 @@ permissions:
 
 jobs:
   pr:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.4.5
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.4.6
     with:
+      artifact-retention-days: 90   # CI artifacts kept 90 days
       # ── Test configuration ──
       run-tests: true
       test-runner: swift

--- a/.github/workflows/distribute-pr.yml
+++ b/.github/workflows/distribute-pr.yml
@@ -1,6 +1,11 @@
-# ── Per-app PR distribution shell ────────────────────────────────────────────
-# Copy into each app repo at .github/workflows/distribute-pr.yml.
-# Only the inputs marked "per-app" need adjusting; the rest stay as-is.
+# ── Per-app PR shell (workflows-macos v0.4.5, product-file model) ─────────────
+# Trigger-only: the orchestrator discovers every Config/products/<id>.json and
+# compiles each product (unsigned, fork-PR safe), then runs the Swift package
+# tests. Identity + channels live in the product files, not here.
+#
+# Runs on GitHub-hosted runners by design: MacPacker is a PUBLIC repo, and
+# pointing a public-repo PR build at a self-hosted runner would let fork PRs
+# execute arbitrary code on that machine.
 # ─────────────────────────────────────────────────────────────────────────────
 name: Distribute PR
 
@@ -13,12 +18,8 @@ permissions:
 
 jobs:
   pr:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.3.47
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.4.5
     with:
-      has-finder-extension: true
-      has-quicklook-extension: true
-      scheme-name: MacPacker
-
       # ── Test configuration ──
       run-tests: true
       test-runner: swift

--- a/.github/workflows/distribute-release.yml
+++ b/.github/workflows/distribute-release.yml
@@ -1,4 +1,4 @@
-# ── Per-app release shell (workflows-macos v0.4.5, product-file model) ────────
+# ── Per-app release shell (workflows-macos v0.4.6, product-file model) ────────
 # Fires on a version tag. The orchestrator parses the tag → the target product,
 # validates the version against that product's inline changelog, then builds and
 # publishes just it. The GH Release is created last (fail-safe ordering).
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.4.5
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.4.6
     secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
@@ -47,6 +47,7 @@ jobs:
       SPARKLE_ED_PRIVATE_KEY:         ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
+      artifact-retention-days: 90   # CI artifacts kept 90 days
       # The store leg MUST archive "Release Store" — the orchestrator default is
       # "Release", which would build the wrong flavor.
       configuration-app-store: Release Store

--- a/.github/workflows/distribute-release.yml
+++ b/.github/workflows/distribute-release.yml
@@ -1,15 +1,22 @@
-# ── Per-app release distribution shell ───────────────────────────────────────
-# Copy into each app repo at .github/workflows/distribute-release.yml.
-# Triggered by pushing a v*.*.* tag. Strict fail-safe order: GH Release is
-# only created after every other publish step succeeds.
+# ── Per-app release shell (workflows-macos v0.4.5, product-file model) ────────
+# Fires on a version tag. The orchestrator parses the tag → the target product,
+# validates the version against that product's inline changelog, then builds and
+# publishes just it. The GH Release is created last (fail-safe ordering).
+#
+# Cross-account (sarensw/MacPacker → LeanBytes/workflows-macos): `secrets: inherit`
+# forwards nothing across accounts, so the map stays explicit. No JIRA_API_TOKEN
+# here — the release orchestrator does not declare it (passing an undeclared
+# secret is a hard workflow error) and release runs no tests.
 # ─────────────────────────────────────────────────────────────────────────────
 name: Distribute Release
 
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-beta.*'
+      - 'v*'           # primary product (MacPacker): v0.17.0
+      - '*-v*'         # extra products:              <id>-v0.17.0
+      - '!*-beta.*'    # exclude the auto-pushed beta tags
+      - '!*-alpha.*'   # …and alpha tags
 
 permissions:
   contents: write    # for the GH Release
@@ -17,8 +24,8 @@ permissions:
 
 jobs:
   release:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.3.47
-    secrets: 
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.4.5
+    secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
       KEYCHAIN_PASSWORD:              ${{ secrets.KEYCHAIN_PASSWORD }}
@@ -40,20 +47,8 @@ jobs:
       SPARKLE_ED_PRIVATE_KEY:         ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
-      # ── Build toggles ─
-      build-direct: true
-      build-app-store: true
-
-      # ── Distribute toggles ──
-      distribute-app-store: true
-      distribute-stable-appcast: true
-
-      # ── Per-app build flags ──
-      has-finder-extension: true
-      has-quicklook-extension: true
-
-      # ── Build configuration ──
-      configuration-direct: Release
+      # The store leg MUST archive "Release Store" — the orchestrator default is
+      # "Release", which would build the wrong flavor.
       configuration-app-store: Release Store
 
       # ── Discussion configuration ──

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -1,0 +1,1061 @@
+{
+  "id": "",
+  "platform": "macos",
+  "scheme": "MacPacker",
+  "product-name": "MacPacker",
+  "bundle-id": "com.sarensx.MacPacker",
+  "scheme-store": "MacPacker Store",
+  "has-finder": true,
+  "bundle-id-finder": "com.sarensx.MacPacker.FinderExtension",
+  "has-quicklook": true,
+  "bundle-id-quicklook": "com.sarensx.MacPacker.QuickLookExtension",
+  "build-direct": true,
+  "build-app-store": true,
+  "distribute-app-store": true,
+  "distribute-appcast": true,
+  "s3-subpath": "",
+  "appcast-seed-path": "Config/appcast.xml",
+  "changelog": {
+    "comingNext": {
+      "en": "Support for deletion of files / folders from .zip archives",
+      "zh-Hans": "支持从 .zip 压缩包中删除文件 / 文件夹",
+      "fr": "Prise en charge de la suppression de fichiers / dossiers des archives .zip",
+      "de": "Unterstützung zum Löschen von Dateien / Ordnern aus .zip-Archiven",
+      "it": "Supporto per l’eliminazione di file / cartelle dagli archivi .zip",
+      "ja": ".zip アーカイブ内のファイル / フォルダ削除をサポート",
+      "fa": "پشتیبانی از حذف فایل‌ها / پوشه‌ها از آرشیوهای .zip",
+      "pl": "Obsługa usuwania plików / folderów z archiwów .zip",
+      "pt-BR": "Suporte para exclusão de arquivos / pastas de arquivos .zip",
+      "ru": "Поддержка удаления файлов / папок из архивов .zip",
+      "uk": "Підтримка видалення файлів / папок з архівів .zip",
+      "es-MX": "Compatibilidad con eliminación de archivos / carpetas de archivos .zip",
+      "ko": ".zip 아카이브에서 파일 / 폴더 삭제 지원"
+    },
+    "versions": [
+      {
+        "version": "0.17.0",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Extraction progress window with live speed chart and cancel",
+              "zh-Hans": "解压进度窗口，含实时速度图表和取消功能",
+              "fr": "Fenêtre de progression d’extraction avec graphique de vitesse en direct et annulation",
+              "de": "Fortschrittsfenster beim Entpacken mit Live-Geschwindigkeitsdiagramm und Abbrechen",
+              "it": "Finestra di avanzamento dell’estrazione con grafico della velocità in tempo reale e annullamento",
+              "ja": "解凍の進行状況ウィンドウ（リアルタイム速度グラフとキャンセル機能付き）",
+              "fa": "پنجره پیشرفت استخراج با نمودار سرعت زنده و امکان لغو",
+              "pl": "Okno postępu wypakowywania z wykresem prędkości na żywo i możliwością anulowania",
+              "pt-BR": "Janela de progresso da extração com gráfico de velocidade ao vivo e cancelamento",
+              "ru": "Окно хода распаковки с графиком скорости в реальном времени и отменой",
+              "uk": "Вікно перебігу розпакування з живим графіком швидкості та скасуванням",
+              "es-MX": "Ventana de progreso de extracción con gráfica de velocidad en vivo y cancelación",
+              "ko": "실시간 속도 차트와 취소 기능이 있는 압축 해제 진행 창"
+            },
+            "issues": [
+              "119"
+            ]
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "\"Extract archive\" produced no files for zip/7z archives",
+              "zh-Hans": "修复 zip/7z 压缩包使用「解压归档」时不生成文件的问题",
+              "fr": "« Extraire l’archive » ne produisait aucun fichier pour les archives zip/7z",
+              "de": "\"Archiv entpacken\" erzeugte bei zip/7z-Archiven keine Dateien",
+              "it": "\"Estrai archivio\" non produceva file per gli archivi zip/7z",
+              "ja": "zip/7z アーカイブで「アーカイブを解凍」がファイルを生成しない問題を修正",
+              "fa": "«استخراج آرشیو» برای آرشیوهای zip/7z هیچ فایلی ایجاد نمی‌کرد",
+              "pl": "„Wypakuj archiwum” nie tworzyło plików dla archiwów zip/7z",
+              "pt-BR": "\"Extrair arquivo\" não produzia arquivos para arquivos zip/7z",
+              "ru": "«Извлечь архив» не создавал файлы для архивов zip/7z",
+              "uk": "«Розпакувати архів» не створював файли для архівів zip/7z",
+              "es-MX": "\"Extraer archivo\" no producía archivos para archivos zip/7z",
+              "ko": "zip/7z 아카이브에서 \"아카이브 추출\"이 파일을 생성하지 않던 문제 수정"
+            },
+            "issues": []
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Apps extracted from ZIP archives with the 7-Zip engine wouldn't launch because symbolic links and file permissions were lost",
+              "zh-Hans": "修复使用 7-Zip 引擎从 ZIP 压缩包解压的应用因符号链接和文件权限丢失而无法启动的问题",
+              "fr": "Les apps extraites d’archives ZIP avec le moteur 7-Zip ne se lançaient pas car les liens symboliques et les permissions étaient perdus",
+              "de": "Mit der 7-Zip-Engine aus ZIP-Archiven entpackte Apps ließen sich nicht starten, weil symbolische Links und Dateiberechtigungen verloren gingen",
+              "it": "Le app estratte da archivi ZIP con il motore 7-Zip non si avviavano perché i collegamenti simbolici e i permessi andavano persi",
+              "ja": "7-Zip エンジンで ZIP アーカイブから解凍したアプリが、シンボリックリンクとファイル権限の消失により起動できない問題を修正",
+              "fa": "برنامه‌های استخراج‌شده از آرشیوهای ZIP با موتور 7-Zip به‌دلیل از دست رفتن پیوندهای نمادین و مجوزهای فایل اجرا نمی‌شدند",
+              "pl": "Aplikacje wypakowane z archiwów ZIP silnikiem 7-Zip nie uruchamiały się z powodu utraty dowiązań symbolicznych i uprawnień plików",
+              "pt-BR": "Aplicativos extraídos de arquivos ZIP com o mecanismo 7-Zip não abriam porque links simbólicos e permissões eram perdidos",
+              "ru": "Приложения, извлечённые из ZIP-архивов с движком 7-Zip, не запускались из-за потери символических ссылок и прав доступа",
+              "uk": "Застосунки, розпаковані із ZIP-архівів рушієм 7-Zip, не запускалися через втрату символьних посилань і прав доступу",
+              "es-MX": "Las apps extraídas de archivos ZIP con el motor 7-Zip no se abrían porque se perdían los enlaces simbólicos y los permisos",
+              "ko": "7-Zip 엔진으로 ZIP 아카이브에서 추출한 앱이 심볼릭 링크와 파일 권한 손실로 인해 실행되지 않던 문제 수정"
+            },
+            "issues": [
+              "121"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "0.16.0",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Open split ZIP files",
+              "zh-Hans": "支持打开分卷 ZIP 文件",
+              "fr": "Ouverture des archives ZIP fractionnées",
+              "de": "Geteilte ZIP-Archive öffnen",
+              "it": "Apri archivi ZIP suddivisi",
+              "ja": "分割 ZIP ファイルをサポート",
+              "fa": "باز کردن فایل‌های ZIP چندبخشی",
+              "pl": "Otwieranie podzielonych archiwów ZIP",
+              "pt-BR": "Abrir arquivos ZIP divididos",
+              "ru": "Открытие составных ZIP-архивов",
+              "uk": "Відкриття багатотомних ZIP-архівів",
+              "es-MX": "Abrir archivos ZIP divididos",
+              "ko": "분할 ZIP 파일 열기"
+            },
+            "issues": [
+              "115"
+            ]
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Hold ⌥ while dropping an archive to open it in a new window",
+              "zh-Hans": "拖放压缩包时按住 ⌥ 可在新窗口中打开",
+              "fr": "Maintenez ⌥ en déposant une archive pour l’ouvrir dans une nouvelle fenêtre",
+              "de": "⌥ beim Ablegen eines Archivs gedrückt halten, um es in einem neuen Fenster zu öffnen",
+              "it": "Tieni premuto ⌥ mentre trascini un archivio per aprirlo in una nuova finestra",
+              "ja": "アーカイブをドロップする際に ⌥ を押し続けると新しいウィンドウで開く",
+              "fa": "با نگه داشتن ⌥ هنگام رها کردن آرشیو، آن را در پنجره‌ای جدید باز کنید",
+              "pl": "Przytrzymaj ⌥ podczas upuszczania archiwum, aby otworzyć je w nowym oknie",
+              "pt-BR": "Mantenha ⌥ pressionado ao soltar um arquivo para abri-lo em uma nova janela",
+              "ru": "Удерживайте ⌥ при перетаскивании архива, чтобы открыть его в новом окне",
+              "uk": "Утримуйте ⌥ під час перетягування архіву, щоб відкрити його в новому вікні",
+              "es-MX": "Mantén presionada la tecla ⌥ al soltar un archivo para abrirlo en una ventana nueva",
+              "ko": "아카이브를 놓을 때 ⌥ 키를 누르고 있으면 새 창에서 열립니다"
+            },
+            "issues": [
+              "116"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "0.15.4",
+        "items": [
+          {
+            "type": "fix",
+            "title": {
+              "en": "Finder toolbar icon appears too large",
+              "zh-Hans": "Finder 工具栏图标显示过大",
+              "fr": "L’icône de la barre d’outils du Finder apparaissait trop grande",
+              "de": "Finder-Symbol in der Symbolleiste erschien zu groß",
+              "it": "L’icona della barra degli strumenti del Finder appariva troppo grande",
+              "ja": "Finder ツールバーのアイコンが大きすぎて表示される問題を修正",
+              "fa": "آیکون نوار ابزار Finder بیش از حد بزرگ نمایش داده می‌شد",
+              "pl": "Ikona paska narzędzi Findera była wyświetlana zbyt duża",
+              "pt-BR": "O ícone da barra de ferramentas do Finder aparecia grande demais",
+              "ru": "Значок панели инструментов Finder отображался слишком большим",
+              "uk": "Значок панелі інструментів Finder відображався занадто великим",
+              "es-MX": "El ícono de la barra de herramientas de Finder aparecía demasiado grande",
+              "ko": "Finder 도구 막대 아이콘이 너무 크게 표시되던 문제 수정"
+            },
+            "issues": [
+              "112"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "0.15.3",
+        "items": [
+          {
+            "type": "core",
+            "title": {
+              "en": "Update 7-Zip to v26.01",
+              "zh-Hans": "更新 7-Zip 至 v26.01",
+              "fr": "Mise à jour de 7-Zip vers la version 26.01",
+              "de": "7-Zip auf Version 26.01 aktualisiert",
+              "it": "Aggiornamento di 7-Zip alla versione 26.01",
+              "ja": "7-Zip を v26.01 に更新",
+              "fa": "به‌روزرسانی 7-Zip به نسخه 26.01",
+              "pl": "Aktualizacja 7-Zip do wersji 26.01",
+              "pt-BR": "Atualização do 7-Zip para a versão 26.01",
+              "ru": "Обновление 7-Zip до версии 26.01",
+              "uk": "Оновлення 7-Zip до версії 26.01",
+              "es-MX": "Actualización de 7-Zip a la versión 26.01",
+              "ko": "7-Zip을 v26.01로 업데이트"
+            },
+            "issues": [
+              "104"
+            ]
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Potential Zip-Slip vulnerability in archive extraction",
+              "zh-Hans": "归档解压过程中存在潜在的 Zip-Slip 漏洞",
+              "fr": "Vulnérabilité Zip-Slip potentielle lors de l’extraction d’archives",
+              "de": "Potenzielle Zip-Slip-Sicherheitslücke bei der Archivextraktion",
+              "it": "Potenziale vulnerabilità Zip-Slip durante l’estrazione degli archivi",
+              "ja": "アーカイブ展開時の潜在的な Zip-Slip 脆弱性",
+              "fa": "آسیب‌پذیری احتمالی Zip-Slip هنگام استخراج آرشیوها",
+              "pl": "Potencjalna podatność Zip-Slip podczas rozpakowywania archiwów",
+              "pt-BR": "Possível vulnerabilidade Zip-Slip na extração de arquivos",
+              "ru": "Потенциальная уязвимость Zip-Slip при распаковке архивов",
+              "uk": "Потенційна вразливість Zip-Slip під час розпакування архівів",
+              "es-MX": "Posible vulnerabilidad Zip-Slip durante la extracción de archivos",
+              "ko": "아카이브 추출 과정의 잠재적 Zip-Slip 취약점"
+            },
+            "issues": [
+              "103",
+              "LB-555"
+            ]
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Archives with UTF-8 characters in their file name could not be opened",
+              "zh-Hans": "文件名包含 UTF-8 字符的压缩包无法打开",
+              "fr": "Les archives dont le nom contient des caractères UTF-8 ne pouvaient pas être ouvertes",
+              "de": "Archive mit UTF-8-Zeichen im Dateinamen konnten nicht geöffnet werden",
+              "it": "Gli archivi con caratteri UTF-8 nel nome del file non potevano essere aperti",
+              "ja": "ファイル名に UTF-8 文字を含むアーカイブを開けない問題を修正",
+              "fa": "آرشیوهایی با نویسه‌های UTF-8 در نام فایل قابل باز شدن نبودند",
+              "pl": "Nie można było otwierać archiwów z znakami UTF-8 w nazwie pliku",
+              "pt-BR": "Arquivos com caracteres UTF-8 no nome não podiam ser abertos",
+              "ru": "Архивы с символами UTF-8 в имени файла не открывались",
+              "uk": "Архіви з символами UTF-8 в імені файлу не відкривалися",
+              "es-MX": "No se podían abrir archivos con caracteres UTF-8 en el nombre",
+              "ko": "파일 이름에 UTF-8 문자가 포함된 아카이브를 열 수 없던 문제 수정"
+            },
+            "issues": [
+              "107"
+            ]
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Quick Look preview not working",
+              "zh-Hans": "快速查看预览无法使用",
+              "fr": "L’aperçu Quick Look ne fonctionnait pas",
+              "de": "Quick-Look-Vorschau funktionierte nicht",
+              "it": "L’anteprima Quick Look non funzionava",
+              "ja": "Quick Look プレビューが機能しない問題を修正",
+              "fa": "پیش‌نمایش Quick Look کار نمی‌کرد",
+              "pl": "Podgląd Quick Look nie działał",
+              "pt-BR": "A visualização do Quick Look não funcionava",
+              "ru": "Предпросмотр Quick Look не работал",
+              "uk": "Попередній перегляд Quick Look не працював",
+              "es-MX": "La vista previa de Quick Look no funcionaba",
+              "ko": "Quick Look 미리보기가 동작하지 않던 문제 수정"
+            },
+            "issues": [
+              "106"
+            ]
+          },
+          {
+            "type": "lang",
+            "title": {
+              "en": "Updates to Chinese & Polish translations",
+              "zh-Hans": "更新中文和波兰语翻译",
+              "fr": "Mises à jour des traductions chinoise et polonaise",
+              "de": "Aktualisierungen der chinesischen und polnischen Übersetzungen",
+              "it": "Aggiornamenti alle traduzioni in cinese e polacco",
+              "ja": "中国語およびポーランド語翻訳を更新",
+              "fa": "به‌روزرسانی ترجمه‌های چینی و لهستانی",
+              "pl": "Aktualizacje tłumaczeń chińskich i polskich",
+              "pt-BR": "Atualizações nas traduções para chinês e polonês",
+              "ru": "Обновления китайского и польского переводов",
+              "uk": "Оновлення китайського та польського перекладів",
+              "es-MX": "Actualizaciones de las traducciones al chino y polaco",
+              "ko": "중국어 및 폴란드어 번역 업데이트"
+            },
+            "issues": []
+          }
+        ]
+      },
+      {
+        "version": "0.15.2",
+        "items": [
+          {
+            "type": "fix",
+            "title": {
+              "en": "Archives opened via Finder integration show empty contents",
+              "zh-Hans": "通过 Finder 集成打开的压缩包显示为空",
+              "fr": "Les archives ouvertes via l’intégration Finder affichent un contenu vide",
+              "de": "Über die Finder-Integration geöffnete Archive zeigen leeren Inhalt an",
+              "it": "Gli archivi aperti tramite l’integrazione Finder mostrano un contenuto vuoto",
+              "ja": "Finder 統合経由で開いたアーカイブの内容が空になる問題を修正",
+              "fa": "آرشیوهای بازشده از طریق یکپارچه‌سازی Finder محتوای خالی نشان می‌دادند",
+              "pl": "Archiwa otwierane przez integrację z Finderem wyświetlały pustą zawartość",
+              "pt-BR": "Arquivos abertos pela integração com o Finder exibiam conteúdo vazio",
+              "ru": "Архивы, открытые через интеграцию с Finder, отображали пустое содержимое",
+              "uk": "Архіви, відкриті через інтеграцію Finder, відображали порожній вміст",
+              "es-MX": "Los archivos abiertos mediante la integración con Finder mostraban contenido vacío",
+              "ko": "Finder 통합으로 연 아카이브의 내용이 비어 보이던 문제 수정"
+            },
+            "pr": 98
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Export logs for troubleshooting",
+              "zh-Hans": "导出日志用于故障排查",
+              "fr": "Exporter les journaux pour le dépannage",
+              "de": "Protokolle für die Fehleranalyse exportieren",
+              "it": "Esporta i log per la risoluzione dei problemi",
+              "ja": "トラブルシューティング用にログをエクスポート",
+              "fa": "خروجی گرفتن از گزارش‌ها برای عیب‌یابی",
+              "pl": "Eksportowanie logów do diagnostyki",
+              "pt-BR": "Exportar logs para diagnóstico",
+              "ru": "Экспорт журналов для диагностики",
+              "uk": "Експорт журналів для діагностики",
+              "es-MX": "Exportar registros para diagnóstico",
+              "ko": "문제 해결을 위한 로그 내보내기"
+            },
+            "pr": 100
+          }
+        ]
+      },
+      {
+        "version": "0.15.1",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Language support for Korean",
+              "zh-Hans": "新增韩语支持",
+              "fr": "Prise en charge de la langue coréenne",
+              "de": "Unterstützung für Koreanisch",
+              "it": "Supporto per la lingua coreana",
+              "ja": "韓国語サポートを追加",
+              "fa": "پشتیبانی از زبان کره‌ای",
+              "pl": "Obsługa języka koreańskiego",
+              "pt-BR": "Suporte ao idioma coreano",
+              "ru": "Поддержка корейского языка",
+              "uk": "Підтримка корейської мови",
+              "es-MX": "Compatibilidad con el idioma coreano",
+              "ko": "한국어 지원 추가"
+            },
+            "pr": 95
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Language support for Mexican Spanish",
+              "zh-Hans": "新增墨西哥西班牙语支持",
+              "fr": "Prise en charge de l’espagnol mexicain",
+              "de": "Unterstützung für mexikanisches Spanisch",
+              "it": "Supporto per lo spagnolo messicano",
+              "ja": "メキシコスペイン語サポートを追加",
+              "fa": "پشتیبانی از اسپانیایی مکزیکی",
+              "pl": "Obsługa hiszpańskiego (Meksyk)",
+              "pt-BR": "Suporte ao espanhol mexicano",
+              "ru": "Поддержка мексиканского испанского языка",
+              "uk": "Підтримка мексиканської іспанської мови",
+              "es-MX": "Compatibilidad con español mexicano",
+              "ko": "멕시코 스페인어 지원 추가"
+            },
+            "pr": 95
+          }
+        ]
+      },
+      {
+        "version": "0.15",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "wim support",
+              "zh-Hans": "支持 WIM",
+              "fr": "Prise en charge de WIM",
+              "de": "WIM-Unterstützung",
+              "it": "Supporto WIM",
+              "ja": "WIM サポート",
+              "fa": "پشتیبانی از WIM",
+              "pl": "Obsługa WIM",
+              "pt-BR": "Suporte a WIM",
+              "ru": "Поддержка WIM",
+              "uk": "Підтримка WIM",
+              "es-MX": "Compatibilidad con WIM",
+              "ko": "WIM 지원"
+            },
+            "pr": 70
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Open password protected / encrypted archives",
+              "zh-Hans": "打开受密码保护/加密的压缩包",
+              "fr": "Ouverture des archives protégées par mot de passe / chiffrées",
+              "de": "Öffnen passwortgeschützter / verschlüsselter Archive",
+              "it": "Apri archivi protetti da password / crittografati",
+              "ja": "パスワード保護 / 暗号化されたアーカイブを開く",
+              "fa": "باز کردن آرشیوهای رمزدار / رمزگذاری‌شده",
+              "pl": "Otwieranie archiwów chronionych hasłem / zaszyfrowanych",
+              "pt-BR": "Abrir arquivos protegidos por senha / criptografados",
+              "ru": "Открытие архивов, защищённых паролем / зашифрованных",
+              "uk": "Відкриття архівів, захищених паролем / зашифрованих",
+              "es-MX": "Abrir archivos protegidos con contraseña / cifrados",
+              "ko": "암호 보호 / 암호화된 아카이브 열기"
+            },
+            "pr": 6
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "New Welcome & About dialogs",
+              "zh-Hans": "全新的欢迎与关于对话框",
+              "fr": "Nouvelles fenêtres de bienvenue et À propos",
+              "de": "Neue Willkommens- und „Über“-Dialoge",
+              "it": "Nuove finestre di Benvenuto e Informazioni",
+              "ja": "新しいウェルカムおよび「このアプリについて」ダイアログ",
+              "fa": "پنجره‌های جدید خوش‌آمدگویی و «درباره»",
+              "pl": "Nowe okna powitalne i „O programie”",
+              "pt-BR": "Novos diálogos de Boas-vindas e Sobre",
+              "ru": "Новые окна приветствия и «О программе»",
+              "uk": "Нові вікна привітання та «Про програму»",
+              "es-MX": "Nuevos diálogos de Bienvenida y Acerca de",
+              "ko": "새로운 환영 및 정보 대화상자"
+            },
+            "pr": 82
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Sorting enabled for all columns, sort order persisted and name is default",
+              "zh-Hans": "所有列均支持排序，排序顺序会被保存，名称为默认排序",
+              "fr": "Tri activé pour toutes les colonnes, ordre de tri conservé et nom défini par défaut",
+              "de": "Sortierung für alle Spalten aktiviert, Sortierreihenfolge wird gespeichert und Name ist Standard",
+              "it": "Ordinamento abilitato per tutte le colonne, ordine salvato e nome come predefinito",
+              "ja": "すべての列で並び替えを有効化、並び順を保持し、名前をデフォルトに設定",
+              "fa": "مرتب‌سازی برای همه ستون‌ها فعال شد، ترتیب مرتب‌سازی ذخیره می‌شود و نام پیش‌فرض است",
+              "pl": "Sortowanie dostępne dla wszystkich kolumn, kolejność sortowania zapisywana, nazwa jako domyślna",
+              "pt-BR": "Ordenação habilitada para todas as colunas, ordem persistida e nome como padrão",
+              "ru": "Сортировка доступна для всех столбцов, порядок сохраняется, имя — по умолчанию",
+              "uk": "Сортування доступне для всіх стовпців, порядок зберігається, назва — за замовчуванням",
+              "es-MX": "Ordenación habilitada para todas las columnas, el orden se conserva y el nombre es el predeterminado",
+              "ko": "모든 열 정렬 지원, 정렬 순서 유지 및 이름을 기본값으로 설정"
+            },
+            "pr": 77
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "New option to quit on last window closed",
+              "zh-Hans": "新增“关闭最后一个窗口时退出”选项",
+              "fr": "Nouvelle option pour quitter à la fermeture de la dernière fenêtre",
+              "de": "Neue Option zum Beenden beim Schließen des letzten Fensters",
+              "it": "Nuova opzione per uscire alla chiusura dell’ultima finestra",
+              "ja": "最後のウィンドウを閉じたときに終了する新オプション",
+              "fa": "گزینه جدید برای خروج هنگام بسته شدن آخرین پنجره",
+              "pl": "Nowa opcja zamykania aplikacji po zamknięciu ostatniego okna",
+              "pt-BR": "Nova opção para encerrar ao fechar a última janela",
+              "ru": "Новая опция выхода при закрытии последнего окна",
+              "uk": "Нова опція виходу після закриття останнього вікна",
+              "es-MX": "Nueva opción para salir al cerrar la última ventana",
+              "ko": "마지막 창 닫기 시 종료하는 새 옵션"
+            },
+            "pr": 89
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Up/down keys not working when preview is opened",
+              "zh-Hans": "打开预览时上下方向键无法使用",
+              "fr": "Les touches haut/bas ne fonctionnaient pas lorsque l’aperçu était ouvert",
+              "de": "Pfeiltasten hoch/runter funktionierten nicht bei geöffneter Vorschau",
+              "it": "I tasti su/giù non funzionavano quando l’anteprima era aperta",
+              "ja": "プレビュー表示中に上下キーが動作しない問題を修正",
+              "fa": "کلیدهای بالا/پایین هنگام باز بودن پیش‌نمایش کار نمی‌کردند",
+              "pl": "Klawisze góra/dół nie działały przy otwartym podglądzie",
+              "pt-BR": "As teclas para cima/baixo não funcionavam com a pré-visualização aberta",
+              "ru": "Клавиши вверх/вниз не работали при открытом предпросмотре",
+              "uk": "Клавіші вгору/вниз не працювали при відкритому перегляді",
+              "es-MX": "Las teclas arriba/abajo no funcionaban cuando la vista previa estaba abierta",
+              "ko": "미리보기 열림 상태에서 위/아래 키가 동작하지 않던 문제 수정"
+            },
+            "pr": 78
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Support for magic numbers at the end of archive files",
+              "zh-Hans": "支持压缩文件末尾的魔术数字",
+              "fr": "Prise en charge des magic numbers à la fin des fichiers d’archive",
+              "de": "Unterstützung für Magic Numbers am Ende von Archivdateien",
+              "it": "Supporto per magic number alla fine dei file archivio",
+              "ja": "アーカイブファイル末尾のマジックナンバーをサポート",
+              "fa": "پشتیبانی از اعداد جادویی در انتهای فایل‌های آرشیو",
+              "pl": "Obsługa magic numbers na końcu plików archiwów",
+              "pt-BR": "Suporte a magic numbers no final de arquivos compactados",
+              "ru": "Поддержка magic numbers в конце архивных файлов",
+              "uk": "Підтримка magic numbers наприкінці архівних файлів",
+              "es-MX": "Compatibilidad con magic numbers al final de archivos comprimidos",
+              "ko": "아카이브 파일 끝의 매직 넘버 지원"
+            },
+            "pr": 69
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Update acknowledgements",
+              "zh-Hans": "更新致谢内容",
+              "fr": "Mise à jour des remerciements",
+              "de": "Danksagungen aktualisiert",
+              "it": "Aggiornati i riconoscimenti",
+              "ja": "謝辞を更新",
+              "fa": "به‌روزرسانی قدردانی‌ها",
+              "pl": "Zaktualizowano podziękowania",
+              "pt-BR": "Atualização dos agradecimentos",
+              "ru": "Обновлены благодарности",
+              "uk": "Оновлено подяки",
+              "es-MX": "Actualización de agradecimientos",
+              "ko": "감사의 말 업데이트"
+            },
+            "pr": 79
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Drop macOS 13 support",
+              "zh-Hans": "停止支持 macOS 13",
+              "fr": "Abandon de la prise en charge de macOS 13",
+              "de": "Unterstützung für macOS 13 eingestellt",
+              "it": "Rimosso il supporto per macOS 13",
+              "ja": "macOS 13 のサポートを終了",
+              "fa": "پشتیبانی از macOS 13 حذف شد",
+              "pl": "Usunięto wsparcie dla macOS 13",
+              "pt-BR": "Encerrado o suporte ao macOS 13",
+              "ru": "Прекращена поддержка macOS 13",
+              "uk": "Припинено підтримку macOS 13",
+              "es-MX": "Se eliminó el soporte para macOS 13",
+              "ko": "macOS 13 지원 종료"
+            },
+            "pr": 80
+          }
+        ]
+      },
+      {
+        "version": "0.14.1",
+        "items": [
+          {
+            "type": "fix",
+            "title": {
+              "en": "Wrong translations in settings"
+            }
+          },
+          {
+            "type": "lang",
+            "title": {
+              "en": "Language update for several languages"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.14",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "New menu to open a new empty window"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Extended info on archive in status bar"
+            },
+            "pr": 61
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "tar.gz and tgz not working"
+            },
+            "pr": 54
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Can't close QuickLook with Space"
+            },
+            "pr": 55
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "macOS not recognizing MacPacker as a viable VHDX reader"
+            },
+            "pr": 56
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Cache cleanup not happening when just closing a window or loading a new archive"
+            },
+            "pr": 58
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "App crashes when unpacking exe / msi files"
+            },
+            "pr": 59
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Extract here and Extract to folder via Finder don't work"
+            },
+            "pr": 62
+          }
+        ]
+      },
+      {
+        "version": "0.13",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "arj, dmg/apfs (Apple File System), chm, fat, ntfs, tar.z/taz, qcow2, squashfs, vdi, vhd, vhdx, vmdk, xar support"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Special handling for Apple Installer Packages (pkg)"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Added settings for easier access to managing the Finder file provider extension"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Extracting folders does not include files"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Added attributions for 3rd party libraries/code"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Language support for Persian"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.12",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Added 'File' > 'Open...' menu to open archives when no window is open"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Improved TAR archive handling"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "MacPacker not showing up in 'Open With…' menu in Finder (App Store version only)"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Chinese (Unicode) characters in archive contents not displayed correctly"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Separated localization of changelog from app localization"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Language support for Ukrainian, Russian"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Detect archive type based on magic number in addition to file extension"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.11",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Use system preview instead of internal previewer"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Navigate the archive using keys similar to Finder"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Crash when using the open with option"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Quick look extension missing in App Store version"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Empty window opened in addition to file opened with 'Open With' option in Finder"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Re-enable macOS 13 as minimum deployment target"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Language support for Italian"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.10",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Quick Look extension"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Added Send-a-smile menu to let users quickly star the repo or add a review in the App Store"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "App crashes when all windows are closed and then the app gets terminated"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Cleanup logging"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.9",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Finder integration via context menu"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Language support for German, French, Simplified Chinese"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.8",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "gzip, bzip2, xz, cab, iso, sit & sea (StuffIt), Z, cpio support"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Show packed size, size, modified date, permissions in columns"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.7",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "lzh, lha, lzx support"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Close internal previewer using Space, or Esc"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Show archive name in title"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Extract selected files via UI"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Extract full archive"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "App Store version shows \"MacPacker store\" as product name in Launchpad"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "New architecture for archive handlers"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.6",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Hit space to open internal preview"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Setting to change the breadcrumb position"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "rar read support"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Show folder / file icons in table"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Add support for macOS 14"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.5",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Multiple windows support"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Open info for archive"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Breadcrumb view for navigation"
+            }
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Open With in Finder not working"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Major code cleanup"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.4",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Viewer to show preview of files"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "7zip read support"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Clean cache when MacPacker terminates"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.3",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Highlight when dragging file to MacPacker window"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Double click any file to extract and open it using the default editor"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Breadcrumb showing the current path in the archive (incl. nested support)"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Support for any valid zip-based file"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Automatic cache cleaning & zip creation support"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Prepare the core for creating/editing archives"
+            }
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Unit tests"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.2",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Welcome & about dialog"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Auto update"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "zip support"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "\"Open With...\" context menu support"
+            }
+          }
+        ]
+      },
+      {
+        "version": "0.1",
+        "items": [
+          {
+            "type": "feat",
+            "title": {
+              "en": "Drag & drop an lz4 or tar file to MacPacker"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Manual option to clear the cache"
+            }
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Traverse through nested archives"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #127

Moves MacPacker off the `workflows-macos` v0.3.47 old model onto the **v0.4.5 product-file model**.

- **`Config/products/macpacker.json`** (new) — identity (`MacPacker` / `MacPacker Store`, `com.sarensx.MacPacker` + Finder/QuickLook extension ids), channel toggles, and the inline `changelog` migrated **verbatim** from `Config/Changelog.json` (22 versions, all locales). Empty `id` → primary → **bare `v*` tags**, unchanged.
- **Shells are now trigger-only**, pinned `@v0.4.5`. `scheme-name` / `has-finder-extension` / `has-quicklook-extension` are gone (now product-file fields).
- **Release tag filter** fixed to `['v*','*-v*','!*-beta.*','!*-alpha.*']`.
- **Explicit secrets map kept** — `sarensw` and `LeanBytes` are different accounts, so `secrets: inherit` would forward nothing. Beta gains `JIRA_API_TOKEN` (the v0.4.5 beta orchestrator declares it for the run-tests failure gate); release stays at 20 (it declares no such input — passing an undeclared secret is a hard error).
- **Stays on GitHub-hosted runners** — public repo; a self-hosted PR build would let fork PRs execute code on that machine.
- `attach-release-assets` left at its default (`true`).

`Config/Changelog.json` is **kept** — the app reads it via `WelcomeChangelogView`.

⚠️ **Before merging:** the first push to `main` will cut a beta at **`v0.17.0-beta.1`** (changelog `versions[0]` = 0.17.0, while the shipped appcast is at 0.14.1). Trim `versions[0]` first if that isn't intended.