### PR TITLE
fix: strip split-volume suffix when naming the extract-to folder

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -78,6 +78,26 @@
             ]
           },
           {
+            "type": "fix",
+            "title": {
+              "en": "Split and multi-volume archives now extract to a folder named after the archive",
+              "zh-Hans": "分卷和多卷压缩包现在会解压到以压缩包命名的文件夹",
+              "fr": "Les archives fractionnées et multi-volumes s'extraient désormais dans un dossier nommé d'après l'archive",
+              "de": "Aufgeteilte und mehrteilige Archive werden nun in einen nach dem Archiv benannten Ordner entpackt",
+              "it": "Gli archivi suddivisi e multi-volume ora si estraggono in una cartella denominata come l'archivio",
+              "ja": "分割・マルチボリュームアーカイブはアーカイブ名のフォルダーに展開されるようになりました",
+              "fa": "آرشیوهای چندبخشی و چندجلدی اکنون در پوشه‌ای به‌نام آرشیو استخراج می‌شوند",
+              "pl": "Archiwa dzielone i wielowolumenowe są teraz wypakowywane do folderu o nazwie archiwum",
+              "pt-BR": "Arquivos divididos e de vários volumes agora são extraídos para uma pasta com o nome do arquivo",
+              "ru": "Составные и многотомные архивы теперь распаковываются в папку с именем архива",
+              "uk": "Складені та багатотомні архіви тепер розпаковуються до теки з іменем архіву",
+              "es-MX": "Los archivos divididos y de varios volúmenes ahora se extraen en una carpeta con el nombre del archivo",
+              "ko": "분할 및 다중 볼륨 아카이브가 이제 아카이브 이름을 딴 폴더에 풀립니다",
+              "nl": "Gesplitste en multi-volume archieven worden nu uitgepakt in een map die naar het archief is vernoemd"
+            },
+            "issues": []
+          },
+          {
             "type": "core",
             "title": {
               "en": "Made previously hard-coded strings available for localization",

--- a/Modules/Sources/Core/ArchiveSupport/ArchiveTypeDetector.swift
+++ b/Modules/Sources/Core/ArchiveSupport/ArchiveTypeDetector.swift
@@ -68,6 +68,17 @@ final public class ArchiveTypeDetector: Sendable {
                         break
                     }
                 }
+            } else if let split = byExt.split {
+                // A split/multi-volume part (.z03, .zip.005) is detected by its
+                // own $-anchored regex; strip that suffix so the folder is named
+                // after the archive base (MyArchive.z03 → "MyArchive"). Detection
+                // is case-insensitive, so the strip must be too — but we replace
+                // in the original `name` to keep the base name's casing.
+                name = name.replacingOccurrences(
+                    of: split.pattern,
+                    with: "",
+                    options: [.regularExpression, .caseInsensitive]
+                )
             } else {
                 for ext in byExt.type.extensions {
                     if lowercasedName.hasSuffix(".\(ext)") {

--- a/Modules/Tests/CoreTests/ArchiveNamingTests.swift
+++ b/Modules/Tests/CoreTests/ArchiveNamingTests.swift
@@ -1,0 +1,198 @@
+//
+//  ArchiveNamingTests.swift
+//  Modules
+//
+//  `ArchiveTypeDetector.getNameWithoutExtension(for:)` — the name of the folder
+//  the "Extract to …" action creates. It classifies by *name* only
+//  (`detectByExtension`), so every case here works on paths that need not exist;
+//  the one fixture-backed test pins exactly that contract: a real spanned
+//  terminal `.zip` must still be named from its name, not from its bytes.
+//
+//  Three branches to keep honest: compound (`tar.gz`), split volume
+//  (`.z03`, `.zip.005`), plain format (`.zip`) — all case-insensitive matches
+//  that must preserve the base name's own casing.
+//
+
+import Testing
+import Foundation
+@testable import Core
+
+extension AllCoreTests {
+    @MainActor struct ArchiveNamingTests {
+
+        private let catalog = ArchiveTypeCatalog()
+
+        /// The name the extract-to folder would get for `file`. The path is never
+        /// read, so it does not have to exist.
+        private func folderName(_ file: String) -> String {
+            ArchiveTypeDetector(catalog: catalog)
+                .getNameWithoutExtension(for: URL(fileURLWithPath: "/tmp/\(file)"))
+        }
+
+        private func zipDir() -> URL {
+            Bundle.module.url(forResource: "zip", withExtension: nil)!
+        }
+
+        // MARK: - Plain format extensions
+
+        @Test func plainExtensionStripped() {
+            let cases = [
+                "MyArchive.zip", "MyArchive.7z", "MyArchive.rar", "MyArchive.tar",
+                "MyArchive.xz", "MyArchive.gz", "MyArchive.bz2", "MyArchive.z",
+                "MyArchive.sit", "MyArchive.sitx", "MyArchive.zipx", "MyArchive.lzh",
+                "MyArchive.iso", "MyArchive.dmg", "MyArchive.deb", "MyArchive.msi",
+                // zip aliases — same format, so the same branch has to strip them
+                "MyArchive.jar", "MyArchive.aar", "MyArchive.apk",
+            ]
+            for file in cases {
+                #expect(folderName(file) == "MyArchive", "\(file)")
+            }
+        }
+
+        /// Catalog-driven: a format added later gets naming coverage for free.
+        @Test func everyCatalogFormatExtensionStripped() {
+            for type in catalog.getAllTypes() {
+                for ext in type.extensions {
+                    #expect(folderName("MyArchive.\(ext)") == "MyArchive", "\(type.id): .\(ext)")
+                    #expect(folderName("MyArchive.\(ext.uppercased())") == "MyArchive",
+                            "\(type.id): .\(ext.uppercased())")
+                }
+            }
+        }
+
+        // MARK: - Compound extensions
+
+        @Test func compoundExtensionStripped() {
+            let cases = [
+                "MyArchive.tar.gz", "MyArchive.tar.bz2", "MyArchive.tar.xz",
+                "MyArchive.tar.lz4", "MyArchive.tar.Z", "MyArchive.tgz",
+                "MyArchive.tbz2", "MyArchive.txz", "MyArchive.taz",
+            ]
+            for file in cases {
+                #expect(folderName(file) == "MyArchive", "\(file)")
+            }
+        }
+
+        @Test func everyCatalogCompoundExtensionStripped() {
+            for composition in catalog.allCompositions() {
+                for ext in composition.extensions {
+                    #expect(folderName("MyArchive.\(ext)") == "MyArchive", ".\(ext)")
+                    #expect(folderName("MyArchive.\(ext.uppercased())") == "MyArchive",
+                            ".\(ext.uppercased())")
+                }
+            }
+        }
+
+        // MARK: - Split volume suffixes
+
+        @Test func spannedVolumeSuffixStripped() {
+            for file in ["MyArchive.z01", "MyArchive.z02", "MyArchive.z03",
+                         "MyArchive.z10", "MyArchive.z99", "MyArchive.z100",
+                         "MyArchive.z000001"] {
+                #expect(folderName(file) == "MyArchive", "\(file)")
+            }
+        }
+
+        @Test func numericVolumeSuffixStripped() {
+            for file in ["MyArchive.zip.001", "MyArchive.zip.002", "MyArchive.zip.005",
+                         "MyArchive.zip.0001", "MyArchive.zip.1234"] {
+                #expect(folderName(file) == "MyArchive", "\(file)")
+            }
+        }
+
+        /// Every part of one set must name the *same* folder — otherwise extracting
+        /// two volumes of the same archive produces two folders.
+        @Test func allPartsOfASetNameTheSameFolder() {
+            for part in ["split_pk.z01", "split_pk.z02", "split_pk.zip"] {
+                #expect(folderName(part) == "split_pk", "\(part)")
+            }
+            for part in ["split_7zz.zip.001", "split_7zz.zip.002", "split_7zz.zip.003"] {
+                #expect(folderName(part) == "split_7zz", "\(part)")
+            }
+        }
+
+        // MARK: - Casing
+
+        @Test func stripIsCaseInsensitiveAndBaseKeepsItsCasing() {
+            let cases = [
+                ("MyArchive.Z03", "MyArchive"),
+                ("MYARCHIVE.Z03", "MYARCHIVE"),
+                ("MyArchive.ZIP.005", "MyArchive"),
+                ("MYARCHIVE.Zip.005", "MYARCHIVE"),
+                ("MyArchive.ZIP", "MyArchive"),
+                ("MyArchive.TAR.GZ", "MyArchive"),
+                // mixed case on a compound — only the trailing component upper
+                ("MyArchive.tar.Z", "MyArchive"),
+                ("MixedCase.TaR.gZ", "MixedCase"),
+            ]
+            for (file, expected) in cases {
+                #expect(folderName(file) == expected, "\(file)")
+            }
+        }
+
+        // MARK: - Dotted base names (the suffix regexes are `$`-anchored)
+
+        @Test func onlyTheTrailingVolumeSuffixIsStripped() {
+            let cases = [
+                // dots inside the base survive
+                ("My.Archive.z03", "My.Archive"),
+                ("My.Archive.zip.007", "My.Archive"),
+                // a volume-looking token earlier in the name is not eaten
+                ("data.z01.backup.z02", "data.z01.backup"),
+                ("v1.2.3.z01", "v1.2.3"),
+                // a split part of a compound keeps the compound (the extract runs twice)
+                ("MyArchive.tar.gz.z02", "MyArchive.tar.gz"),
+            ]
+            for (file, expected) in cases {
+                #expect(folderName(file) == expected, "\(file)")
+            }
+        }
+
+        // MARK: - Look-alikes that are not volumes
+
+        @Test func volumeLookalikesAreNotStripped() {
+            let cases = [
+                // spanned needs 2+ digits, numeric needs 3+
+                ("notes.z1", "notes.z1"),
+                ("photo.zip.99", "photo.zip.99"),
+                // numeric scheme is `.zip.NNN` only — a zip alias is not a volume
+                ("app.apk.001", "app.apk.001"),
+                ("MyArchive.tar.gz.001", "MyArchive.tar.gz.001"),
+                // trailing plain extension wins; the earlier `.z01` stays in the base
+                ("archive.z01.zip", "archive.z01"),
+            ]
+            for (file, expected) in cases {
+                #expect(folderName(file) == expected, "\(file)")
+            }
+        }
+
+        @Test func unknownNamesAreReturnedUnchanged() {
+            for file in ["readme.txt", "README", "notes.markdown", "archive.z01.txt"] {
+                #expect(folderName(file) == file, "\(file)")
+            }
+        }
+
+        // MARK: - Name-only contract (no content probe)
+
+        /// `split_pk.zip` is a *real* spanned terminal volume — `detect(for:)`
+        /// recognizes it from the EOCD marker. Naming must not: it runs on
+        /// `detectByExtension`, so the bare `.zip` is stripped as a plain zip.
+        /// Switching this to `detect(for:)` would name the folder `split_pk.zip`,
+        /// because no split pattern matches a bare `.zip`.
+        @Test func bareSpannedVolumeIsNamedFromItsNameNotItsBytes() {
+            let detector = ArchiveTypeDetector(catalog: catalog)
+            let url = zipDir().appendingPathComponent("split_pk.zip")
+
+            #expect(detector.detect(for: url)?.split?.scheme == "spanned")
+            #expect(detector.getNameWithoutExtension(for: url) == "split_pk")
+        }
+
+        // MARK: - Tripwire
+
+        /// Naming samples above are hand-written per scheme (a regex gives no
+        /// sample name). A new split entry must arrive with its own cases.
+        @Test func everySplitSchemeHasNamingSamples() {
+            #expect(Set(catalog.allSplits().map(\.id)) == ["zip-spanned", "zip-numeric"])
+        }
+    }
+}

--- a/Modules/Tests/CoreTests/CoverageGapTests.swift
+++ b/Modules/Tests/CoreTests/CoverageGapTests.swift
@@ -320,35 +320,6 @@ extension AllCoreTests {
         }
     }
 
-    // MARK: - ArchiveTypeDetector: getNameWithoutExtension
-
-    @MainActor struct DetectorNameWithoutExtensionTests {
-
-        @Test func nameWithoutExtensionForSimpleArchive() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-            let url = URL(fileURLWithPath: "/tmp/archive.zip")
-            let name = detector.getNameWithoutExtension(for: url)
-            #expect(name == "archive")
-        }
-
-        @Test func nameWithoutExtensionForCompound() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-            let url = URL(fileURLWithPath: "/tmp/archive.tar.gz")
-            let name = detector.getNameWithoutExtension(for: url)
-            #expect(name == "archive")
-        }
-
-        @Test func nameWithoutExtensionForUnknown() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-            let url = URL(fileURLWithPath: "/tmp/document.txt")
-            let name = detector.getNameWithoutExtension(for: url)
-            #expect(name == "document.txt")
-        }
-    }
-
     // MARK: - ArchiveSupportUtilities: makeTempFileDescriptor
 
     @MainActor struct TempFileDescriptorTests {

--- a/Modules/Tests/CoreTests/EdgeCaseTests.swift
+++ b/Modules/Tests/CoreTests/EdgeCaseTests.swift
@@ -168,52 +168,7 @@ extension AllCoreTests {
             #expect(result!.type.id == "zip")
         }
 
-        @Test func getNameWithoutExtensionNoMatch() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-
-            let url = URL(fileURLWithPath: "/tmp/readme.txt")
-            let name = detector.getNameWithoutExtension(for: url)
-            #expect(name == "readme.txt")
-        }
-
-        @Test func getNameWithoutExtensionStripsUppercaseExtension() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-
-            // Detection is case-insensitive, so the suffix strip must be too;
-            // the base name keeps its original casing.
-            let zipUrl = URL(fileURLWithPath: "/tmp/MyArchive.ZIP")
-            #expect(detector.getNameWithoutExtension(for: zipUrl) == "MyArchive")
-
-            // Same for a compound (tar.gz) extension written in uppercase.
-            let compoundUrl = URL(fileURLWithPath: "/tmp/MyArchive.TAR.GZ")
-            #expect(detector.getNameWithoutExtension(for: compoundUrl) == "MyArchive")
-
-            // Mixed case on a compound — only the trailing component is uppercase.
-            let tarZUrl = URL(fileURLWithPath: "/tmp/MyArchive.tar.Z")
-            #expect(detector.getNameWithoutExtension(for: tarZUrl) == "MyArchive")
-        }
-
-        @Test func getNameWithoutExtensionStripsSplitVolumeSuffix() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-
-            // A split/multi-volume part is detected by its own suffix (.zNN,
-            // .zip.NNN); that suffix must be stripped so the extract-to-folder
-            // is named after the archive base, not the volume — mirroring how
-            // ArchiveState.splitSetName(for:) titles the window.
-            let spannedUrl = URL(fileURLWithPath: "/tmp/MyArchive.z03")
-            #expect(detector.getNameWithoutExtension(for: spannedUrl) == "MyArchive")
-
-            let numericUrl = URL(fileURLWithPath: "/tmp/MyArchive.zip.005")
-            #expect(detector.getNameWithoutExtension(for: numericUrl) == "MyArchive")
-
-            // Detection is case-insensitive, so the strip must be too; the base
-            // name keeps its original casing.
-            let upperUrl = URL(fileURLWithPath: "/tmp/MyArchive.Z03")
-            #expect(detector.getNameWithoutExtension(for: upperUrl) == "MyArchive")
-        }
+        // `getNameWithoutExtension` cases live in `ArchiveNamingTests`.
 
         @Test func detectAllCompoundExtensions() {
             let catalog = ArchiveTypeCatalog()

--- a/Modules/Tests/CoreTests/EdgeCaseTests.swift
+++ b/Modules/Tests/CoreTests/EdgeCaseTests.swift
@@ -195,6 +195,26 @@ extension AllCoreTests {
             #expect(detector.getNameWithoutExtension(for: tarZUrl) == "MyArchive")
         }
 
+        @Test func getNameWithoutExtensionStripsSplitVolumeSuffix() {
+            let catalog = ArchiveTypeCatalog()
+            let detector = ArchiveTypeDetector(catalog: catalog)
+
+            // A split/multi-volume part is detected by its own suffix (.zNN,
+            // .zip.NNN); that suffix must be stripped so the extract-to-folder
+            // is named after the archive base, not the volume — mirroring how
+            // ArchiveState.splitSetName(for:) titles the window.
+            let spannedUrl = URL(fileURLWithPath: "/tmp/MyArchive.z03")
+            #expect(detector.getNameWithoutExtension(for: spannedUrl) == "MyArchive")
+
+            let numericUrl = URL(fileURLWithPath: "/tmp/MyArchive.zip.005")
+            #expect(detector.getNameWithoutExtension(for: numericUrl) == "MyArchive")
+
+            // Detection is case-insensitive, so the strip must be too; the base
+            // name keeps its original casing.
+            let upperUrl = URL(fileURLWithPath: "/tmp/MyArchive.Z03")
+            #expect(detector.getNameWithoutExtension(for: upperUrl) == "MyArchive")
+        }
+
         @Test func detectAllCompoundExtensions() {
             let catalog = ArchiveTypeCatalog()
             let detector = ArchiveTypeDetector(catalog: catalog)

--- a/Modules/Tests/CoreTests/UtilityTests.swift
+++ b/Modules/Tests/CoreTests/UtilityTests.swift
@@ -518,23 +518,7 @@ extension AllCoreTests {
             #expect(result == nil)
         }
 
-        @Test func getNameWithoutExtensionSimple() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-            let url = URL(fileURLWithPath: "/tmp/archive.zip")
-
-            let name = detector.getNameWithoutExtension(for: url)
-            #expect(name == "archive")
-        }
-
-        @Test func getNameWithoutExtensionCompound() {
-            let catalog = ArchiveTypeCatalog()
-            let detector = ArchiveTypeDetector(catalog: catalog)
-            let url = URL(fileURLWithPath: "/tmp/archive.tar.gz")
-
-            let name = detector.getNameWithoutExtension(for: url)
-            #expect(name == "archive")
-        }
+        // `getNameWithoutExtension` cases live in `ArchiveNamingTests`.
 
         @Test func detectByMagicNumberWithTestArchive() {
             let catalog = ArchiveTypeCatalog()


### PR DESCRIPTION
`getNameWithoutExtension(for:)` stripped the suffix in its composition and plain-extension branches but had **no branch for split / multi-volume archives**. A split detection (`byExt.split != nil`, `byExt.composition == nil`) fell into the plain `else`, which iterates only `byExt.type.extensions` (`zip`/`jar`/`aar`/`apk`) — none of which matches `.zNN` / `.zip.NNN`, so nothing was stripped. Dropping `archive.z03` to extract named the folder `"archive.z03"` instead of `"archive"`. The sibling `ArchiveState.splitSetName(for:)` already handles splits correctly for the window title, so splits were handled in one place and missed here.

## Fix
Add a `byExt.split` branch that strips the split's own `$`-anchored regex (`\.z[0-9]{2,}$`, `\.zip\.[0-9]{3,}$`), case-insensitively, replacing in the original `name` so the base keeps its casing (`MyArchive.Z03` → `"MyArchive"`). The composition and plain branches (the case-insensitive fix from #170) are byte-for-byte unchanged.

## Test plan
`cd Modules && swift test` — **379 passed, 0 failed**, including a new `getNameWithoutExtensionStripsSplitVolumeSuffix` (`MyArchive.z03` / `MyArchive.zip.005` / `MyArchive.Z03` → `"MyArchive"`; red before the fix returned the suffix-laden names).

## AI disclosure
This change was written with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Split and multi-volume archives now extract into a folder named after the archive, without split-volume suffixes such as `.z01` or `.zip.001`.
  * Archive names with uppercase split-volume extensions are handled correctly while preserving the original name casing.
  * Archive folder names are now determined consistently across archive formats and volume parts.

* **Documentation**
  * Added localized release notes for this fix in version 0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->