### PR TITLE
docs: add AGENTS.md and the contributor process templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Translations
+    url: https://poeditor.com/join/project/J2Qq2SUzYr
+    about: Fix or add a translation directly on POEditor — no issue needed.
+  - name: Documentation & format guides
+    url: https://macpacker.app/en/docs
+    about: Per-format guides and the full format reference.
+  - name: Questions & ideas
+    url: https://github.com/sarensw/MacPacker/discussions
+    about: For open questions and discussion, rather than a concrete bug or feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for MacPacker
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**What would you like MacPacker to do?**
+Describe the feature in a few sentences.
+
+**What are you trying to accomplish?**
+The task or workflow behind the request. Helps find the best solution, which
+isn't always the one suggested.
+
+**How do you handle it today?**
+Optional: another app, a workaround, or nothing.
+
+**Anything else?**
+Optional: screenshots, mockups, or how other tools solve it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thanks for contributing to MacPacker. Keep this short — a few sentences is fine. -->
+
+## What & why
+
+<!-- What changes, and what problem it solves. -->
+
+<!-- If this addresses an existing issue: Closes #123 -->
+
+## How it was verified
+
+<!--
+Required. Describe what you ran or clicked, and paste the evidence.
+- UI changes: before/after screenshots
+- Core, logging, build, or scripting changes: terminal output, logs, or test results
+-->
+
+## Checklist
+
+- [ ] Verification evidence is included above
+- [ ] Changelog entry added to `Config/products/macpacker.json` (or: no user-visible change)
+- [ ] `Config/Version.xcconfig` is untouched
+- [ ] AI involvement disclosed, if AI was the primary author — see [AI_CONTRIBUTING.md](../AI_CONTRIBUTING.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,5 @@ Required. Describe what you ran or clicked, and paste the evidence.
 ## Checklist
 
 - [ ] Verification evidence is included above
-- [ ] Changelog entry added to `Config/products/macpacker.json` (or: no user-visible change)
-- [ ] `Config/Version.xcconfig` is untouched
+- [ ] Changelog entry added to `Config/products/macpacker.json`
 - [ ] AI involvement disclosed, if AI was the primary author — see [AI_CONTRIBUTING.md](../AI_CONTRIBUTING.md)

--- a/.github/workflows/guard-version.yml
+++ b/.github/workflows/guard-version.yml
@@ -1,0 +1,28 @@
+# ── Version guard ─────────────────────────────────────────────────────────────
+# Config/Version.xcconfig stays at 0.0.0-dev; the release version is set by CI at
+# tag time. This job only triggers when a pull request touches that file, and
+# fails unless the author owns the repository.
+#
+# Because of the paths filter this workflow does not report on most pull
+# requests, so it must NOT be configured as a required status check — required
+# checks that never report block merging.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Guard Version
+
+on:
+  pull_request:
+    paths:
+      - 'Config/Version.xcconfig'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    if: github.event.pull_request.author_association != 'OWNER'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject the version change
+        run: |
+          echo "::error file=Config/Version.xcconfig::Config/Version.xcconfig must not be changed in a pull request. It stays at MARKETING_VERSION = 0.0.0-dev; CI sets the release version at tag time. Revert this file to merge."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,54 +1,52 @@
 # Agent Guide
 
-Working instructions for AI coding agents in this repository. Humans: see
-[CONTRIBUTING.md](CONTRIBUTING.md) and [AI_CONTRIBUTING.md](AI_CONTRIBUTING.md).
+Instructions for AI coding agents. Humans: [CONTRIBUTING.md](CONTRIBUTING.md),
+[AI_CONTRIBUTING.md](AI_CONTRIBUTING.md).
 
-MacPacker is a sandboxed SwiftUI archive manager for macOS, with a Finder
-extension and a Quick Look extension. Most logic lives in the `Modules` Swift
-package; the Xcode project is the app shell.
+App logic lives in the `Modules` Swift package. The Xcode project is the shell,
+plus a Finder and a Quick Look extension.
 
 ## Build & test
 
 ```bash
 git submodule update --init --recursive   # required — the build fails without it
-swift test --package-path Modules         # unit tests (what CI runs on every PR)
-open MacPacker.xcodeproj                  # app build, Cmd+R
+swift test --package-path Modules         # unit tests; what PR CI runs
+xcodebuild -scheme MacPacker build        # app build; also extracts new UI strings
 ```
 
-The `MacPacker.xctestplan` scheme runs the XCUITest target only; it is not part
-of PR CI.
+`MacPacker.xctestplan` runs the XCUITest target only, outside PR CI.
 
 ## Rules
 
 **Never set the version.** `Config/Version.xcconfig` stays at
-`MARKETING_VERSION = 0.0.0-dev`. That is the permanent local value, not a
-placeholder. Never edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION` in any
-branch for any reason, including when a change is "for version X". Naming a
-target version in a changelog entry or commit message is fine; changing the
-build setting is not. CI sets the real version at tag time.
+`MARKETING_VERSION = 0.0.0-dev` permanently; CI sets the real version at tag
+time. Never edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION` in any branch,
+including "for version X". Naming a version in a changelog entry or commit
+message is fine.
 
-**Vendored dependencies are pristine submodules.** `Modules/Sources/CSevenZip/vendor/7zip`
-and friends track upstream unmodified. Fixes belong in the bridging layer or in
-MacPacker code, never in vendored sources.
+**Vendored submodules stay pristine.** `Modules/Sources/CSevenZip/vendor/7zip`
+tracks upstream unmodified. Fix in the bridging layer or in MacPacker code.
 
-**Localization goes through POEditor, not by hand.** Do not add translations to
-`Localizable.xcstrings` directly — add the English key and leave the rest.
-See [CONTRIBUTING.md](CONTRIBUTING.md#localization). The changelog is the one
-exception (below).
+**New UI strings: commit the catalog, English only.** Xcode extracts strings
+into the `.xcstrings` catalogs when the app target builds, so `swift test` alone
+leaves them out. Build once, then commit whichever catalog changed
+(`MacPacker/`, `FinderExtension/`, `Modules/Sources/ArchivePreviewUI/`). Fill in
+English only — the other languages come back from POEditor. Without the catalog
+entry the string can never be translated.
 
-**Bug fixes start with a failing test.** Reproduce in a test in
-`Modules/Tests/CoreTests`, then fix. Archive fixtures live in the
-`MacPacker-TestArchives` submodule.
+**Bug fixes start with a failing test** in `Modules/Tests/CoreTests`. If it
+needs an archive fixture, build the archive in the test at runtime. Do not
+commit archive files — fixtures live in a separate repository, and archives
+easily carry third-party or personal content. If a fixture cannot be generated,
+describe the reproduction in the PR and leave it to the maintainer.
 
-**Link the issue when one exists.** If the change addresses a reported issue,
-reference it in the PR body (`Closes #123`). Do not open an issue solely to have
-something to link — the changelog falls back to the PR number (see below).
+**Link the issue when one exists** in the PR body (`Closes #123`). Do not open
+an issue solely to have something to link.
 
 ## Changelog
 
 User-visible changes need an entry in `Config/products/macpacker.json` under
-`changelog.versions[]`. There is no separate CHANGELOG file. CI validates at tag
-time that the released version exists here.
+`changelog.versions[]`. There is no separate CHANGELOG file.
 
 ```jsonc
 {
@@ -56,48 +54,38 @@ time that the released version exists here.
   "items": [
     {
       "type": "fix",              // feat | fix | core | lang
-      "title": { "en": "…", "de": "…", /* all 14 languages */ },
-      "issues": ["170"]           // issue number, or this PR's own number
+      "title": { "en": "…", "de": "…", /* every language in the file */ },
+      "issues": ["170"]           // the issue, or this PR's own number
     }
   ]
 }
 ```
 
-Versions are listed newest first. Add to the first block, unless that version is
-already released — then add a new block above it. Check the exact tag:
-`git tag --list "v0.20.0"`. Empty means unreleased. Beta tags
-(`v0.20.0-beta.6`) do not count as released.
+**Do not decide version numbers.** Versions are listed newest first; add the
+item to the first block. If that version is already tagged (`git tag --list
+"v0.20.0"` returns something — beta tags do not count), say so in the PR and
+leave the new block to the maintainer.
 
-**`issues` always points at something.** Prefer the issue the change addresses —
-readers land on the report in a user's own words. If there is no issue, use this
-pull request's own number instead; GitHub resolves issue and PR numbers from the
-same namespace, so either link works.
+**`issues` always points at something.** Prefer the issue, so readers land on
+the report in a user's own words; otherwise use this PR's own number, which
+shares GitHub's numbering. That number exists only once the PR is open, so add
+it in a second push. Never guess a number, and never write an empty `[]`.
 
-That means the number does not exist until the PR is opened. Sequence:
-
-1. Write the entry with everything except `issues`, and open the PR.
-2. Add `"issues": ["<pr-number>"]` and push again.
-
-Never guess a number. An invented one resolves to somebody else's issue. Leave
-the field out until the real number exists, and never write an empty `[]`.
-
-**Writing the title.** Customer-facing and short. Describe what changed for the
-user, not how it was implemented. Aim for under ~50 characters.
+**Titles: customer-facing and short.** What changed for the user, not how it was
+built. Under ~50 characters.
 
 - Yes: `Extract-to-folder ignores extension case`
 - No: `Normalize archive extension casing in ExtractDestinationResolver`
 
-**Translations.** Fill in all 14 languages: `en`, `de`, `es-MX`, `fa`, `fr`,
-`it`, `ja`, `ko`, `nl`, `pl`, `pt-BR`, `ru`, `uk`, `zh-Hans`. Translate the
-meaning for a user of that language, not the English wording literally. Keep
-each one roughly as short as the English. Format names (`zip`, `7z`, `apk`),
-`MacPacker`, and macOS feature names (`Finder`, `Quick Look`) stay untranslated.
-
-Get the English wording approved before writing out all 14 languages.
+**Translate into every language already present in the file** — match that set,
+not a fixed list. Translate the meaning rather than the English wording, and
+keep each roughly as short. `MacPacker`, format names (`zip`, `7z`) and macOS
+feature names (`Finder`, `Quick Look`) stay untranslated. Get the English
+approved before writing the rest.
 
 ## Conventions
 
 - Commit and PR titles: `feat:`, `fix:`, `core:`, `lang:`, `docs:`, `ci:`,
-  `refactor:` — same set as the changelog `type` field.
-- Do not add `Co-Authored-By` trailers for AI tools.
-- Do not commit `Config/SigningOverride.xcconfig` (gitignored, local only).
+  `refactor:` — the changelog `type` set.
+- No `Co-Authored-By` trailers for AI tools.
+- Never commit `Config/SigningOverride.xcconfig` (gitignored).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,9 @@ exception (below).
 `Modules/Tests/CoreTests`, then fix. Archive fixtures live in the
 `MacPacker-TestArchives` submodule.
 
-**Link the issue, if there is one.** When the change addresses a reported issue,
-reference it in the PR body (`Closes #123`). The changelog entry's `issues` field
-is always filled — see below. No need to open an issue just to have one to link.
+**Link the issue when one exists.** If the change addresses a reported issue,
+reference it in the PR body (`Closes #123`). Do not open an issue solely to have
+something to link — the changelog falls back to the PR number (see below).
 
 ## Changelog
 
@@ -63,8 +63,10 @@ time that the released version exists here.
 }
 ```
 
-Add to the topmost unreleased `version` block, or open a new one if the last
-block is already released.
+Versions are listed newest first. Add to the first block, unless that version is
+already released — then add a new block above it. Check the exact tag:
+`git tag --list "v0.20.0"`. Empty means unreleased. Beta tags
+(`v0.20.0-beta.6`) do not count as released.
 
 **`issues` always points at something.** Prefer the issue the change addresses —
 readers land on the report in a user's own words. If there is no issue, use this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,10 @@ on the app target build, so `swift test` alone leaves new strings out and they
 never reach POEditor. Commit whichever catalog changed (`MacPacker/`,
 `FinderExtension/`, `Modules/Sources/ArchivePreviewUI/`). Write no translations
 into it, English included: the literal in the code is the key and its own
-fallback, and every value — `en` too — comes back from POEditor.
+fallback, and every value — `en` too — comes back from POEditor. Where the
+literal alone does not say where the string appears, pass `comment:` at the call
+site (`Text(_, comment:)`, `String(localized:comment:)`); it is the only context
+a translator gets.
 
 **Bug fixes start with a failing test** in `Modules/Tests/CoreTests`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 Instructions for AI coding agents. Humans: [CONTRIBUTING.md](CONTRIBUTING.md),
 [AI_CONTRIBUTING.md](AI_CONTRIBUTING.md).
 
-App logic lives in the `Modules` Swift package. The Xcode project is the shell,
-plus a Finder and a Quick Look extension.
+App logic is in the `Modules` Swift package; the Xcode project is the shell plus
+a Finder and a Quick Look extension.
 
 ## Build & test
 
@@ -19,33 +19,26 @@ xcodebuild -scheme MacPacker build        # app build; also extracts new UI stri
 ## Rules
 
 **Never set the version.** `Config/Version.xcconfig` stays at
-`MARKETING_VERSION = 0.0.0-dev` permanently; CI sets the real version at tag
-time. Never edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION` in any branch,
-including "for version X". Naming a version in a changelog entry or commit
-message is fine.
+`MARKETING_VERSION = 0.0.0-dev`; CI sets the real one at tag time. Never edit
+`MARKETING_VERSION` or `CURRENT_PROJECT_VERSION`, in any branch, including "for
+version X". Naming a version in a changelog entry or commit message is fine.
 
 **Vendored submodules stay pristine.** `Modules/Sources/CSevenZip/vendor/7zip`
 tracks upstream unmodified. Fix in the bridging layer or in MacPacker code.
 
-**New UI strings: commit the catalog, English only.** Xcode extracts strings
-into the `.xcstrings` catalogs when the app target builds, so `swift test` alone
-leaves them out. Build once, then commit whichever catalog changed
-(`MacPacker/`, `FinderExtension/`, `Modules/Sources/ArchivePreviewUI/`). Fill in
-English only — the other languages come back from POEditor. Without the catalog
-entry the string can never be translated.
+**New UI strings: build, then commit the catalog.** Extraction runs on the app
+target build, so `swift test` alone leaves new strings out and they never reach
+POEditor. Commit whichever catalog changed (`MacPacker/`, `FinderExtension/`,
+`Modules/Sources/ArchivePreviewUI/`) with the English value only; the other
+languages come back from POEditor.
 
 **Bug fixes start with a failing test** in `Modules/Tests/CoreTests`.
 
-**Archive fixtures never go in this repository.** They live in the
-`MacPacker-TestArchives` submodule, a permanent regression corpus: each archive
-is a real file from a real tool, kept so a later engine change cannot silently
-break the quirk it covers. Do not synthesize an equivalent archive in the test —
-the quirk is usually exactly what a synthetic archive lacks.
-
-Adding one means landing the archive in MacPacker-TestArchives first, then
-bumping the submodule pointer here. Outside contributors cannot push there:
-attach the archive to the PR and let the maintainer place it. Never contribute
-an archive containing third-party or personal content.
+**Archive fixtures live in the `MacPacker-TestArchives` submodule**, never in
+this repository. Do not synthesize a substitute in the test — the quirk under
+fix is usually what a synthetic archive lacks. Order: PR the archive to
+MacPacker-TestArchives, wait for merge, bump the submodule pointer here, then
+the fix. Never contribute archives holding third-party or personal content.
 
 **Link the issue when one exists** in the PR body (`Closes #123`). Do not open
 an issue solely to have something to link.
@@ -68,28 +61,26 @@ User-visible changes need an entry in `Config/products/macpacker.json` under
 }
 ```
 
-**Do not decide version numbers.** Versions are listed newest first. Add the
-item to the first block, unless that version is already tagged (`git tag --list
-"v0.20.0"` returns something — beta tags do not count). If it is, the next
-number is the maintainer's call: still write the full item, but put it in the PR
-body instead of the file, and say the release needs a new block.
+**Never pick a version number.** Versions run newest first; add to the first
+block unless it is already tagged (`git tag --list "v0.20.0"` — beta tags do not
+count). If tagged, write the full item into the PR body instead and say a new
+block is needed.
 
-**`issues` always points at something.** Prefer the issue, so readers land on
-the report in a user's own words; otherwise use this PR's own number, which
-shares GitHub's numbering. That number exists only once the PR is open, so add
-it in a second push. Never guess a number, and never write an empty `[]`.
+**`issues` is never empty.** Prefer the issue, so readers land on the report in
+a user's own words; otherwise this PR's own number, which shares GitHub's
+numbering. That number exists only after the PR is open — add it in a second
+push. Never guess one.
 
-**Titles: customer-facing and short.** What changed for the user, not how it was
-built. Under ~50 characters.
+**Titles: customer-facing, under ~50 characters.** What changed for the user,
+not how it was built.
 
 - Yes: `Extract-to-folder ignores extension case`
 - No: `Normalize archive extension casing in ExtractDestinationResolver`
 
-**Translate into every language already present in the file** — match that set,
-not a fixed list. Translate the meaning rather than the English wording, and
-keep each roughly as short. `MacPacker`, format names (`zip`, `7z`) and macOS
-feature names (`Finder`, `Quick Look`) stay untranslated. Get the English
-approved before writing the rest.
+**Translate into every language already in the file**, not a fixed list.
+Translate meaning, not wording; keep each roughly as short as the English.
+`MacPacker`, format names (`zip`, `7z`) and macOS features (`Finder`,
+`Quick Look`) stay untranslated. Get the English approved first.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,12 @@ version X". Naming a version in a changelog entry or commit message is fine.
 **Vendored submodules stay pristine.** `Modules/Sources/CSevenZip/vendor/7zip`
 tracks upstream unmodified. Fix in the bridging layer or in MacPacker code.
 
-**New UI strings: build, then commit the catalog.** Extraction runs on the app
-target build, so `swift test` alone leaves new strings out and they never reach
-POEditor. Commit whichever catalog changed (`MacPacker/`, `FinderExtension/`,
-`Modules/Sources/ArchivePreviewUI/`) with the English value only; the other
-languages come back from POEditor.
+**New UI strings: build, then commit the catalog as generated.** Extraction runs
+on the app target build, so `swift test` alone leaves new strings out and they
+never reach POEditor. Commit whichever catalog changed (`MacPacker/`,
+`FinderExtension/`, `Modules/Sources/ArchivePreviewUI/`). Write no translations
+into it, English included: the literal in the code is the key and its own
+fallback, and every value — `en` too — comes back from POEditor.
 
 **Bug fixes start with a failing test** in `Modules/Tests/CoreTests`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,18 @@ leaves them out. Build once, then commit whichever catalog changed
 English only — the other languages come back from POEditor. Without the catalog
 entry the string can never be translated.
 
-**Bug fixes start with a failing test** in `Modules/Tests/CoreTests`. If it
-needs an archive fixture, build the archive in the test at runtime. Do not
-commit archive files — fixtures live in a separate repository, and archives
-easily carry third-party or personal content. If a fixture cannot be generated,
-describe the reproduction in the PR and leave it to the maintainer.
+**Bug fixes start with a failing test** in `Modules/Tests/CoreTests`.
+
+**Archive fixtures never go in this repository.** They live in the
+`MacPacker-TestArchives` submodule, a permanent regression corpus: each archive
+is a real file from a real tool, kept so a later engine change cannot silently
+break the quirk it covers. Do not synthesize an equivalent archive in the test —
+the quirk is usually exactly what a synthetic archive lacks.
+
+Adding one means landing the archive in MacPacker-TestArchives first, then
+bumping the submodule pointer here. Outside contributors cannot push there:
+attach the archive to the PR and let the maintainer place it. Never contribute
+an archive containing third-party or personal content.
 
 **Link the issue when one exists** in the PR body (`Closes #123`). Do not open
 an issue solely to have something to link.
@@ -61,10 +68,11 @@ User-visible changes need an entry in `Config/products/macpacker.json` under
 }
 ```
 
-**Do not decide version numbers.** Versions are listed newest first; add the
-item to the first block. If that version is already tagged (`git tag --list
-"v0.20.0"` returns something — beta tags do not count), say so in the PR and
-leave the new block to the maintainer.
+**Do not decide version numbers.** Versions are listed newest first. Add the
+item to the first block, unless that version is already tagged (`git tag --list
+"v0.20.0"` returns something — beta tags do not count). If it is, the next
+number is the maintainer's call: still write the full item, but put it in the PR
+body instead of the file, and say the release needs a new block.
 
 **`issues` always points at something.** Prefer the issue, so readers land on
 the report in a user's own words; otherwise use this PR's own number, which

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# Agent Guide
+
+Working instructions for AI coding agents in this repository. Humans: see
+[CONTRIBUTING.md](CONTRIBUTING.md) and [AI_CONTRIBUTING.md](AI_CONTRIBUTING.md).
+
+MacPacker is a sandboxed SwiftUI archive manager for macOS, with a Finder
+extension and a Quick Look extension. Most logic lives in the `Modules` Swift
+package; the Xcode project is the app shell.
+
+## Build & test
+
+```bash
+git submodule update --init --recursive   # required — the build fails without it
+swift test --package-path Modules         # unit tests (what CI runs on every PR)
+open MacPacker.xcodeproj                  # app build, Cmd+R
+```
+
+The `MacPacker.xctestplan` scheme runs the XCUITest target only; it is not part
+of PR CI.
+
+## Rules
+
+**Never set the version.** `Config/Version.xcconfig` stays at
+`MARKETING_VERSION = 0.0.0-dev`. That is the permanent local value, not a
+placeholder. Never edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION` in any
+branch for any reason, including when a change is "for version X". Naming a
+target version in a changelog entry or commit message is fine; changing the
+build setting is not. CI sets the real version at tag time.
+
+**Vendored dependencies are pristine submodules.** `Modules/Sources/CSevenZip/vendor/7zip`
+and friends track upstream unmodified. Fixes belong in the bridging layer or in
+MacPacker code, never in vendored sources.
+
+**Localization goes through POEditor, not by hand.** Do not add translations to
+`Localizable.xcstrings` directly — add the English key and leave the rest.
+See [CONTRIBUTING.md](CONTRIBUTING.md#localization). The changelog is the one
+exception (below).
+
+**Bug fixes start with a failing test.** Reproduce in a test in
+`Modules/Tests/CoreTests`, then fix. Archive fixtures live in the
+`MacPacker-TestArchives` submodule.
+
+**Link the issue, if there is one.** When the change addresses a reported issue,
+reference it in the PR body (`Closes #123`). The changelog entry's `issues` field
+is always filled — see below. No need to open an issue just to have one to link.
+
+## Changelog
+
+User-visible changes need an entry in `Config/products/macpacker.json` under
+`changelog.versions[]`. There is no separate CHANGELOG file. CI validates at tag
+time that the released version exists here.
+
+```jsonc
+{
+  "version": "0.20.0",
+  "items": [
+    {
+      "type": "fix",              // feat | fix | core | lang
+      "title": { "en": "…", "de": "…", /* all 14 languages */ },
+      "issues": ["170"]           // issue number, or this PR's own number
+    }
+  ]
+}
+```
+
+Add to the topmost unreleased `version` block, or open a new one if the last
+block is already released.
+
+**`issues` always points at something.** Prefer the issue the change addresses —
+readers land on the report in a user's own words. If there is no issue, use this
+pull request's own number instead; GitHub resolves issue and PR numbers from the
+same namespace, so either link works.
+
+That means the number does not exist until the PR is opened. Sequence:
+
+1. Write the entry with everything except `issues`, and open the PR.
+2. Add `"issues": ["<pr-number>"]` and push again.
+
+Never guess a number. An invented one resolves to somebody else's issue. Leave
+the field out until the real number exists, and never write an empty `[]`.
+
+**Writing the title.** Customer-facing and short. Describe what changed for the
+user, not how it was implemented. Aim for under ~50 characters.
+
+- Yes: `Extract-to-folder ignores extension case`
+- No: `Normalize archive extension casing in ExtractDestinationResolver`
+
+**Translations.** Fill in all 14 languages: `en`, `de`, `es-MX`, `fa`, `fr`,
+`it`, `ja`, `ko`, `nl`, `pl`, `pt-BR`, `ru`, `uk`, `zh-Hans`. Translate the
+meaning for a user of that language, not the English wording literally. Keep
+each one roughly as short as the English. Format names (`zip`, `7z`, `apk`),
+`MacPacker`, and macOS feature names (`Finder`, `Quick Look`) stay untranslated.
+
+Get the English wording approved before writing out all 14 languages.
+
+## Conventions
+
+- Commit and PR titles: `feat:`, `fix:`, `core:`, `lang:`, `docs:`, `ci:`,
+  `refactor:` — same set as the changelog `type` field.
+- Do not add `Co-Authored-By` trailers for AI tools.
+- Do not commit `Config/SigningOverride.xcconfig` (gitignored, local only).

--- a/AI_CONTRIBUTING.md
+++ b/AI_CONTRIBUTING.md
@@ -24,15 +24,14 @@ All AI-assisted contributions require manual verification. Contributions without
 - For visual/UI changes: include before/after screenshots.
 - For core, logging, build, or scripting changes: include terminal output, logs, or passing test results.
 
-## Never Set the Version
+## Point Your Agent at AGENTS.md
 
-`Config/Version.xcconfig` stays at `MARKETING_VERSION = 0.0.0-dev` locally. That
-is not a placeholder waiting to be filled in — it is the permanent local value.
-The release version comes from CI at tag time.
+[AGENTS.md](AGENTS.md) holds the repository rules an agent has to follow while
+writing code — build and test commands, the changelog entry every user-visible
+change needs, and the settings it must never touch. Most agents load it (or the
+`CLAUDE.md` symlink) automatically; if yours does not, point it there yourself.
 
-Never edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION`, in any branch, for
-any reason, including when a change is "for version X". Naming the target version
-in a changelog entry or commit message is fine; changing the build setting is not.
+Following those rules is the contributor's responsibility, not the agent's.
 
 ## Why These Rules Exist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,11 @@
+# Pull Requests
+
+Small fixes: just open a pull request. For larger changes, open an issue first so we can discuss the approach before you spend time on it — MacPacker is still early and some breaking changes are ahead.
+
+If your PR addresses an existing issue, reference it in the description (`Closes #123`).
+
+[AGENTS.md](AGENTS.md) documents how to build and test the project, and the repository rules that apply to every change (changelog entries, vendored dependencies, versioning). Worth reading before the first PR, whether or not you use an AI tool.
+
 # AI
 
 MacPacker accepts AI-assisted contributions. Pull requests where AI is the primary author must follow the [AI Contribution Guidelines](AI_CONTRIBUTING.md): disclose AI involvement, open the PR from a human account, and include verification evidence that the change works. 
@@ -6,11 +14,7 @@ Using AI as a coding buddy for minor edits and completions, where you are clearl
 
 # Localization
 
-Localization (translation of all strings to specific languages) is done using [POEditor](poeditor.com).
-
-## Update Language
-
-- 
+Localization (translation of all strings to specific languages) is done using [POEditor](poeditor.com). Add new strings to `Localizable.xcstrings` in English only — the other languages come back from POEditor.
 
 ## Push new texts for translation
 

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -53,7 +53,10 @@
               "es-MX": "Compatibilidad con jar, aar y apk",
               "ko": "jar, aar, apk 지원",
               "nl": "Ondersteuning voor jar, aar en apk"
-            }
+            },
+            "issues": [
+              "162"
+            ]
           },
           {
             "type": "fix",
@@ -95,7 +98,9 @@
               "ko": "폴더로 압축 풀기가 분할 접미사를 제거",
               "nl": "Uitpakken naar map verwijdert het volumesuffix"
             },
-            "issues": []
+            "issues": [
+              "171"
+            ]
           },
           {
             "type": "fix",


### PR DESCRIPTION
## What & why

The process rules for this repository lived in the maintainer's head rather than
in the repository: nothing told a contributor — human or agent — that a
changelog entry belongs in `Config/products/macpacker.json`, that
`Config/Version.xcconfig` is never edited, or that archive fixtures go to
`MacPacker-TestArchives` first. There was also no agent entry point at all, so
`AI_CONTRIBUTING.md` was only ever read by the maintainer reviewing a pull
request, never by the tool writing the code.

This adds that missing layer and the GitHub templates around it.

- **`AGENTS.md`** (+ a `CLAUDE.md` symlink, so Claude Code, Codex and Cursor all
  pick it up): build and test commands, and the rules that actually bite —
  never set the version, vendored submodules stay pristine, build before
  committing a string catalog, fixtures land in the fixture repository first,
  and how a changelog entry is written.
- **`.github/PULL_REQUEST_TEMPLATE.md`**: asks for the verification evidence
  `AI_CONTRIBUTING.md` already required but had no mechanism to collect.
- **`.github/workflows/guard-version.yml`**: fails a pull request that edits
  `Config/Version.xcconfig`, so this is enforced rather than requested.
- **`.github/ISSUE_TEMPLATE/`**: adds a feature request template, and a
  `config.yml` that routes translations to POEditor and open questions to
  Discussions instead of the issue tracker.
- **`AI_CONTRIBUTING.md`** keeps policy and hands the mechanics to `AGENTS.md`.
  **`CONTRIBUTING.md`** documents the pull request flow and loses an empty
  section.
- **`Config/products/macpacker.json`**: fills the `issues` field on the two
  unreleased 0.20.0 entries that lacked it.

## How it was verified

Every factual claim in `AGENTS.md` was checked against the repository rather
than assumed:

- `swift package --package-path Modules describe` → package `Modules`, test
  target `CoreTests`, confirming the documented test command.
- `SWIFT_EMIT_LOC_STRINGS = YES` on the app targets, and the string catalog
  shows 4 freshly extracted keys with no localizations against 129 carrying an
  `en` value from POEditor — confirming that the literal is its own fallback and
  that no translation, English included, is written by hand.
- The changelog and `MacPacker/Localizable.xcstrings` use an identical set of 14
  languages, so `AGENTS.md` refers to "every language already in the file"
  rather than a fixed list that would rot when a language is added.
- `git tag --list` returns `v0.20.0-beta.6` but no bare `v0.20.0`, which is why
  the released-version check is an exact tag match and excludes beta tags.
- `.github/workflows/guard-version.yml` parses, with the trigger scoped to
  `Config/Version.xcconfig` and the job skipped for `OWNER`.
- `Config/products/macpacker.json` still parses after the edit; the 0.20.0 block
  has all 6 items carrying `issues`, and the language count per item is
  unchanged at 14.

Documentation and configuration only — no application code changes, so there is
nothing to screenshot.

## Notes

- `guard-version.yml` must **not** be configured as a required status check. The
  `paths:` filter means it does not report on most pull requests, and a required
  check that never reports blocks merging. There is a comment to that effect in
  the file.
- No changelog entry for this pull request: it changes no user-visible
  behaviour. Flagging rather than deciding, since the checklist deliberately no
  longer offers a "no user-visible change" opt-out.
- The `issues` field was completed only for the unreleased 0.20.0 block. It is a
  recent addition — 27 of 119 items carry it — so filling in older versions
  would reconstruct history rather than enforce the rule going forward.

## Checklist

- [x] Verification evidence is included above
- [x] Changelog entry added to `Config/products/macpacker.json` — see Notes
- [x] AI involvement disclosed, if AI was the primary author — see [AI_CONTRIBUTING.md](../AI_CONTRIBUTING.md)

AI disclosure: written by Claude Code with the maintainer directing scope and
correcting the rules through review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added clearer contribution guidance covering issues, pull requests, testing, localization, changelog updates, and project conventions.
  - Added feature-request and pull-request templates to help capture goals, verification details, supporting evidence, and context.
  - Added contact links for translation, documentation, and general questions.

- **Chores**
  - Added automated checks to protect development version settings.
  - Updated changelog entries with references to related fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->