### PR TITLE
fix: sort archive list by name on first launch so folders stay on top

### DIFF
--- a/Config/Changelog.json
+++ b/Config/Changelog.json
@@ -16,6 +16,30 @@
     },
     "versions": [
         {
+            "version": "0.18.0",
+            "items": [
+                {
+                    "type": "fix",
+                    "title": {
+                        "en": "Folders now stay on top by default when opening an archive",
+                        "zh-Hans": "打开压缩包时，文件夹现在默认显示在顶部",
+                        "fr": "Les dossiers restent désormais en haut par défaut à l’ouverture d’une archive",
+                        "de": "Ordner bleiben beim Öffnen eines Archivs jetzt standardmäßig oben",
+                        "it": "Le cartelle ora restano in cima per impostazione predefinita all’apertura di un archivio",
+                        "ja": "アーカイブを開いたとき、フォルダがデフォルトで先頭に表示されるようになりました",
+                        "fa": "هنگام باز کردن یک آرشیو، پوشه‌ها اکنون به‌طور پیش‌فرض در بالا می‌مانند",
+                        "pl": "Foldery są teraz domyślnie wyświetlane na górze po otwarciu archiwum",
+                        "pt-BR": "As pastas agora aparecem no topo por padrão ao abrir um arquivo",
+                        "ru": "Папки теперь по умолчанию отображаются сверху при открытии архива",
+                        "uk": "Теки тепер за замовчуванням відображаються зверху під час відкриття архіву",
+                        "es-MX": "Las carpetas ahora aparecen arriba de forma predeterminada al abrir un archivo",
+                        "ko": "이제 아카이브를 열 때 폴더가 기본적으로 맨 위에 표시됩니다"
+                    },
+                    "issues": ["126"]
+                }
+            ]
+        },
+        {
             "version": "0.17.0",
             "items": [
                 {

--- a/MacPacker/MacPackerApp.swift
+++ b/MacPacker/MacPackerApp.swift
@@ -25,6 +25,7 @@ struct MacPackerApp: App {
     
     init() {
         tb.start()
+        Keys.registerDefaults()
         log.notice("MacPackerApp.init — app process starting")
         
         #if DEBUG

--- a/Modules/Sources/Core/AppStorageKeys.swift
+++ b/Modules/Sources/Core/AppStorageKeys.swift
@@ -5,6 +5,8 @@
 //  Created by Stephan Arenswald on 16.09.25.
 //
 
+import Foundation
+
 public enum Keys {
     // general settings
     public static let settingBreadcrumbPosition = "settingBreadcrumbPosition"
@@ -18,4 +20,13 @@ public enum Keys {
     
     public static let defaultOrderColumn = "defaultOrderColum"
     public static let defaultOrderColumnAscending = "defaultOrderColumnAscending"
+
+    // register defaults upon app start so that the archive table has a default it
+    // can use when showing the table for the first time
+    public static func registerDefaults() {
+        UserDefaults.standard.register(defaults: [
+            defaultOrderColumn: ArchiveSortOrder.name.rawValue,
+            defaultOrderColumnAscending: true,
+        ])
+    }
 }

--- a/Modules/Tests/CoreTests/ArchiveStateTests.swift
+++ b/Modules/Tests/CoreTests/ArchiveStateTests.swift
@@ -162,6 +162,32 @@ extension AllCoreTests {
             #expect(items[1].type == .file)
         }
 
+        @Test func loadChildrenDefaultsToNameSortOnFirstLaunch() async throws {
+            // Regression for #126: simulate a first launch where no header click has
+            // ever persisted a sort — only the registration-domain defaults seeded at
+            // startup. The list must already be name-ascending with folders on top,
+            // matching the header arrow, instead of falling back to insertion order.
+            UserDefaults.standard.removeObject(forKey: Keys.defaultOrderColumn)
+            UserDefaults.standard.removeObject(forKey: Keys.defaultOrderColumnAscending)
+            Keys.registerDefaults()
+
+            let state = ArchiveState(catalog: ArchiveTypeCatalog(), engineSelector: ArchiveEngineSelector7zip())
+            let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let url = folderURL.appendingPathComponent("defaultArchive.zip")
+
+            state.open(url: url)
+            try await state.openTask?.value
+
+            state.loadChildren()
+
+            let items = state.childItems!
+            #expect(items.count == 2)
+            #expect(items[0].type == .directory)
+            #expect(items[0].name == "folder")
+            #expect(items[1].type == .file)
+            #expect(items[1].name == "hello world.txt")
+        }
+
         @Test func directoriesBeforeFilesInSortedOrder() async throws {
             let state = ArchiveState(catalog: ArchiveTypeCatalog(), engineSelector: ArchiveEngineSelector7zip())
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!


### PR DESCRIPTION
## What

On first launch — before any column-header click had persisted a sort — the archive list showed the Name-column sort arrow but was actually in archive **insertion order**, with folders not on top. It only corrected itself after the user clicked the Name header once (then persisted across restarts).

## Root cause

`ArchiveState.loadChildren()` reads the sort column from raw `UserDefaults`, which is `nil` until a header click writes it. The default (`.name`, ascending) lived only as an `@AppStorage` default in `ArchiveTableViewRepresentable` — that drives the header arrow but is never written to `UserDefaults`. So the data reader (nil → insertion order) and the arrow (name asc) disagreed.

## Fix

Seed `UserDefaults` registration-domain defaults at app startup via new `Keys.registerDefaults()` (name, ascending). Every reader — the raw reads in `loadChildren()` and the `@AppStorage` arrow — now agrees on first launch, so folders stay on top and the arrow tells the truth. First header click still writes an explicit value and persists as before.

Left untouched on purpose: the existing `"defaultOrderColum"` key-string typo (both readers share the constant; renaming would silently reset users' saved sort).

## Test

- New regression test `loadChildrenDefaultsToNameSortOnFirstLaunch` — no persisted key, only the registered default → asserts folders-on-top name-ascending.
- `swift test --filter loadChildren` → 8/8 pass.
- Manual: wipe `defaults delete com.sarensx.MacPacker`, launch, open a mixed folder/file archive stored non-alphabetically → sorted by name, folders on top, no click needed.

Closes #126