### PR TITLE
fix: show folders that the archive has no directory entry for

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -76,6 +76,27 @@
             "issues": [
               "142"
             ]
+          },
+          {
+            "type": "fix",
+            "title": {
+              "en": "Archives that don't store folder entries no longer appear empty",
+              "zh-Hans": "不存储文件夹条目的压缩包不再显示为空",
+              "fr": "Les archives qui n'enregistrent pas d'entrées de dossier n'apparaissent plus vides",
+              "de": "Archive ohne gespeicherte Ordnereinträge erscheinen nicht mehr leer",
+              "it": "Gli archivi che non memorizzano voci di cartella non appaiono più vuoti",
+              "ja": "フォルダのエントリを保存していないアーカイブが空と表示されなくなりました",
+              "fa": "آرشیوهایی که ورودی پوشه ذخیره نمی‌کنند دیگر خالی نمایش داده نمی‌شوند",
+              "pl": "Archiwa, które nie przechowują wpisów folderów, nie są już wyświetlane jako puste",
+              "pt-BR": "Arquivos compactados que não armazenam entradas de pasta não aparecem mais vazios",
+              "ru": "Архивы, не хранящие записи папок, больше не отображаются пустыми",
+              "uk": "Архіви, які не зберігають записи папок, більше не відображаються порожніми",
+              "es-MX": "Los archivos comprimidos que no almacenan entradas de carpeta ya no aparecen vacíos",
+              "ko": "폴더 항목을 저장하지 않는 아카이브가 더 이상 비어 있는 것으로 표시되지 않습니다"
+            },
+            "issues": [
+              "144"
+            ]
           }
         ]
       },

--- a/MacPacker/Features/ArchiveContentViewer/ArchiveTableViewRepresentable.swift
+++ b/MacPacker/Features/ArchiveContentViewer/ArchiveTableViewRepresentable.swift
@@ -155,7 +155,7 @@ struct ArchiveTableViewRepresentable: NSViewRepresentable {
                         image = cached
                     } else {
                         let computed: NSImage
-                        if item.type == .directory {
+                        if item.isFolder {
                             computed = NSWorkspace.shared.icon(for: .folder)
                         } else {
                             computed = NSWorkspace.shared.icon(forFileType: item.ext)

--- a/Modules/Sources/ArchivePreviewUI/ArchiveViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchiveViewController.swift
@@ -145,7 +145,7 @@ extension ArchiveViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
             iconView.setContentCompressionResistancePriority(.required, for: .horizontal)
 
             let icon: NSImage? = {
-                if archiveItem.type == .directory {
+                if archiveItem.isFolder {
                     return SystemHelper.shared.getNSImageForFolder()
                 } else {
                     return SystemHelper.shared.getNSImageByExtension(fileName: archiveItem.name)

--- a/Modules/Sources/Core/ArchiveLoader.swift
+++ b/Modules/Sources/Core/ArchiveLoader.swift
@@ -23,6 +23,10 @@ struct ArchiveLoaderLoadResult: Sendable {
 
 struct ArchiveLoaderBuildTreeResult {
     let error: String?
+    /// The entries *after* the tree was built — including the directories
+    /// `buildTree` had to synthesize. `ArchiveLoaderLoadResult.entries` is a
+    /// snapshot taken before that and does not contain them.
+    let entries: [UUID: ArchiveItem]
 }
 
 final actor ArchiveLoader {
@@ -319,6 +323,6 @@ final actor ArchiveLoader {
             i += 1
         }
 
-        return ArchiveLoaderBuildTreeResult(error: nil)
+        return ArchiveLoaderBuildTreeResult(error: nil, entries: entries)
     }
 }

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -242,8 +242,8 @@ extension ArchiveState {
             childItems = children.sorted { a, b in
                 switch defaultOrderColumn {
                 case ArchiveSortOrder.name.rawValue:
-                    if a.type != b.type {
-                        return a.type == .directory
+                    if a.isFolder != b.isFolder {
+                        return a.isFolder
                     }
 
                     let cmp = a.name.localizedStandardCompare(b.name)
@@ -699,14 +699,19 @@ extension ArchiveState {
                 
                 try Task.checkCancellation()
                 
+                // buildTree synthesizes the directories the archive has no entry
+                // for, so its result carries the entries — loaderResult.entries
+                // is a snapshot from before and misses them.
+                var loadedEntries = loaderResult.entries
                 if !loaderResult.hasTree {
                     let builderResult = await archiveLoader.buildTree(at: loaderResult.root)
                     self.error = builderResult.error
+                    loadedEntries = builderResult.entries
                     if let treeError = builderResult.error {
                         log.error("Tree build failed", context: ["file": url.lastPathComponent, "error": treeError])
                     }
                 }
-                self.entries.merge(loaderResult.entries, uniquingKeysWith: { lhs, _ in lhs })
+                self.entries.merge(loadedEntries, uniquingKeysWith: { lhs, _ in lhs })
                 self.entries[loaderResult.root.id] = root
 
                 loadChildren()
@@ -943,11 +948,13 @@ extension ArchiveState {
                 
                 updateStatusText("building tree...")
                 
+                var loadedEntries = loaderResult.entries
                 if !loaderResult.hasTree {
                     let builderResult = await archiveLoader.buildTree(at: archiveItem)
                     self.error = builderResult.error
+                    loadedEntries = builderResult.entries
                 }
-                self.entries.merge(loaderResult.entries) { (current, _) in current }
+                self.entries.merge(loadedEntries) { (current, _) in current }
                 
                 loadChildren()
                 

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -705,7 +705,8 @@ extension ArchiveState {
                 var loadedEntries = loaderResult.entries
                 if !loaderResult.hasTree {
                     let builderResult = await archiveLoader.buildTree(at: loaderResult.root)
-                    self.error = builderResult.error
+                    // keep a load error — a clean tree build does not undo it
+                    self.error = builderResult.error ?? self.error
                     loadedEntries = builderResult.entries
                     if let treeError = builderResult.error {
                         log.error("Tree build failed", context: ["file": url.lastPathComponent, "error": treeError])
@@ -951,7 +952,8 @@ extension ArchiveState {
                 var loadedEntries = loaderResult.entries
                 if !loaderResult.hasTree {
                     let builderResult = await archiveLoader.buildTree(at: archiveItem)
-                    self.error = builderResult.error
+                    // keep a load error — a clean tree build does not undo it
+                    self.error = builderResult.error ?? self.error
                     loadedEntries = builderResult.entries
                 }
                 self.entries.merge(loadedEntries) { (current, _) in current }

--- a/Modules/Sources/Core/Models/ArchiveItem.swift
+++ b/Modules/Sources/Core/Models/ArchiveItem.swift
@@ -41,6 +41,10 @@ public class ArchiveItem: Identifiable, Hashable, @unchecked Sendable {
     /// we can easily distinguish if a nested archive still needs to be extracted or not.
     public private(set) var children: [UUID]? = nil
     
+    /// A real directory entry, or a folder `ArchiveLoader.buildTree` had to
+    /// synthesize because the archive carries no entry for it.
+    public var isFolder: Bool { type == .directory || type == .virtual }
+
     // The following are only relevant if this is a nested archive
     // that can be opened
     public private(set) var url: URL? = nil

--- a/Modules/Tests/CoreTests/DefaultArchiveTests.swift
+++ b/Modules/Tests/CoreTests/DefaultArchiveTests.swift
@@ -35,13 +35,15 @@ extension AllCoreTests {
         }
         
         @Test("Test all defaultArchives on 7zip", arguments: [
-            // ext, id, folder entries
+            // ext, id, entries (incl. root), root children
             ("7z", "7zip", 5, 2),
-            ("arj", "arj", 4, 2),
+            // arj/cab/lzh store no folder entries — buildTree synthesizes the
+            // folder, so the entry count matches the formats that do store it
+            ("arj", "arj", 5, 2),
             ("ar", "ar", 4, 3), // `ar` archives do not store folders, only folder paths
-            ("cab", "cab", 4, 2),
+            ("cab", "cab", 5, 2),
             ("cpio", "cpio", 5, 2),
-            ("lzh", "lha", 4, 2),
+            ("lzh", "lha", 5, 2),
             ("rar", "rar", 5, 2),
             ("tar", "tar", 5, 2),
             ("xar", "xar", 6, 3), // additional `[TOC].xml`
@@ -91,17 +93,16 @@ extension AllCoreTests {
         }
         
         @Test("Test all defaultArchives on xad", arguments: [
-            ("zip", "zip", true),
-            ("7z", "7zip", true),
-            ("tbz2", "tar", true),
-            ("tar.bz2", "tar", true),
-            ("cab", "cab", false),
-            ("cpio", "cpio", true)
+            ("zip", "zip"),
+            ("7z", "7zip"),
+            ("tbz2", "tar"),
+            ("tar.bz2", "tar"),
+            ("cab", "cab"), // stores no folder entry — buildTree synthesizes it
+            ("cpio", "cpio")
         ])
-        func testAllXadEngine(arg: (String, String, Bool)) async throws {
+        func testAllXadEngine(arg: (String, String)) async throws {
             let ext = arg.0
             let id = arg.1
-            let folderEntries = arg.2
             let state = ArchiveState(catalog: ArchiveTypeCatalog(), engineSelector: ArchiveEngineSelectorXad())
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
             
@@ -111,7 +112,7 @@ extension AllCoreTests {
             try await state.openTask?.value
             
             #expect(state.type?.id == id)
-            #expect(state.entries.count == (folderEntries ? 5 : 4))
+            #expect(state.entries.count == 5)
             #expect(state.root?.children?.count == 2)
             #expect(state.root === state.selectedItem)
         }

--- a/Modules/Tests/CoreTests/ZipTests.swift
+++ b/Modules/Tests/CoreTests/ZipTests.swift
@@ -75,5 +75,42 @@ extension AllCoreTests {
             // level 4
             #expect(FileManager.default.fileExists(atPath: extractedUrl.appendingPathComponent("level2").appendingPathComponent("level3").appendingPathComponent("level4").appendingPathComponent("level4").path))
         }
+
+        /// Zips written without directory entries (`zip -D`, and what several
+        /// download sites serve) only list `folder/file.txt`. The folder itself
+        /// is synthesized by `ArchiveLoader.buildTree`, so it must still show up.
+        @Test func zipWithoutDirectoryEntries() async throws {
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ZipTests-\(UUID().uuidString)")
+            let src = dir.appendingPathComponent("folder")
+            try FileManager.default.createDirectory(at: src, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: dir) }
+            try "hello".write(to: src.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+            // -D: no directory entries, so the archive holds a single entry
+            // "folder/file.txt" and nothing else.
+            let zip = dir.appendingPathComponent("noDirEntries.zip")
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+            p.arguments = ["-D", "-r", zip.path, "folder"]
+            p.currentDirectoryURL = dir
+            p.standardOutput = FileHandle.nullDevice
+            p.standardError = FileHandle.nullDevice
+            try p.run()
+            p.waitUntilExit()
+            #expect(p.terminationStatus == 0)
+
+            let state = ArchiveState(catalog: ArchiveTypeCatalog(), engineSelector: ArchiveEngineSelector7zip())
+            state.open(url: zip)
+            try await state.openTask?.value
+
+            #expect(state.childItems?.count == 1)
+            let folder = try #require(state.childItems?.first)
+            #expect(folder.name == "folder")
+            #expect(folder.isFolder)
+
+            try await state.openAsync(item: folder)
+            #expect(state.childItems?.map(\.name) == ["file.txt"])
+        }
     }
 }


### PR DESCRIPTION
Fixes #144

## Problem

A zip whose entire central directory is one entry — `WEB-DL/Dollars.1971.1080p.WEBRip.srt`, no `WEB-DL/` entry — opened without an error but showed an empty file list. Extract-all still worked.

Not a 7zip engine bug: 7-Zip lists exactly what the central directory holds. The archive simply carries no entry for the folder, which `zip -D` and several download sites produce, and arj/cab/lzh never store at all.

## Cause

`ArchiveLoader.buildTree` synthesizes the missing folder, but it runs *after* `loadEntries` already handed back its `entries` snapshot. The synthesized item was registered in the loader's dictionary only. `ArchiveState` merged the stale snapshot, so `loadChildren` could not resolve the UUID out of `root.children` and `compactMap` dropped it.

Any archive whose root level contains only synthesized folders showed empty — through the XAD engine and the QuickLook preview too, since both take the same path.

## Changes

- `ArchiveLoaderBuildTreeResult` carries the post-build `entries`; `ArchiveState.open` and `ArchiveState.unfold` merge those instead of the snapshot.
- `ArchiveItem.isFolder` (`.directory || .virtual`), used at the three `type == .directory` checks that would otherwise render a synthesized folder as a file: sort order, app icon, QuickLook icon.

## Tests

- `ZipTests.zipWithoutDirectoryEntries` — fixture built at test time with `zip -D`, no new checked-in archive. Red before the fix (`childItems` empty), green after.
- `DefaultArchiveTests`: arj/cab/lzh expected 4 entries, which encoded the dropped folder — now 5, matching the formats that do store one. The xad `folderEntries` flag no longer distinguishes anything and is gone.
- 324/324 pass.

Verified in the app against the reported archive: `WEB-DL` lists with a folder icon and opens to the `.srt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archives now consistently treat virtual and synthesized directories as folders for navigation and display.
* **Bug Fixes**
  * Folder grouping and folder icons are now based on folder status rather than raw type checks.
  * Archives that omit explicit directory entries no longer appear empty; rebuilt tree nodes and errors are preserved correctly.
* **Tests**
  * Added a test for ZIP archives created without directory entries.
  * Updated parsing expectations for affected 7zip/XAD engine cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->