### PR TITLE
fix: Makes previously hard-coded strings available for localization

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -34,6 +34,33 @@
     },
     "versions": [
       {
+        "version": "0.20.0",
+        "items": [
+          {
+            "type": "core",
+            "title": {
+              "en": "Made previously hard-coded strings available for localization",
+              "zh-Hans": "使之前硬编码的字符串可进行本地化",
+              "fr": "Rendu les chaînes auparavant codées en dur disponibles pour la localisation",
+              "de": "Zuvor fest codierte Texte für die Lokalisierung verfügbar gemacht",
+              "it": "Rese disponibili per la localizzazione le stringhe precedentemente codificate",
+              "ja": "以前ハードコードされていた文字列をローカライズ可能に変更",
+              "fa": "رشته‌های قبلاً کدنویسی‌شده برای بومی‌سازی در دسترس قرار گرفتند",
+              "pl": "Udostępniono do lokalizacji wcześniej zakodowane na stałe ciągi tekstowe",
+              "pt-BR": "Strings anteriormente codificadas diretamente agora podem ser localizadas",
+              "ru": "Ранее жёстко заданные строки стали доступны для локализации",
+              "uk": "Раніше жорстко задані рядки стали доступними для локалізації",
+              "es-MX": "Las cadenas anteriormente codificadas de forma fija ahora están disponibles para localización",
+              "ko": "이전에 하드코딩된 문자열을 현지화할 수 있도록 변경",
+              "nl": "Voorheen hardgecodeerde teksten beschikbaar gemaakt voor lokalisatie"
+            },
+            "issues": [
+              "161"
+            ]
+          }
+        ]
+      },
+      {
         "version": "0.19.0",
         "items": [
           {

--- a/MacPacker/Features/ArchiveContentViewer/ArchiveContentToolbarView.swift
+++ b/MacPacker/Features/ArchiveContentViewer/ArchiveContentToolbarView.swift
@@ -179,7 +179,7 @@ struct ArchiveContentToolbarView: ToolbarContent {
                     openURL(URL(string: "https://poeditor.com/join/project/J2Qq2SUzYr")!)
                 } label: {
                     Label {
-                        Text(verbatim: "Help with translation")
+                        Text("Help with translation", comment: "Menu item that opens the translation contribution page")
                     } icon: {
                         Image(systemName: "flag")
                     }
@@ -240,7 +240,7 @@ struct ArchiveContentToolbarView: ToolbarContent {
                             Image(nsImage: .menuIcon(named: "AppIcon_FlowMoose", pointSize: 16))
                         }
                         .labelStyle(.titleAndIcon)
-                        Text(verbatim: "Voice-2-Text working everywhere")
+                        Text("Voice-2-Text working everywhere", comment: "Short description of the FlowMoose app")
                     }
                     
                     Button {
@@ -252,7 +252,7 @@ struct ArchiveContentToolbarView: ToolbarContent {
                             Image(nsImage: .menuIcon(named: "AppIcon_FileFillet", pointSize: 16))
                         }
                         .labelStyle(.titleAndIcon)
-                        Text(verbatim: "Organize files. Fast.")
+                        Text("Organize files. Fast.", comment: "Short description of the FileFillet app")
                     }
                 } label: {
                     Label {

--- a/MacPacker/Features/PasswordWindow/PasswordView.swift
+++ b/MacPacker/Features/PasswordWindow/PasswordView.swift
@@ -24,19 +24,19 @@ struct PasswordView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             if let name = request?.url.lastPathComponent {
-                Text(verbatim: "“\(name)” is password protected.")
+                Text("“\(name)” is password protected.", comment: "Explains that the named archive requires a password")
                     .font(.callout)
             }
 
             HStack(spacing: 4) {
-                Text(verbatim: "Password:")
+                Text("Password:", comment: "Label for the password field")
                 PasswordFieldView(password: $password)
                     .onSubmit { onSubmit?(password) }
             }
 
             if isRetry {
                 Label {
-                    Text(verbatim: "That password is incorrect. Try again.")
+                    Text("That password is incorrect. Try again.", comment: "Shown after an incorrect password is entered")
                 } icon: {
                     Image(systemName: "exclamationmark.triangle.fill")
                 }
@@ -50,13 +50,13 @@ struct PasswordView: View {
                 Button {
                     onCancel?()
                 } label: {
-                    Text(verbatim: "Cancel")
+                    Text("Cancel", comment: "Cancels password entry")
                 }
 
                 Button {
                     onSubmit?(password)
                 } label: {
-                    Text(verbatim: "OK")
+                    Text("OK", comment: "Submits the entered password")
                 }
                 .buttonStyle(.borderedProminent)
             }

--- a/MacPacker/Features/Settings/AboutSettingsView.swift
+++ b/MacPacker/Features/Settings/AboutSettingsView.swift
@@ -125,7 +125,7 @@ struct AboutSettingsView: View {
                 Button {
                     openURL(Constants.privacyURL)
                 } label: {
-                    Text("Privacy Policy", comment: "Button that opens the privacy policy")
+                    Text("Privacy", comment: "Button that opens the privacy policy")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -135,7 +135,17 @@ struct AboutSettingsView: View {
                 Button {
                     openURL(Constants.termsURL)
                 } label: {
-                    Text("Terms of Service", comment: "Button that opens the terms of service")
+                    Text("Terms", comment: "Button that opens the terms of service")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 8)
+                
+                Button {
+                    openURL(Constants.imprintURL)
+                } label: {
+                    Text("Imprint", comment: "Button that opens the imprint")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }

--- a/MacPacker/Features/Settings/AboutSettingsView.swift
+++ b/MacPacker/Features/Settings/AboutSettingsView.swift
@@ -125,7 +125,7 @@ struct AboutSettingsView: View {
                 Button {
                     openURL(Constants.privacyURL)
                 } label: {
-                    Text(verbatim: "Privacy Policy")
+                    Text("Privacy Policy", comment: "Button that opens the privacy policy")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -135,7 +135,7 @@ struct AboutSettingsView: View {
                 Button {
                     openURL(Constants.termsURL)
                 } label: {
-                    Text(verbatim: "Terms of Service")
+                    Text("Terms of Service", comment: "Button that opens the terms of service")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }

--- a/MacPacker/Features/Settings/GeneralSettingsView.swift
+++ b/MacPacker/Features/Settings/GeneralSettingsView.swift
@@ -51,7 +51,7 @@ struct GeneralSettingsView: View {
                 HStack {
                     Picker(String(""), selection: $breadcrumbPosition) {
                         ForEach(BreadcrumbPosition.allCases, id: \.self) { position in
-                            Text(position.rawValue)
+                            breadcrumbPositionLabel(position)
                                 .tag(position)
                         }
                     }
@@ -71,6 +71,18 @@ struct GeneralSettingsView: View {
             }
         }
         .padding()
+    }
+    
+    @ViewBuilder
+    private func breadcrumbPositionLabel(_ position: BreadcrumbPosition) -> some View {
+        switch position {
+        case .top:
+            Text("Top", comment: "Breadcrumb position at the top of the archive window")
+        case .bottom:
+            Text("Bottom", comment: "Breadcrumb position at the bottom of the archive window")
+        case .none:
+            Text("None", comment: "Hide the breadcrumb in the archive window")
+        }
     }
 }
 

--- a/MacPacker/Features/Settings/GeneralSettingsView.swift
+++ b/MacPacker/Features/Settings/GeneralSettingsView.swift
@@ -73,6 +73,7 @@ struct GeneralSettingsView: View {
         .padding()
     }
     
+    /// Returns the localized label for a breadcrumb position in the settings picker.
     @ViewBuilder
     private func breadcrumbPositionLabel(_ position: BreadcrumbPosition) -> some View {
         switch position {

--- a/MacPacker/Features/Welcome/WelcomeFooterView.swift
+++ b/MacPacker/Features/Welcome/WelcomeFooterView.swift
@@ -42,7 +42,7 @@ struct WelcomeFooterView: View {
                         openURL(Constants.privacyURL)
                     } label: {
                         HStack(spacing: 2) {
-                            Text(verbatim: "Privacy")
+                            Text("Privacy", comment: "Button that opens the privacy policy")
                         }
                     }
                     .buttonStyle(.plain)
@@ -51,7 +51,7 @@ struct WelcomeFooterView: View {
                         openURL(Constants.termsURL)
                     } label: {
                         HStack(spacing: 2) {
-                            Text(verbatim: "Terms")
+                            Text("Terms", comment: "Button that opens the terms of service")
                         }
                     }
                     .buttonStyle(.plain)
@@ -60,7 +60,7 @@ struct WelcomeFooterView: View {
                         openURL(Constants.imprintURL)
                     } label: {
                         HStack(spacing: 2) {
-                            Text(verbatim: "Imprint")
+                            Text("Imprint", comment: "Button that opens the imprint")
                         }
                     }
                     .buttonStyle(.plain)

--- a/MacPacker/Features/Welcome/WelcomeMoreFromLeanBytesView.swift
+++ b/MacPacker/Features/Welcome/WelcomeMoreFromLeanBytesView.swift
@@ -57,14 +57,14 @@ struct MoreFromLeanBytesProductView: View {
 struct WelcomeMoreFromLeanBytesView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(verbatim: "MacPacker is sponsored by my own work at LeanBytes. Supporting the apps below directly supports this open-source tool.")
+            Text("MacPacker is sponsored by my own work at LeanBytes. Supporting the apps below directly supports this open-source tool.", comment: "Explains that supporting the listed LeanBytes apps supports MacPacker")
                 .foregroundStyle(.secondary)
                 .font(.callout)
                 .fixedSize(horizontal: false, vertical: true)
             
-            MoreFromLeanBytesProductView(logo: "AppIcon_FlowMoose", title: Constants.otherAppFlowMoose, description: "Voice-2-Text to reduce stress on wrists and arms in the age of AI chats. Offline, local only.", openSource: false, url: Constants.otherAppFlowMooseURL)
+            MoreFromLeanBytesProductView(logo: "AppIcon_FlowMoose", title: Constants.otherAppFlowMoose, description: String(localized: "Voice-2-Text to reduce stress on wrists and arms in the age of AI chats. Offline, local only.", comment: "Description of the FlowMoose app"), openSource: false, url: Constants.otherAppFlowMooseURL)
             
-            MoreFromLeanBytesProductView(logo: "AppIcon_FileFillet", title: Constants.otherAppFileFillet, description: "Copy or move files to your favorite folders and their sub-folders. No need to open new Finder windows.", openSource: true, url: Constants.otherAppMacPackerURL)
+            MoreFromLeanBytesProductView(logo: "AppIcon_FileFillet", title: Constants.otherAppFileFillet, description: String(localized: "Copy or move files to your favorite folders and their sub-folders. No need to open new Finder windows.", comment: "Description of the FileFillet app"), openSource: true, url: Constants.otherAppMacPackerURL)
         }
         .padding(.horizontal, 16)
         .padding(.top, 16)

--- a/MacPacker/Features/Welcome/WelcomeView.swift
+++ b/MacPacker/Features/Welcome/WelcomeView.swift
@@ -56,7 +56,7 @@ struct WelcomeView: View {
                         .padding(.top, 22)
                         .padding(.bottom, 22)
                     
-                    Text(verbatim: "❤️ Many thanks to all the PR contributors, translators and sponsors of this project!")
+                    Text("❤️ Many thanks to all the PR contributors, translators and sponsors of this project!", comment: "Thanks shown to contributors, translators, and project sponsors on the welcome screen")
                         .padding(.horizontal, 16)
                     
                     #if !STORE

--- a/MacPacker/Localizable.xcstrings
+++ b/MacPacker/Localizable.xcstrings
@@ -244,6 +244,83 @@
         }
       }
     },
+    "“%@” is password protected." : {
+      "comment" : "Explains that the named archive requires a password",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” ist passwortgeschützt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” is password protected."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” está protegido con contraseña."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "« %@ » est protégé par mot de passe."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” è protetto da password."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」はパスワードで保護されています。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@'은(는) 암호로 보호되어 있습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„%@” jest chroniony hasłem."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” está protegido por senha."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«%@» защищён паролем."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«%@» захищено паролем."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@”受密码保护。"
+          }
+        }
+      }
+    },
     "%@ left" : {
       "comment" : "Time remaining in the extraction row, e.g. '14 sec left'.",
       "localizations" : {
@@ -671,6 +748,23 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "❤️ Many thanks to all the PR contributors, translators and sponsors of this project!" : {
+      "comment" : "Thanks shown to contributors, translators, and project sponsors on the welcome screen",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "❤️ Vielen Dank an alle PR-Mitwirkenden, Übersetzer und Sponsoren dieses Projekts!"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "❤️ Many thanks to all the PR contributors, translators and sponsors of this project!"
           }
         }
       }
@@ -1340,6 +1434,12 @@
             "state" : "translated",
             "value" : "Automatic engine selection"
           }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматический выбор движка"
+          }
         }
       }
     },
@@ -1374,6 +1474,89 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动检查更新"
+          }
+        }
+      }
+    },
+    "Bottom" : {
+      "comment" : "Breadcrumb position at the bottom of the archive window",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bottom"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abajo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En bas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In basso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하단"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onder"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "na dole"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inferior"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Внизу"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "внизу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "底部"
           }
         }
       }
@@ -1539,7 +1722,7 @@
       }
     },
     "Cancel" : {
-      "comment" : "Alert button that keeps the app running so the extraction can finish.\nButton in the save-on-close prompt that keeps the window open",
+      "comment" : "Alert button that keeps the app running so the extraction can finish.\nButton in the save-on-close prompt that keeps the window open\nCancels password entry",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1694,6 +1877,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Clear"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить"
           }
         }
       }
@@ -2215,6 +2404,23 @@
         }
       }
     },
+    "Copy or move files to your favorite folders and their sub-folders. No need to open new Finder windows." : {
+      "comment" : "Description of the FileFillet app",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopiere oder verschiebe Dateien in deine bevorzugten Ordner und deren Unterordner. Ganz ohne zusätzliche Finder-Fenster."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy or move files to your favorite folders and their sub-folders. No need to open new Finder windows."
+          }
+        }
+      }
+    },
     "Could not open archive" : {
       "comment" : "A title for an alert that a user can't open an archive.",
       "isCommentAutoGenerated" : true,
@@ -2229,6 +2435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Could not open archive"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невозможно открыть архив"
           }
         }
       }
@@ -2246,6 +2458,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Create a new archive"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать новый архив"
           }
         }
       }
@@ -3967,6 +4185,23 @@
         }
       }
     },
+    "Help with translation" : {
+      "comment" : "Menu item that opens the translation contribution page",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bei der Übersetzung helfen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Help with translation"
+          }
+        }
+      }
+    },
     "How to set %@ as default?" : {
       "comment" : "A button that shows a popover explaining how to set MacPacker as the default file opener.",
       "localizations" : {
@@ -4028,6 +4263,89 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如何将 %@ 设为默认？"
+          }
+        }
+      }
+    },
+    "Imprint" : {
+      "comment" : "Button that opens the imprint",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impressum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legal Notice"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso legal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mentions légales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note legali"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "法的情報"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "법적 고지"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Juridische informatie"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota prawna"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso legal"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Правовая информация"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Правова інформація"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "法律声明"
           }
         }
       }
@@ -4232,6 +4550,12 @@
             "state" : "translated",
             "value" : "Learn to use %@"
           }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Научитесь пользоваться %@"
+          }
         }
       }
     },
@@ -4409,6 +4733,12 @@
             "state" : "translated",
             "value" : "MacPacker chooses the engine for each archive, and tries another one if the first can't read it. Turn this off to choose engines yourself."
           }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MacPacker выбирает движок для каждого архива и пробует другой, если первый не может его прочитать. Отключите эту функцию, чтобы выбирать движки самостоятельно."
+          }
         }
       }
     },
@@ -4461,6 +4791,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MacPacker 包含数种归档引擎。推荐使用默认引擎；如果你遇到特定格式的问题，可以尝试替代引擎。不过请注意，不同格式对引擎的支持可能有所不同。"
+          }
+        }
+      }
+    },
+    "MacPacker is sponsored by my own work at LeanBytes. Supporting the apps below directly supports this open-source tool." : {
+      "comment" : "Explains that supporting the listed LeanBytes apps supports MacPacker",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MacPacker wird durch meine eigene Arbeit bei LeanBytes finanziert. Wenn du die Apps unten unterstützt, unterstützt du damit direkt dieses Open-Source-Projekt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MacPacker is sponsored by my own work at LeanBytes. Supporting the apps below directly supports this open-source tool."
           }
         }
       }
@@ -4953,6 +5300,95 @@
             "state" : "translated",
             "value" : "No recent archives."
           }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавних архивов нет."
+          }
+        }
+      }
+    },
+    "None" : {
+      "comment" : "Hide the breadcrumb in the archive window",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ohne"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "None"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninguno"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brak"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не призначено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无"
+          }
         }
       }
     },
@@ -5046,8 +5482,7 @@
       }
     },
     "OK" : {
-      "comment" : "The label of a button that dismisses a dialog.",
-      "isCommentAutoGenerated" : true,
+      "comment" : "Submits the entered password",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -5538,6 +5973,23 @@
         }
       }
     },
+    "Organize files. Fast." : {
+      "comment" : "Short description of the FileFillet app",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dateien organisieren. Schnell."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Organize files. Fast."
+          }
+        }
+      }
+    },
     "Packed Size" : {
       "comment" : "Column that shows the packed size of the archive files",
       "localizations" : {
@@ -5616,8 +6068,7 @@
       }
     },
     "Password:" : {
-      "comment" : "A text field for entering a password.",
-      "isCommentAutoGenerated" : true,
+      "comment" : "Label for the password field",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -5843,6 +6294,89 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览"
+          }
+        }
+      }
+    },
+    "Privacy" : {
+      "comment" : "Button that opens the privacy policy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenschutz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confidentialité"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인정보 보호"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prywatność"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidade"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конфиденциальность"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приватність"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐私"
           }
         }
       }
@@ -6273,7 +6807,7 @@
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Заметки к выпуску"
+            "value" : "Примечания к выпуску"
           }
         },
         "uk" : {
@@ -7198,6 +7732,106 @@
         }
       }
     },
+    "Terms" : {
+      "comment" : "Button that opens the terms of service",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutzungsbedingungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terms & Conditions"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Términos y condiciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conditions générales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termini e condizioni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用規約"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이용 약관"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voorwaarden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warunki i zasady"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termos e Condições"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Положения и условия"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Умови та положення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条款与条件"
+          }
+        }
+      }
+    },
+    "That password is incorrect. Try again." : {
+      "comment" : "Shown after an incorrect password is entered",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Passwort ist falsch. Versuche es erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That password is incorrect. Try again."
+          }
+        }
+      }
+    },
     "the archive" : {
       "comment" : "Fallback name in the save-on-close prompt when the archive has no file name yet",
       "localizations" : {
@@ -7217,6 +7851,89 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Архив"
+          }
+        }
+      }
+    },
+    "Top" : {
+      "comment" : "Breadcrumb position at the top of the archive window",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oben"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arriba"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En haut"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In alto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상단"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bovenaan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Na górze"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acima"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сверху"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зверху"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顶部"
           }
         }
       }
@@ -7379,6 +8096,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "访问网站"
+          }
+        }
+      }
+    },
+    "Voice-2-Text to reduce stress on wrists and arms in the age of AI chats. Offline, local only." : {
+      "comment" : "Description of the FlowMoose app",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprache-zu-Text zur Entlastung von Handgelenken und Armen im Zeitalter von KI-Chats. Offline und ausschließlich lokal."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice-2-Text to reduce stress on wrists and arms in the age of AI chats. Offline, local only."
+          }
+        }
+      }
+    },
+    "Voice-2-Text working everywhere" : {
+      "comment" : "Short description of the FlowMoose app",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprache-zu-Text, die überall funktioniert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice-2-Text working everywhere"
           }
         }
       }


### PR DESCRIPTION
- Localized breadcrumb position options: `Top`, `Bottom`, and `None`.
- Localized legal links in About and Welcome screens:
  - Privacy Policy / Privacy
  - Terms of Service / Terms
  - Imprint
- Localized password dialog labels, validation message, and actions.
- Localized remaining static UI text in the toolbar and welcome views.
- Converted descriptions passed dynamically to LeanBytes product cards to use `String(localized:comment:)`.

## Validation

- Reviewed all changed SwiftUI labels to ensure static user-facing text no longer uses `Text(verbatim:)`.
- Build was not run in the current environment because the active developer directory contains Command Line Tools only, not full Xcode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Localization**
  - Added localized text for archive viewer help, password prompts, error messages, and action buttons.
  - Improved translations for privacy policy, terms of service, imprint, and contributor links across settings and welcome screens.
  - Added localized welcome messaging and product descriptions.
  - Improved breadcrumb-position labels for top, bottom, and hidden positions.
  - Expanded translated content across 15 languages with clearer translator context and updated legal notices.
- **Documentation**
  - Added a localized version 0.20.0 changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->