### PR TITLE
fix: stop under-counting the XAD total uncompressed size by one byte per directory

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -120,6 +120,26 @@
             ]
           },
           {
+            "type": "fix",
+            "title": {
+              "en": "Correct total size for archives with folders",
+              "zh-Hans": "修正含文件夹压缩包的总大小",
+              "fr": "Taille totale corrigée pour les archives contenant des dossiers",
+              "de": "Korrekte Gesamtgröße bei Archiven mit Ordnern",
+              "it": "Dimensione totale corretta per gli archivi con cartelle",
+              "ja": "フォルダーを含むアーカイブの合計サイズを修正",
+              "fa": "اندازهٔ کل صحیح برای آرشیوهای دارای پوشه",
+              "pl": "Poprawny łączny rozmiar archiwów z folderami",
+              "pt-BR": "Tamanho total correto para arquivos com pastas",
+              "ru": "Правильный общий размер для архивов с папками",
+              "uk": "Правильний загальний розмір для архівів із теками",
+              "es-MX": "Tamaño total correcto para archivos con carpetas",
+              "ko": "폴더가 포함된 압축 파일의 전체 크기 수정",
+              "nl": "Correcte totale grootte voor archieven met mappen"
+            },
+            "issues": []
+          },
+          {
             "type": "core",
             "title": {
               "en": "Made previously hard-coded strings available for localization",

--- a/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
@@ -405,8 +405,13 @@ final actor ArchiveXadEngine: ArchiveEngine {
             )
             
             entries[entry.id] = entry
-            
-            uncompressedSizeOverall += Int64(entry.uncompressedSize)
+
+            // Directory entries keep the "-1" unknown sentinel in
+            // `uncompressedSize` (their size block is skipped under `if !isDir`
+            // above), so clamp before accumulating — otherwise every directory
+            // subtracts a byte from the reported total. Mirrors the same
+            // `max(0, …)` clamp the extraction side applies for its byte totals.
+            uncompressedSizeOverall += Int64(Swift.max(0, entry.uncompressedSize))
         }
         
         emit(.done)

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -295,17 +295,9 @@ extension AllCoreTests {
             #expect(result.items.count > 0)
         }
 
-        // Regression: the XAD engine reported a total uncompressed size that
-        // was too small by one byte per directory entry. Directory entries
-        // carry the "-1" unknown sentinel in `uncompressedSize` (their size
-        // block is skipped under `if !isDir`), and the load-side accumulation
-        // summed that sentinel verbatim — so an archive with D directories
-        // reported a total D bytes short. The fix clamps the sentinel to 0 at
-        // the accumulation site, the same `max(0, …)` clamp the extraction
-        // side already applies for its byte totals. The fixture
-        // `defaultArchive.zip` has one directory (`folder/`) plus three files,
-        // so the reported total must equal the sum of the file-entry sizes
-        // only — with the bug it is one byte less.
+        // Regression: directory entries keep the "-1" unknown sentinel in
+        // `uncompressedSize`, and the load-side total summed it verbatim — so
+        // an archive with D directories reported D bytes short.
         @Test func loadArchiveViaXadReportsCorrectTotalSizeWithDirectories() async throws {
             let engine = ArchiveXadEngine()
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
@@ -313,9 +305,7 @@ extension AllCoreTests {
 
             let result = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
 
-            // The fixture must actually contain directory entries for this
-            // regression to mean anything; otherwise the assertion would pass
-            // trivially even without the fix.
+            // Without a directory entry the assertion passes even unfixed.
             let dirCount = result.items.values.filter { $0.type == .directory }.count
             #expect(dirCount > 0, "fixture should contain at least one directory entry")
 

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -295,6 +295,42 @@ extension AllCoreTests {
             #expect(result.items.count > 0)
         }
 
+        // Regression: the XAD engine reported a total uncompressed size that
+        // was too small by one byte per directory entry. Directory entries
+        // carry the "-1" unknown sentinel in `uncompressedSize` (their size
+        // block is skipped under `if !isDir`), and the load-side accumulation
+        // summed that sentinel verbatim — so an archive with D directories
+        // reported a total D bytes short. The fix clamps the sentinel to 0 at
+        // the accumulation site, the same `max(0, …)` clamp the extraction
+        // side already applies for its byte totals. The fixture
+        // `defaultArchive.zip` has one directory (`folder/`) plus three files,
+        // so the reported total must equal the sum of the file-entry sizes
+        // only — with the bug it is one byte less.
+        @Test func loadArchiveViaXadReportsCorrectTotalSizeWithDirectories() async throws {
+            let engine = ArchiveXadEngine()
+            let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let url = folderURL.appendingPathComponent("defaultArchive.zip")
+
+            let result = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+
+            // The fixture must actually contain directory entries for this
+            // regression to mean anything; otherwise the assertion would pass
+            // trivially even without the fix.
+            let dirCount = result.items.values.filter { $0.type == .directory }.count
+            #expect(dirCount > 0, "fixture should contain at least one directory entry")
+
+            let expected = result.items.values.reduce(Int64(0)) { sum, item in
+                item.type == .file
+                    ? sum + Int64(Swift.max(0, item.uncompressedSize))
+                    : sum
+            }
+
+            #expect(
+                result.uncompressedSize == expected,
+                "total uncompressed size should sum file sizes only, got \(result.uncompressedSize) expected \(expected)"
+            )
+        }
+
         // MARK: extract(items:)
 
         @Test func extractSingleFileViaXad() async throws {


### PR DESCRIPTION
**PR title:** `fix: stop under-counting the XAD total uncompressed size by one byte per directory`

---

## What

- An archive loaded via the **XAD engine** (RAR, cab, tar, zip-via-XAD, …) reported a
  total uncompressed size that was **too small by one byte for every directory entry** in
  the archive.
- Directory entries carry the `-1` "unknown" sentinel in their `uncompressedSize`, and the
  load-side total summed that sentinel verbatim — so an archive with *D* directories
  reported a total *D* bytes short. With the fix, directory entries contribute `0`, as they
  already do on the extraction side.

## How

`Modules/Sources/Core/Engine/ArchiveXadEngine.swift` — `loadArchive` accumulates each
entry's `uncompressedSize` into the returned `uncompressedSize` total. Directory entries
skip the size-reading block (`if !isDir`) and keep `uncompressedSize` at its `-1` sentinel,
which was added straight into the sum:

```swift
// before
uncompressedSizeOverall += Int64(entry.uncompressedSize)
// after
uncompressedSizeOverall += Int64(Swift.max(0, entry.uncompressedSize))
```

The clamp mirrors the **same convention the extraction side already uses** for its byte
totals (`Swift.max(0, …)` in the per-item `totalBytes` reduce and in `advanceBase`). The
`-1` sentinel convention itself, `Archive7ZipEngine` (already correct), the extraction-side
clamps, and the rest of `loadArchive` are untouched — this is the one accumulation site
that was unguarded.

`Modules/Tests/CoreTests/EngineTests.swift` — new regression test
`loadArchiveViaXadReportsCorrectTotalSizeWithDirectories` (in `ArchiveXadEngineTests`).
It loads the bundled `defaultArchive.zip` (one directory `folder/` + three files totaling
52784 bytes uncompressed), asserts the fixture actually contains a directory (so the test
can't pass trivially), and asserts `result.uncompressedSize == sum of file-entry sizes
only`.

## AI disclosure

This PR was primarily authored by an AI assistant (Claude Code), under my direction and
review, per `AI_CONTRIBUTING.md`.

## Verification

Headless core gate — `cd Modules && swift test`:

```
Suite AllCoreTests passed after 15.703 seconds.
Test run with 385 tests in 116 suites passed after 15.704 seconds.
```

RED before the fix (the new regression test, against the unmodified accumulation):

```
Test loadArchiveViaXadReportsCorrectTotalSizeWithDirectories()
  Expectation failed: (result.uncompressedSize → 52783) == (expected → 52784)
  total uncompressed size should sum file sizes only, got 52783 expected 52784
```

GREEN after the one-line fix:

```
Test loadArchiveViaXadReportsCorrectTotalSizeWithDirectories() passed.
```

`52783 == 52784 − 1`: the single directory entry was subtracting exactly one byte. With the
clamp the reported total is `52784`, matching the sum of file sizes.

The change is Core-only (engine data layer + its test); no app, extension, UI, version, or
submodule changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected archive size reporting so directory entries and invalid size values no longer reduce the reported total.
  * Archive totals now accurately reflect the combined sizes of files only.

* **Tests**
  * Added regression coverage for archive size calculations involving directories and invalid size markers.

* **Documentation**
  * Updated the version 0.20.0 changelog with the archive size calculation fix in all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->