### PR TITLE
Update 7zip to 26.02

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -55,6 +55,27 @@
             "issues": [
               "142"
             ]
+          },
+          {
+            "type": "feat",
+            "title": {
+              "en": "Show archive engine versions in Settings",
+              "zh-Hans": "在设置中显示压缩引擎版本",
+              "fr": "Afficher les versions des moteurs d'archive dans les Réglages",
+              "de": "Versionen der Archiv-Engines in den Einstellungen anzeigen",
+              "it": "Mostra le versioni dei motori di archivio nelle Impostazioni",
+              "ja": "設定でアーカイブエンジンのバージョンを表示",
+              "fa": "نمایش نسخه موتورهای بایگانی در تنظیمات",
+              "pl": "Wyświetlanie wersji silników archiwów w Ustawieniach",
+              "pt-BR": "Exibir as versões dos motores de arquivo nas Configurações",
+              "ru": "Отображение версий архивных движков в настройках",
+              "uk": "Відображення версій архівних рушіїв у налаштуваннях",
+              "es-MX": "Mostrar las versiones de los motores de archivo en Configuración",
+              "ko": "설정에서 아카이브 엔진 버전 표시"
+            },
+            "issues": [
+              "142"
+            ]
           }
         ]
       },

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -33,6 +33,32 @@
     },
     "versions": [
       {
+        "version": "0.18.1",
+        "items": [
+          {
+            "type": "core",
+            "title": {
+              "en": "Update 7-Zip to v26.02",
+              "zh-Hans": "更新 7-Zip 至 v26.02",
+              "fr": "Mise à jour de 7-Zip vers la version 26.02",
+              "de": "7-Zip auf Version 26.02 aktualisiert",
+              "it": "Aggiornamento di 7-Zip alla versione 26.02",
+              "ja": "7-Zip を v26.02 に更新",
+              "fa": "به‌روزرسانی 7-Zip به نسخه 26.02",
+              "pl": "Aktualizacja 7-Zip do wersji 26.02",
+              "pt-BR": "Atualização do 7-Zip para a versão 26.02",
+              "ru": "Обновление 7-Zip до версии 26.02",
+              "uk": "Оновлення 7-Zip до версії 26.02",
+              "es-MX": "Actualización de 7-Zip a la versión 26.02",
+              "ko": "7-Zip을 v26.02로 업데이트"
+            },
+            "issues": [
+              "142"
+            ]
+          }
+        ]
+      },
+      {
         "version": "0.18.0",
         "items": [
           {

--- a/MacPacker/Features/Settings/FormatSettingsView.swift
+++ b/MacPacker/Features/Settings/FormatSettingsView.swift
@@ -137,9 +137,24 @@ struct FormatSettingsView: View {
                 }
                 .buttonStyle(.borderless)
                 .popover(isPresented: $showEngineInfo) {
-                    Text("MacPacker includes several archive engines. The default is recommended; alternative engines can help with format-specific problems. Keep in mind that engine support varies by format.", comment: "Help text to let users understand what the engine selection for each archive format is about")
-                        .frame(width: 160)
-                        .padding()
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("MacPacker includes several archive engines. The default is recommended; alternative engines can help with format-specific problems. Keep in mind that engine support varies by format.", comment: "Help text to let users understand what the engine selection for each archive format is about")
+
+                        Divider()
+
+                        Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 2) {
+                            ForEach(ArchiveEngineType.allCases) { engine in
+                                GridRow {
+                                    Text(engine.rawValue)
+                                    Text(engine.libraryVersion)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .font(.footnote)
+                    }
+                    .frame(width: 260)
+                    .padding()
                 }
             }
         }

--- a/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
+++ b/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
@@ -98,7 +98,8 @@ bool sz_is_tree(SZArchiveRef archive);
 
 // --- Utilities ---
 
-/// Statically allocated version string -- do not free.
+/// Version of the vendored 7-Zip sources, e.g. "26.02".
+/// Statically allocated -- do not free.
 const char* sz_version(void);
 
 // --- Archive Creation/Update ---

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -33,6 +33,7 @@
 
 #include "7zip/Archive/IArchive.h"
 #include "7zip/IPassword.h"
+#include "7zip/MyVersion.h"   // MY_VERSION -- tracks the vendored submodule
 
 static const GUID IID_IInArchive_Local = {
   0x23170F69, 0x40C1, 0x278A,
@@ -857,7 +858,7 @@ bool sz_is_tree(SZArchiveRef archive) {
 }
 
 const char* sz_version(void) {
-    return "Swift7zip bridge";
+    return MY_VERSION;
 }
 
 } // extern "C"

--- a/Modules/Sources/Core/Engine/ArchiveEngineSelector.swift
+++ b/Modules/Sources/Core/Engine/ArchiveEngineSelector.swift
@@ -6,11 +6,13 @@
 //
 
 import Foundation
+import Swift7zip
+import XADMaster
 import tb
 
 private let log = tb.Logger(subsystem: "app.MacPacker", category: "engine")
 
-public enum ArchiveEngineType: String, Identifiable, Sendable, Codable {
+public enum ArchiveEngineType: String, CaseIterable, Identifiable, Sendable, Codable {
     case xad = "XAD (The Unarchiver)"
     case `7zip` = "7-Zip"
     case swc = "SWCompression"
@@ -34,6 +36,30 @@ extension ArchiveEngineType {
         case .xad:  "xad"
         case .`7zip`: "7zip"
         case .swc:  "swc"
+        }
+    }
+
+    /// Version of the underlying library, for display in the engine info popover.
+    ///
+    /// All three values are kept honest by `EngineVersionTests`.
+    public var libraryVersion: String {
+        switch self {
+        case .`7zip`:
+            // Compiled in from the vendored 7-Zip sources.
+            SevenZipArchive.libraryVersion
+        case .xad:
+            // CFBundleVersion of the embedded XADMaster.framework. Note this is
+            // upstream XADMaster's version -- it does not move when the fork's
+            // branch revision does. XADMasterVersionString from XADMaster.h is
+            // declared but never defined in the shipped binary, so it can't be used.
+            Bundle(for: XADArchive.self).infoDictionary?["CFBundleVersion"] as? String ?? "—"
+        case .swc:
+            // ponytail: hardcoded. SWCompression exposes no version at runtime --
+            // its _SWC_VERSION is internal and lives in the `swcomp` executable
+            // target, which the library target excludes. EngineVersionTests fails
+            // if this drifts from the pin in the workspace Package.resolved; bump
+            // it there and here together.
+            "4.9.1"
         }
     }
 }

--- a/Modules/Sources/Swift7zip/SevenZipArchive.swift
+++ b/Modules/Sources/Swift7zip/SevenZipArchive.swift
@@ -36,7 +36,10 @@ public class SevenZipArchive {
 
     // MARK: - Inspection
 
-    /// Version string of the embedded 7-zip bridge.
+    /// Version of the embedded 7-Zip library, e.g. `26.02`.
+    ///
+    /// Read from the vendored sources at compile time, so it follows the
+    /// `Sources/CSevenZip/vendor/7zip` submodule automatically.
     public static var libraryVersion: String {
         String(cString: sz_version())
     }

--- a/Modules/Tests/CoreTests/EngineVersionTests.swift
+++ b/Modules/Tests/CoreTests/EngineVersionTests.swift
@@ -1,0 +1,75 @@
+//
+//  EngineVersionTests.swift
+//  Modules
+//
+//  Created by Stephan Arenswald on 27.07.26.
+//
+//  Guard rails for the engine versions shown in the "Info on Engines" popover.
+//  7-Zip and XAD report their own version at runtime -- these tests catch those
+//  lookups silently breaking. SWCompression reports nothing, so its value is
+//  hardcoded and checked here against the pin it claims to mirror.
+//
+
+import Foundation
+import Testing
+@testable import Core
+
+extension AllCoreTests {
+    struct EngineVersionTests {
+
+        /// Repo root, derived from this file's location at compile time.
+        /// `Bundle.module` is no help -- none of these files are test resources.
+        private static var repoRoot: URL {
+            URL(fileURLWithPath: #filePath)          // Modules/Tests/CoreTests/EngineVersionTests.swift
+                .deletingLastPathComponent()         // Modules/Tests/CoreTests
+                .deletingLastPathComponent()         // Modules/Tests
+                .deletingLastPathComponent()         // Modules
+                .deletingLastPathComponent()         // <repo>
+        }
+
+        @Test("7-Zip version comes from the vendored submodule")
+        func sevenZipVersionMatchesVendoredSource() throws {
+            let header = Self.repoRoot
+                .appending(path: "Modules/Sources/CSevenZip/vendor/7zip/C/7zVersion.h")
+            let source = try String(contentsOf: header, encoding: .utf8)
+
+            let match = try #require(
+                source.firstMatch(of: /#define\s+MY_VERSION_NUMBERS\s+"([^"]+)"/),
+                "MY_VERSION_NUMBERS not found in \(header.path)"
+            )
+
+            #expect(ArchiveEngineType.`7zip`.libraryVersion == String(match.1))
+        }
+
+        @Test("XAD version resolves from the embedded framework bundle")
+        func xadVersionResolvesFromFrameworkBundle() {
+            // "—" is the fallback when the Info.plist lookup fails.
+            #expect(ArchiveEngineType.xad.libraryVersion != "—")
+        }
+
+        @Test("SWCompression version matches the resolved package pin")
+        func swcVersionMatchesResolvedPin() throws {
+            // The app builds against the workspace Package.resolved, not Modules/.
+            let resolved = Self.repoRoot
+                .appending(path: "MacPacker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved")
+            let data = try Data(contentsOf: resolved)
+
+            struct Resolved: Decodable {
+                struct Pin: Decodable {
+                    struct State: Decodable { let version: String? }
+                    let identity: String
+                    let state: State
+                }
+                let pins: [Pin]
+            }
+
+            let pin = try #require(
+                try JSONDecoder().decode(Resolved.self, from: data)
+                    .pins.first { $0.identity == "swcompression" },
+                "no swcompression pin in \(resolved.path)"
+            )
+
+            #expect(ArchiveEngineType.swc.libraryVersion == pin.state.version)
+        }
+    }
+}


### PR DESCRIPTION
resolves #142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced “Info on Engines” in Settings to show each archive engine’s name alongside its library version in a clearer two-column layout.

* **Bug Fixes**
  * Improved engine version reporting to reflect the actual bundled library versions (including 7-Zip 26.02).

* **Documentation**
  * Updated the 0.18.1 changelog entry to note the 7-Zip update and related feature.

* **Tests**
  * Added automated checks to confirm the UI-reported engine versions for 7-Zip, XAD, and SWCompression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->