### PR TITLE
fix: Finder toolbar icon size

### DIFF
--- a/FinderExtension/FinderSync.swift
+++ b/FinderExtension/FinderSync.swift
@@ -93,9 +93,13 @@ class FinderSync: FIFinderSync {
     }
     
     override var toolbarItemImage: NSImage {
-        let img = NSImage(named: "AppIcon_MacPacker") ?? NSImage()
-        img.size = NSSize(width: 18, height: 18)
-        return img
+        // Finder toolbar items use a 16 pt square, like the built-in toolbar icons.
+        // Copy the cached asset before changing its logical (point) size.
+        guard let image = NSImage(named: "AppIcon_MacPacker")?.copy() as? NSImage else {
+            return NSImage(size: NSSize(width: 16, height: 16))
+        }
+        image.size = NSSize(width: 16, height: 16)
+        return image
     }
     
     /// Whether the URL points at a directory. Uses the file system's

--- a/MacPacker/Features/Settings/AboutSettingsView.swift
+++ b/MacPacker/Features/Settings/AboutSettingsView.swift
@@ -72,11 +72,11 @@ struct AboutSettingsView: View {
                     Text(verbatim: "© 2023-2026 Stephan Arenswald")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
-                    Text(verbatim: "Licensed under the GNU General Public License v3.0 (GPL-3.0-or-later). This is free software: you can redistribute it and/or modify it under the terms of the GPL.")
+                    Text("Licensed under the GNU General Public License v3.0 (GPL-3.0-or-later). This is free software: you can redistribute it and/or modify it under the terms of the GPL.", comment: "License notice shown in the About settings.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
-                    Text(verbatim: "No warranty. See LICENSE for details.")
+                    Text("No warranty. See LICENSE for details.", comment: "Warranty disclaimer shown in the About settings.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                     

--- a/MacPacker/Features/Settings/FormatSettingsView.swift
+++ b/MacPacker/Features/Settings/FormatSettingsView.swift
@@ -84,8 +84,8 @@ struct FormatSettingsView: View {
     func showInfoToSetAsDefault() {
         let alert = NSAlert()
         alert.icon = NSImage(named: "AppIcon")
-        alert.messageText = "Set MacPacker as the default app"
-        alert.informativeText = "To make MacPacker the default for a file type: Right-click a file → 'Get Info' → choose MacPacker under 'Open with:' → click 'Change All…' to apply it to all similar archives."
+        alert.messageText = String(localized: "Set MacPacker as the default app", comment: "Title of the alert that explains how to set MacPacker as the default app for archive files.")
+        alert.informativeText = String(localized: "To make MacPacker the default for a file type: Right-click a file → 'Get Info' → choose MacPacker under 'Open with:' → click 'Change All…' to apply it to all similar archives.", comment: "Instructions in the alert explaining how to set MacPacker as the default app for archive files in Finder.")
         alert.alertStyle = .informational
         alert.runModal()
     }


### PR DESCRIPTION
Probably fix https://github.com/sarensw/MacPacker/issues/134

Adjusts the MacPacker Finder Sync extension toolbar icon to match the size of native Finder toolbar icons.

### Changes
- Changes the toolbar icon’s logical size from **18×18 pt** to the standard **16×16 pt**.
- Creates a copy of the cached asset before resizing it, preventing unintended size changes wherever the same image asset is reused.

### Result
The MacPacker icon now appears visually consistent with the other system icons in the Finder toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the Finder toolbar icon for consistent 16×16-point sizing, with a fallback image when unavailable.
  * Improved localization support for license, warranty, and default-app setup instructions in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->