### PR TITLE
Localize the Default App Instructions Alert + About

### DIFF
--- a/MacPacker/Features/Settings/AboutSettingsView.swift
+++ b/MacPacker/Features/Settings/AboutSettingsView.swift
@@ -72,11 +72,11 @@ struct AboutSettingsView: View {
                     Text(verbatim: "© 2023-2026 Stephan Arenswald")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
-                    Text(verbatim: "Licensed under the GNU General Public License v3.0 (GPL-3.0-or-later). This is free software: you can redistribute it and/or modify it under the terms of the GPL.")
+                    Text("Licensed under the GNU General Public License v3.0 (GPL-3.0-or-later). This is free software: you can redistribute it and/or modify it under the terms of the GPL.", comment: "License notice shown in the About settings.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
-                    Text(verbatim: "No warranty. See LICENSE for details.")
+                    Text("No warranty. See LICENSE for details.", comment: "Warranty disclaimer shown in the About settings.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                     

--- a/MacPacker/Features/Settings/FormatSettingsView.swift
+++ b/MacPacker/Features/Settings/FormatSettingsView.swift
@@ -84,8 +84,8 @@ struct FormatSettingsView: View {
     func showInfoToSetAsDefault() {
         let alert = NSAlert()
         alert.icon = NSImage(named: "AppIcon")
-        alert.messageText = "Set MacPacker as the default app"
-        alert.informativeText = "To make MacPacker the default for a file type: Right-click a file → 'Get Info' → choose MacPacker under 'Open with:' → click 'Change All…' to apply it to all similar archives."
+        alert.messageText = String(localized: "Set MacPacker as the default app", comment: "Title of the alert that explains how to set MacPacker as the default app for archive files.")
+        alert.informativeText = String(localized: "To make MacPacker the default for a file type: Right-click a file → 'Get Info' → choose MacPacker under 'Open with:' → click 'Change All…' to apply it to all similar archives.", comment: "Instructions in the alert explaining how to set MacPacker as the default app for archive files in Finder.")
         alert.alertStyle = .informational
         alert.runModal()
     }

--- a/MacPacker/Localizable.xcstrings
+++ b/MacPacker/Localizable.xcstrings
@@ -4642,6 +4642,9 @@
         }
       }
     },
+    "Licensed under the GNU General Public License v3.0 (GPL-3.0-or-later). This is free software: you can redistribute it and/or modify it under the terms of the GPL." : {
+      "comment" : "License notice shown in the About settings."
+    },
     "Logs:" : {
       "comment" : "A label for the log related section in the advanced settings",
       "localizations" : {
@@ -5308,6 +5311,9 @@
           }
         }
       }
+    },
+    "No warranty. See LICENSE for details." : {
+      "comment" : "Warranty disclaimer shown in the About settings."
     },
     "None" : {
       "comment" : "Hide the breadcrumb in the archive window",
@@ -7121,6 +7127,9 @@
         }
       }
     },
+    "Set MacPacker as the default app" : {
+      "comment" : "Title of the alert that explains how to set MacPacker as the default app for archive files."
+    },
     "Settings..." : {
       "comment" : "Used to open the settings/preferences window",
       "localizations" : {
@@ -7854,6 +7863,9 @@
           }
         }
       }
+    },
+    "To make MacPacker the default for a file type: Right-click a file → 'Get Info' → choose MacPacker under 'Open with:' → click 'Change All…' to apply it to all similar archives." : {
+      "comment" : "Instructions in the alert explaining how to set MacPacker as the default app for archive files in Finder."
     },
     "Top" : {
       "comment" : "Breadcrumb position at the top of the archive window",


### PR DESCRIPTION
- Marked the title and instructional text of the “Set MacPacker as the default app” alert as localizable.
- Added contextual comments to help translators understand where and how these strings are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated the default-app setup alert title and instructions to support localized translations.
  * Added translator guidance to clarify the intended meaning of the alert text.
  * Localized the license and warranty notices in About settings.
  * Added translator guidance for the license and warranty text while preserving their existing formatting.
  * Added English localization entries for all four updated messages, ready for translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->