### PR TITLE
fix: stream and cancel Quick Look archive scans

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -37,6 +37,28 @@
         "version": "0.20.0",
         "items": [
           {
+            "type": "fix",
+            "title": {
+              "en": "Closing Quick Look stops tar.xz scans",
+              "zh-Hans": "关闭 Quick Look 后停止扫描 tar.xz",
+              "fr": "Fermer Quick Look arrête l’analyse des tar.xz",
+              "de": "Schließen von Quick Look stoppt tar.xz-Scans",
+              "it": "Chiudere Quick Look interrompe la scansione tar.xz",
+              "ja": "Quick Look を閉じると tar.xz のスキャンを停止",
+              "fa": "بستن Quick Look پویش tar.xz را متوقف می‌کند",
+              "pl": "Zamknięcie Quick Look zatrzymuje skanowanie tar.xz",
+              "pt-BR": "Fechar o Quick Look interrompe a leitura de tar.xz",
+              "ru": "Закрытие Quick Look останавливает сканирование tar.xz",
+              "uk": "Закриття Quick Look зупиняє сканування tar.xz",
+              "es-MX": "Cerrar Quick Look detiene el análisis de tar.xz",
+              "ko": "Quick Look을 닫으면 tar.xz 스캔 중지",
+              "nl": "Quick Look sluiten stopt tar.xz-scans"
+            },
+            "issues": [
+              "180"
+            ]
+          },
+          {
             "type": "feat",
             "title": {
               "en": "jar, aar, and apk support",

--- a/MacPacker/Features/Debug/QuickLookHarnessWindowController.swift
+++ b/MacPacker/Features/Debug/QuickLookHarnessWindowController.swift
@@ -59,6 +59,7 @@ final class QuickLookHarnessWindowController: NSWindowController, NSToolbarDeleg
     }
 
     func windowWillClose(_ notification: Notification) {
+        previewController.cancelPreviewLoad()
         Self.retained = nil
     }
 
@@ -83,7 +84,7 @@ final class QuickLookHarnessWindowController: NSWindowController, NSToolbarDeleg
 
     private func load(_ url: URL) {
         window?.title = "Quick Look Harness — \(url.lastPathComponent)"
-        Task { try? await previewController.loadPreview(of: url) }
+        previewController.beginLoadingPreview(of: url)
     }
 
     // MARK: - NSToolbarDelegate

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -439,6 +439,8 @@ let package = Package(
             name: "CoreTests",
             dependencies: [
                 "Core",
+                "ArchivePreviewUI",
+                "Swift7zip",
                 .product(name: "tb", package: "TailBeatKit")
             ],
             resources: [

--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewLoader.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewLoader.swift
@@ -6,6 +6,29 @@
 import AppKit
 import Core
 
+/// A read-only selector for the engines that are safe inside Quick Look.
+///
+/// Do not express these pins through `ArchiveEngineConfigStore`: automatic
+/// selection intentionally ignores stored overrides, and writing them also
+/// leaks preview-only choices into the in-app debug harness's user settings.
+private struct ArchivePreviewEngineSelector: ArchiveEngineSelectorProtocol {
+    let base: ArchiveEngineSelector
+    let pinned: [String: ArchiveEngineType]
+
+    func engine(for id: String) -> ArchiveEngine? {
+        guard let type = pinned[id] else { return base.engine(for: id) }
+        return base.engine(for: type)
+    }
+
+    func engine(for type: ArchiveEngineType) -> ArchiveEngine {
+        base.engine(for: type)
+    }
+
+    func engineType(for id: String) -> ArchiveEngineType? {
+        pinned[id] ?? base.engineType(for: id)
+    }
+}
+
 /// Builds a fully-configured `ArchiveState` for previewing an archive.
 ///
 /// QuickLook extensions can't spawn subprocesses, so every format is pinned to a
@@ -18,31 +41,39 @@ enum ArchivePreviewLoader {
         let catalog = ArchiveTypeCatalog()
         let configStore = ArchiveEngineConfigStore(catalog: catalog)
 
-        // NOTE: 7-Zip now runs in-process (Swift7zip, no subprocess), so the
-        // preview could use the native `.7zip` engine instead of pinning these
-        // to `.xad`. Switching them over is tracked as a separate follow-up.
-        configStore.setSelectedEngine(.xad, for: "7zip")
-        configStore.setSelectedEngine(.xad, for: "bzip2")
-        configStore.setSelectedEngine(.xad, for: "cab")
-        configStore.setSelectedEngine(.xad, for: "cpio")
-        configStore.setSelectedEngine(.xad, for: "gzip")
-        configStore.setSelectedEngine(.xad, for: "iso")
-        configStore.setSelectedEngine(.xad, for: "lha")
-        configStore.setSelectedEngine(.swc, for: "lz4")
-        configStore.setSelectedEngine(.xad, for: "lzx")
-        configStore.setSelectedEngine(.xad, for: "rar")
-        configStore.setSelectedEngine(.xad, for: "rpm")
-        configStore.setSelectedEngine(.xad, for: "sea")
-        configStore.setSelectedEngine(.xad, for: "sit")
-        configStore.setSelectedEngine(.xad, for: "sitx")
-        configStore.setSelectedEngine(.xad, for: "tar")
-        configStore.setSelectedEngine(.xad, for: "xar")
-        configStore.setSelectedEngine(.xad, for: "xz")
-        configStore.setSelectedEngine(.xad, for: "z")
-        configStore.setSelectedEngine(.xad, for: "zip")
-        configStore.setSelectedEngine(.xad, for: "zipx")
-
-        let selector = ArchiveEngineSelector(catalog: catalog, configStore: configStore)
-        return ArchiveState(catalog: catalog, engineSelector: selector)
+        // tar.xz previewing opts into 7-Zip's nested-stream path so it can scan
+        // the inner tar without staging it or allocating 7-Zip's whole-XZ-block
+        // seek cache. Staged XAD compounds remain pinned below; ArchiveLoader
+        // makes those cancellable through their extraction progress callback.
+        let selector = ArchivePreviewEngineSelector(
+            base: ArchiveEngineSelector(catalog: catalog, configStore: configStore),
+            pinned: [
+                "7zip": .xad,
+                "bzip2": .xad,
+                "cab": .xad,
+                "cpio": .xad,
+                "gzip": .xad,
+                "iso": .xad,
+                "lha": .xad,
+                "lz4": .swc,
+                "lzx": .xad,
+                "rar": .xad,
+                "rpm": .xad,
+                "sea": .xad,
+                "sit": .xad,
+                "sitx": .xad,
+                "tar": .xad,
+                "xar": .xad,
+                "xz": .`7zip`,
+                "z": .xad,
+                "zip": .xad,
+                "zipx": .xad
+            ]
+        )
+        return ArchiveState(
+            catalog: catalog,
+            engineSelector: selector,
+            compoundLoadingStrategy: .streamed
+        )
     }
 }

--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
@@ -15,6 +15,8 @@ import Core
 /// running the main app.
 public final class ArchivePreviewViewController: NSViewController {
     private let contentViewController = ContentViewController()
+    private var loadTask: Task<Void, Never>?
+    private var currentState: ArchiveState?
 
     private lazy var messageLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")
@@ -60,6 +62,30 @@ public final class ArchivePreviewViewController: NSViewController {
         view = container
     }
 
+    /// Starts loading without holding up Quick Look's prepare callback. Once
+    /// the callback returns, Finder presents the view and sends its normal
+    /// disappearance lifecycle when the preview closes, which lets us cancel
+    /// a scan that is still running.
+    public func beginLoadingPreview(of url: URL) {
+        cancelPreviewLoad()
+        loadTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await loadPreview(of: url)
+            } catch is CancellationError {
+                // Closing or replacing a preview is an expected cancellation.
+            } catch {
+                showMessage("Couldn’t read this archive.\n\(error.localizedDescription)")
+            }
+        }
+    }
+
+    public func cancelPreviewLoad() {
+        loadTask?.cancel()
+        loadTask = nil
+        currentState?.cancelCurrentOperation()
+    }
+
     /// Loads `url` as an archive and shows its contents.
     ///
     /// Awaits the full load (`ArchiveState.openTask`) before returning so the
@@ -78,8 +104,11 @@ public final class ArchivePreviewViewController: NSViewController {
         defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
 
         let state = ArchivePreviewLoader.makeState()
+        currentState = state
         state.open(url: url)
         try await state.openTask?.value
+        try Task.checkCancellation()
+        guard currentState === state else { throw CancellationError() }
 
         // Diagnostics: NSLog always surfaces in Console/Xcode (the appex doesn't
         // call tb.start(), so tb logs don't reach the unified log).

--- a/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
+++ b/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
@@ -10,6 +10,11 @@ extern "C" {
 // Not thread-safe -- must only be used from the thread that called sz_open().
 typedef void* SZArchiveRef;
 
+/// Progress reported by 7-Zip while opening or extracting an archive.
+/// Return false to abort at the next callback.
+typedef bool (*sz_progress_callback)(uint64_t completed, uint64_t total,
+                                     void *context);
+
 // --- Lifecycle ---
 
 /// Open an archive at the given filesystem path.
@@ -18,6 +23,9 @@ typedef void* SZArchiveRef;
 ///                  Formats that encrypt their header (7z -mhe=on, RAR -hp)
 ///                  cannot be listed without it. Also pre-sets the extraction
 ///                  password, so sz_set_password() is not needed afterwards.
+/// @param drill_single_stream  If true, a single stream exposed by a compressor
+///                  such as xz is probed as another archive. Keep false for the
+///                  normal one-layer archive semantics.
 /// @param needs_password_out  If non-NULL, set to true when a handler asked for
 ///                  a password during the open. Meaningful only on failure:
 ///                  it tells the caller to prompt and retry rather than report
@@ -25,7 +33,10 @@ typedef void* SZArchiveRef;
 /// Returns NULL on failure. On failure, *error_out (if non-NULL) is set to a
 /// malloc'd UTF-8 error string -- caller must free() it.
 SZArchiveRef sz_open(const char *path, const char *password,
-                     bool *needs_password_out, char **error_out);
+                     sz_progress_callback progress, void *progress_context,
+                     bool drill_single_stream,
+                     bool *needs_password_out, bool *cancelled_out,
+                     char **error_out);
 
 /// Release all resources. Must be called exactly once per successful sz_open().
 void sz_close(SZArchiveRef archive);
@@ -69,8 +80,6 @@ void sz_set_password(SZArchiveRef archive, const char *password);
 /// extraction — it stops at the next progress checkpoint and the extract
 /// call returns SZ_EXTRACT_ABORTED.
 /// Called on the extraction thread.
-typedef bool (*sz_progress_callback)(uint64_t completed, uint64_t total,
-                                     void *context);
 
 /// Extract call result codes.
 #define SZ_EXTRACT_OK 0
@@ -109,6 +118,10 @@ int sz_extract_all(SZArchiveRef archive, const char *dest_dir,
 /// When true, SZEntry::parent_index and SZEntry::name are populated from the
 /// archive's native tree structure rather than derived from path strings.
 bool sz_is_tree(SZArchiveRef archive);
+
+/// Returns true when a compound archive was opened through the bounded-memory
+/// pull stream rather than 7-Zip's whole-XZ-block seek cache.
+bool sz_uses_bounded_compound_stream(SZArchiveRef archive);
 
 // --- Utilities ---
 

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -6,6 +6,7 @@
 #include "include/sevenzip_bridge.h"
 
 #include <cstdlib>
+#include <cctype>
 #include <cstring>
 #include <string>
 #include <deque>
@@ -29,11 +30,15 @@
 #include "Windows/PropVariantConv.h"
 
 #include "7zip/Common/FileStreams.h"
+#include "7zip/Common/CWrappers.h"
 #include "7zip/Common/StreamUtils.h"
 
 #include "7zip/Archive/IArchive.h"
 #include "7zip/IPassword.h"
 #include "7zip/MyVersion.h"   // MY_VERSION -- tracks the vendored submodule
+
+#include "C/Alloc.h"
+#include "C/Xz.h"
 
 static const GUID IID_IInArchive_Local = {
   0x23170F69, 0x40C1, 0x278A,
@@ -116,6 +121,7 @@ struct SZArchiveHandle {
     UInt32 numItems;
     std::string password;
     bool hasPassword = false;
+    bool usesBoundedCompoundStream = false;
 
     const char* storeString(const std::string &s) {
         storedStrings.push_back(s);
@@ -141,6 +147,17 @@ class COpenVolumeCallback final :
     FString _fileName;
     std::string _password;
     bool _hasPassword = false;
+    sz_progress_callback _progress = nullptr;
+    void *_progressContext = nullptr;
+    UInt64 _total = 0;
+
+    HRESULT Report(UInt64 completed) {
+        if (_progress && !_progress(completed, _total, _progressContext)) {
+            aborted = true;
+            return E_ABORT;
+        }
+        return S_OK;
+    }
 
 public:
     /// Set when a handler asked for a password while opening. Formats that
@@ -148,6 +165,16 @@ public:
     /// without one, and a failed open is otherwise indistinguishable from
     /// "not an archive".
     bool passwordRequested = false;
+    bool aborted = false;
+
+    void SetProgress(sz_progress_callback progress, void *context) {
+        _progress = progress;
+        _progressContext = context;
+    }
+
+    HRESULT CheckCancellation(UInt64 completed) {
+        return Report(completed);
+    }
 
     void SetPassword(const char *password) {
         if (password) {
@@ -209,9 +236,237 @@ public:
         return S_OK;
     }
 
-    Z7_COM7F_IMF(SetTotal(const UInt64 *, const UInt64 *)) { return S_OK; }
-    Z7_COM7F_IMF(SetCompleted(const UInt64 *, const UInt64 *)) { return S_OK; }
+    Z7_COM7F_IMF(SetTotal(const UInt64 *files, const UInt64 *bytes)) {
+        _total = bytes ? *bytes : (files ? *files : 0);
+        return Report(0);
+    }
+
+    Z7_COM7F_IMF(SetCompleted(const UInt64 *files, const UInt64 *bytes)) {
+        UInt64 completed = bytes ? *bytes : (files ? *files : 0);
+        return Report(completed);
+    }
 };
+
+// 7-Zip's archive-open callbacks are not invoked while a decoder is servicing
+// a seekable sub-stream. In particular, finding the next tar header can make
+// the xz handler decode a very large block without reporting open progress.
+// Wrapping the original compressed input gives us cancellation checkpoints at
+// the decoder's regular input reads without modifying vendored 7-Zip code.
+class CCancellableInStream final :
+    public IInStream,
+    public CMyUnknownImp
+{
+    Z7_IFACES_IMP_UNK_2(ISequentialInStream, IInStream)
+
+    CMyComPtr<IInStream> _stream;
+    CMyComPtr<IArchiveOpenCallback> _callbackRef;
+    COpenVolumeCallback *_callback;
+    UInt64 _position = 0;
+
+public:
+    CCancellableInStream(
+        IInStream *stream,
+        COpenVolumeCallback *callback)
+        : _stream(stream), _callbackRef(callback), _callback(callback) {}
+};
+
+Z7_COM7F_IMF(CCancellableInStream::Read(
+    void *data, UInt32 size, UInt32 *processedSize))
+{
+    if (processedSize)
+        *processedSize = 0;
+    RINOK(_callback->CheckCancellation(_position))
+
+    UInt32 processed = 0;
+    const HRESULT result = _stream->Read(data, size, &processed);
+    _position += processed;
+    if (processedSize)
+        *processedSize = processed;
+    if (result != S_OK)
+        return result;
+    return _callback->CheckCancellation(_position);
+}
+
+Z7_COM7F_IMF(CCancellableInStream::Seek(
+    Int64 offset, UInt32 seekOrigin, UInt64 *newPosition))
+{
+    RINOK(_callback->CheckCancellation(_position))
+    UInt64 position = 0;
+    const HRESULT result = _stream->Seek(offset, seekOrigin, &position);
+    if (result != S_OK)
+        return result;
+    _position = position;
+    if (newPosition)
+        *newPosition = position;
+    return _callback->CheckCancellation(_position);
+}
+
+// 7-Zip's XZ IInArchiveGetStream implementation allocates a seek cache equal
+// to the largest *uncompressed* XZ block. Archives made with multi-gigabyte
+// blocks therefore turn a nominally streamed Quick Look scan into a 4 GB
+// allocation. This pull stream instead decodes only as the tar handler reads.
+// It supports arbitrary seeks without a block cache: forward seeks discard
+// decoded bytes, and backward seeks restart the decoder from the beginning.
+// Tar listing is naturally forward-only; restarting mainly keeps later item
+// extraction compatible with the existing seek-based tar handler.
+class CBoundedXzInStream final :
+    public IInStream,
+    public CMyUnknownImp
+{
+    Z7_IFACES_IMP_UNK_2(ISequentialInStream, IInStream)
+
+    static constexpr size_t kInputBufferSize = 1 << 16;
+    // Tar seeks over file bodies rather than reading them. Decode skipped
+    // bytes in 1 MiB chunks to keep call overhead low while remaining bounded.
+    static constexpr size_t kSkipBufferSize = 1 << 20;
+
+    CMyComPtr<IInStream> _compressed;
+    CXzUnpacker _decoder;
+    std::vector<Byte> _input;
+    std::vector<Byte> _skip;
+    SizeT _inputPos = 0;
+    SizeT _inputSize = 0;
+    bool _sourceFinished = false;
+    UInt64 _decodedPos = 0;
+    UInt64 _virtPos = 0;
+    UInt64 _size;
+
+    HRESULT ResetDecoder() {
+        UInt64 position = 0;
+        RINOK(_compressed->Seek(0, STREAM_SEEK_SET, &position))
+        if (position != 0)
+            return E_FAIL;
+        XzUnpacker_Init(&_decoder);
+        _inputPos = 0;
+        _inputSize = 0;
+        _sourceFinished = false;
+        _decodedPos = 0;
+        return S_OK;
+    }
+
+    HRESULT Decode(void *data, UInt32 size, UInt32 *processedSize) {
+        if (processedSize)
+            *processedSize = 0;
+        if (size == 0 || _decodedPos >= _size)
+            return S_OK;
+
+        const UInt64 remaining = _size - _decodedPos;
+        if ((UInt64)size > remaining)
+            size = (UInt32)remaining;
+
+        auto *output = static_cast<Byte *>(data);
+        UInt32 totalOut = 0;
+
+        while (totalOut < size) {
+            if (_inputPos == _inputSize && !_sourceFinished) {
+                _inputPos = 0;
+                _inputSize = 0;
+                UInt32 readSize = (UInt32)_input.size();
+                RINOK(_compressed->Read(_input.data(), readSize, &readSize))
+                _inputSize = readSize;
+                if (readSize == 0)
+                    _sourceFinished = true;
+            }
+
+            SizeT inProcessed = _inputSize - _inputPos;
+            SizeT outProcessed = size - totalOut;
+            ECoderStatus status = CODER_STATUS_NOT_SPECIFIED;
+            const SRes result = XzUnpacker_Code(
+                &_decoder,
+                output + totalOut,
+                &outProcessed,
+                _input.data() + _inputPos,
+                &inProcessed,
+                _sourceFinished ? True : False,
+                CODER_FINISH_ANY,
+                &status);
+
+            _inputPos += inProcessed;
+            totalOut += (UInt32)outProcessed;
+            _decodedPos += outProcessed;
+
+            if (result != SZ_OK)
+                return SResToHRESULT(result);
+
+            if (inProcessed == 0 && outProcessed == 0) {
+                if (_sourceFinished) {
+                    if (!XzUnpacker_IsStreamWasFinished(&_decoder))
+                        return E_FAIL;
+                    break;
+                }
+                if (_inputPos != _inputSize)
+                    return E_FAIL;
+            }
+        }
+
+        if (processedSize)
+            *processedSize = totalOut;
+        return S_OK;
+    }
+
+    HRESULT AlignDecoderToVirtualPosition() {
+        if (_virtPos < _decodedPos)
+            RINOK(ResetDecoder())
+
+        while (_decodedPos < _virtPos) {
+            const UInt64 remaining = _virtPos - _decodedPos;
+            const UInt32 request = (UInt32)(
+                remaining < _skip.size() ? remaining : _skip.size());
+            UInt32 processed = 0;
+            RINOK(Decode(_skip.data(), request, &processed))
+            if (processed == 0)
+                return E_FAIL;
+        }
+        return S_OK;
+    }
+
+public:
+    CBoundedXzInStream(IInStream *compressed, UInt64 size)
+        : _compressed(compressed),
+          _input(kInputBufferSize),
+          _skip(kSkipBufferSize),
+          _size(size) {
+        XzUnpacker_Construct(&_decoder, &g_Alloc);
+    }
+
+    ~CBoundedXzInStream() {
+        XzUnpacker_Free(&_decoder);
+    }
+
+    HRESULT Init() {
+        return ResetDecoder();
+    }
+};
+
+Z7_COM7F_IMF(CBoundedXzInStream::Read(
+    void *data, UInt32 size, UInt32 *processedSize))
+{
+    RINOK(AlignDecoderToVirtualPosition())
+    UInt32 processed = 0;
+    const HRESULT result = Decode(data, size, &processed);
+    _virtPos += processed;
+    if (processedSize)
+        *processedSize = processed;
+    return result;
+}
+
+Z7_COM7F_IMF(CBoundedXzInStream::Seek(
+    Int64 offset, UInt32 seekOrigin, UInt64 *newPosition))
+{
+    __int128 target = offset;
+    switch (seekOrigin) {
+        case STREAM_SEEK_SET: break;
+        case STREAM_SEEK_CUR: target += _virtPos; break;
+        case STREAM_SEEK_END: target += _size; break;
+        default: return STG_E_INVALIDFUNCTION;
+    }
+    if (target < 0 || target > _size)
+        return HRESULT_WIN32_ERROR_NEGATIVE_SEEK;
+    _virtPos = (UInt64)target;
+    if (newPosition)
+        *newPosition = _virtPos;
+    return S_OK;
+}
 
 // --- Format probing helper ---
 
@@ -220,7 +475,8 @@ public:
 static HRESULT tryOpenStream(
     IInStream *stream,
     CMyComPtr<IInArchive> &archiveOut,
-    IArchiveOpenCallback *callback = nullptr)
+    IArchiveOpenCallback *callback = nullptr,
+    const bool *aborted = nullptr)
 {
     UInt32 numFormats = 0;
     GetNumberOfFormats(&numFormats);
@@ -240,7 +496,9 @@ static HRESULT tryOpenStream(
             continue;
 
         UInt64 newPos;
-        stream->Seek(0, STREAM_SEEK_SET, &newPos);
+        const HRESULT seekHr = stream->Seek(0, STREAM_SEEK_SET, &newPos);
+        if (seekHr != S_OK)
+            return seekHr;
 
         UInt64 maxCheckStart = 1 << 22; // 4MB
         hr = archive->Open(stream, &maxCheckStart, callback);
@@ -249,8 +507,48 @@ static HRESULT tryOpenStream(
             return S_OK;
         }
         archive->Close();
+        if (aborted && *aborted)
+            return E_ABORT;
     }
     return S_FALSE;
+}
+
+/// Construct one registered archive handler by its canonical format name.
+/// The bounded XZ path knows its inner stream is tar, so using the tar handler
+/// directly avoids repeatedly rewinding and re-decoding data while probing
+/// every registered format.
+static HRESULT createArchiveByName(
+    const char *name,
+    CMyComPtr<IInArchive> &archiveOut)
+{
+    UInt32 numFormats = 0;
+    GetNumberOfFormats(&numFormats);
+    for (UInt32 i = 0; i < numFormats; i++) {
+        NWindows::NCOM::CPropVariant propName;
+        GetHandlerProperty2(i, NArchive::NHandlerPropID::kName, &propName);
+        if (PropVariantToUTF8(propName) != name)
+            continue;
+
+        NWindows::NCOM::CPropVariant propClassID;
+        GetHandlerProperty2(i, NArchive::NHandlerPropID::kClassID, &propClassID);
+        if (propClassID.vt != VT_BSTR || !propClassID.bstrVal)
+            return E_FAIL;
+
+        GUID classID;
+        memcpy(&classID, propClassID.bstrVal, sizeof(GUID));
+        return CreateArchiver(
+            &classID, &IID_IInArchive_Local, (void **)&archiveOut);
+    }
+    return S_FALSE;
+}
+
+static bool hasXzFileExtension(const char *path) {
+    if (!path) return false;
+    std::string lower(path);
+    for (char &c : lower)
+        c = (char)tolower((unsigned char)c);
+    return (lower.size() >= 3 && lower.compare(lower.size() - 3, 3, ".xz") == 0)
+        || (lower.size() >= 4 && lower.compare(lower.size() - 4, 4, ".txz") == 0);
 }
 
 // --- Minimal extract callback ---
@@ -552,8 +850,12 @@ static int finishExtract(CExtractCallback *callback, HRESULT hr, char **error_ou
 extern "C" {
 
 SZArchiveRef sz_open(const char *path, const char *password,
-                     bool *needs_password_out, char **error_out) {
+                     sz_progress_callback progress, void *progress_context,
+                     bool drill_single_stream,
+                     bool *needs_password_out, bool *cancelled_out,
+                     char **error_out) {
     if (needs_password_out) *needs_password_out = false;
+    if (cancelled_out) *cancelled_out = false;
     try {
         // Force 7-Zip to treat all narrow<->wide path conversions as UTF-8.
         // On macOS the filesystem encoding is always UTF-8, but 7-Zip's
@@ -571,7 +873,7 @@ SZArchiveRef sz_open(const char *path, const char *password,
 
         // Open the file stream
         auto *fileStreamSpec = new CInFileStream;
-        handle->fileStream = fileStreamSpec;
+        CMyComPtr<IInStream> rawFileStream = fileStreamSpec;
         FString fpath = us2fs(UString());
         {
             AString apath(path);
@@ -594,15 +896,30 @@ SZArchiveRef sz_open(const char *path, const char *password,
         CMyComPtr<IArchiveOpenCallback> volCallback = volCallbackSpec;
         volCallbackSpec->SetFilePath(fpath);
         volCallbackSpec->SetPassword(password);
+        volCallbackSpec->SetProgress(progress, progress_context);
+
+        if (progress) {
+            auto *cancellableStream = new CCancellableInStream(
+                rawFileStream, volCallbackSpec);
+            handle->fileStream = cancellableStream;
+        } else {
+            handle->fileStream = rawFileStream;
+        }
 
         // Try each registered format on the file stream
         CMyComPtr<IInArchive> firstArchive;
-        HRESULT hr = tryOpenStream(handle->fileStream, firstArchive, volCallback);
+        HRESULT hr = tryOpenStream(
+            handle->fileStream, firstArchive, volCallback,
+            &volCallbackSpec->aborted);
         if (hr != S_OK || !firstArchive) {
+            if (cancelled_out)
+                *cancelled_out = volCallbackSpec->aborted;
             if (needs_password_out)
                 *needs_password_out = volCallbackSpec->passwordRequested;
             if (error_out)
-                *error_out = strdup(volCallbackSpec->passwordRequested
+                *error_out = strdup(volCallbackSpec->aborted
+                    ? "Archive open cancelled"
+                    : volCallbackSpec->passwordRequested
                     ? "The archive header is encrypted"
                     : "No suitable archive format found");
             delete handle;
@@ -620,42 +937,115 @@ SZArchiveRef sz_open(const char *path, const char *password,
         for (int depth = 0; depth < kMaxNestingDepth; depth++) {
             IInArchive *currentArc = handle->levels.back().archive;
 
-            // Check if this archive signals a nested container
-            NWindows::NCOM::CPropVariant prop;
-            currentArc->GetArchiveProperty(kpidMainSubfile, &prop);
-            if (prop.vt != VT_UI4)
-                break;
-            UInt32 mainSubfile = prop.ulVal;
-
-            // Validate index
             UInt32 itemCount = 0;
             currentArc->GetNumberOfItems(&itemCount);
+
+            // Check if this archive signals a nested container. An opt-in
+            // streaming caller can also probe the sole stream exposed by a
+            // compressor such as xz, which does not set kpidMainSubfile.
+            NWindows::NCOM::CPropVariant prop;
+            currentArc->GetArchiveProperty(kpidMainSubfile, &prop);
+            UInt32 mainSubfile = 0;
+            if (prop.vt == VT_UI4)
+                mainSubfile = prop.ulVal;
+            else if (!drill_single_stream || itemCount != 1)
+                break;
+
+            // Validate index
             if (mainSubfile >= itemCount)
                 break;
 
-            // Get IInArchiveGetStream from current archive
-            CMyComPtr<IInArchiveGetStream> getStream;
-            if (currentArc->QueryInterface(
-                    IID_IInArchiveGetStream_Local,
-                    (void **)&getStream) != S_OK || !getStream)
-                break;
-
-            // Extract the sub-stream
-            CMyComPtr<ISequentialInStream> subSeqStream;
-            if (getStream->GetStream(mainSubfile, &subSeqStream) != S_OK
-                || !subSeqStream)
-                break;
-
-            // Need seekable IInStream for archive opening
             CMyComPtr<IInStream> subStream;
-            if (subSeqStream->QueryInterface(
-                    IID_IInStream_Local,
-                    (void **)&subStream) != S_OK || !subStream)
-                break;
+            bool boundedXzStream = false;
+
+            // Quick Look opts into single-stream drilling for tar.xz. Avoid
+            // XzHandler::GetStream here: it allocates the largest unpacked XZ
+            // block as a seek cache (4 GB for a common large-block archive).
+            if (drill_single_stream && depth == 0 && hasXzFileExtension(path)) {
+                NWindows::NCOM::CPropVariant sizeProp;
+                currentArc->GetProperty(mainSubfile, kpidSize, &sizeProp);
+                if (sizeProp.vt == VT_UI8) {
+                    auto *boundedSpec = new CBoundedXzInStream(
+                        handle->fileStream, sizeProp.uhVal.QuadPart);
+                    CMyComPtr<IInStream> boundedRef = boundedSpec;
+                    const HRESULT initHr = boundedSpec->Init();
+                    if (initHr != S_OK) {
+                        if (error_out)
+                            *error_out = strdup("Could not initialize bounded XZ stream");
+                        delete handle;
+                        return nullptr;
+                    }
+                    subStream = boundedRef;
+                    boundedXzStream = true;
+                }
+            }
+
+            if (!subStream) {
+                // Other nested formats keep 7-Zip's native seekable stream.
+                CMyComPtr<IInArchiveGetStream> getStream;
+                if (currentArc->QueryInterface(
+                        IID_IInArchiveGetStream_Local,
+                        (void **)&getStream) != S_OK || !getStream)
+                    break;
+
+                CMyComPtr<ISequentialInStream> subSeqStream;
+                if (getStream->GetStream(mainSubfile, &subSeqStream) != S_OK
+                    || !subSeqStream)
+                    break;
+
+                if (subSeqStream->QueryInterface(
+                        IID_IInStream_Local,
+                        (void **)&subStream) != S_OK || !subStream)
+                    break;
+            }
 
             // Try to open the sub-stream as a new archive
+            // Cancellation for native nested streams (notably SplitHandler's
+            // combined stream) must travel through the stream itself. Passing
+            // the outer volume callback into the inner handler changes how a
+            // numeric split ZIP is interpreted and makes it reopen the parts
+            // as volumes instead of reading the combined stream.
+            if (progress && !boundedXzStream) {
+                auto *cancellableSubStream = new CCancellableInStream(
+                    subStream, volCallbackSpec);
+                CMyComPtr<IInStream> cancellableSubStreamRef =
+                    cancellableSubStream;
+                subStream = cancellableSubStreamRef;
+            }
             CMyComPtr<IInArchive> innerArchive;
-            if (tryOpenStream(subStream, innerArchive) != S_OK)
+            IArchiveOpenCallback *innerCallback = boundedXzStream && progress
+                ? static_cast<IArchiveOpenCallback *>(volCallbackSpec)
+                : nullptr;
+            HRESULT innerHr;
+            if (boundedXzStream) {
+                innerHr = createArchiveByName("tar", innerArchive);
+                if (innerHr == S_OK && innerArchive) {
+                    UInt64 maxCheckStart = 1 << 22;
+                    innerHr = innerArchive->Open(
+                        subStream, &maxCheckStart, innerCallback);
+                }
+            } else {
+                innerHr = tryOpenStream(
+                    subStream, innerArchive, innerCallback,
+                    progress ? &volCallbackSpec->aborted : nullptr);
+            }
+            if (innerHr == E_ABORT && volCallbackSpec->aborted) {
+                if (cancelled_out) *cancelled_out = true;
+                if (error_out) *error_out = strdup("Archive open cancelled");
+                delete handle;
+                return nullptr;
+            }
+            // The streamed tar.xz path is selected only when the caller asked
+            // to drill into the known inner tar. Falling back to the outer xz
+            // after its decoder failed makes a damaged or truncated stream
+            // look like a successfully opened one-entry archive.
+            if (boundedXzStream && innerHr != S_OK) {
+                if (error_out)
+                    *error_out = strdup("Could not open inner tar stream");
+                delete handle;
+                return nullptr;
+            }
+            if (innerHr != S_OK)
                 break;
 
             // Push the new level
@@ -663,6 +1053,8 @@ SZArchiveRef sz_open(const char *path, const char *password,
             level.archive = innerArchive;
             level.stream = subStream;
             handle->levels.push_back(level);
+            if (boundedXzStream)
+                handle->usesBoundedCompoundStream = true;
         }
 
         // Entry count comes from the innermost archive
@@ -683,6 +1075,10 @@ SZArchiveRef sz_open(const char *path, const char *password,
                 && propIsTree.boolVal != VARIANT_FALSE);
         }
 
+        // The wrapper can outlive this call because archive handlers retain
+        // their input stream. The Swift callback context cannot, so turn the
+        // wrapper into a transparent pass-through once opening has finished.
+        volCallbackSpec->SetProgress(nullptr, nullptr);
         return static_cast<SZArchiveRef>(handle);
     } catch (...) {
         if (error_out)
@@ -949,9 +1345,13 @@ bool sz_is_tree(SZArchiveRef archive) {
     }
 }
 
+bool sz_uses_bounded_compound_stream(SZArchiveRef archive) {
+    if (!archive) return false;
+    return static_cast<SZArchiveHandle *>(archive)->usesBoundedCompoundStream;
+}
+
 const char* sz_version(void) {
     return MY_VERSION;
 }
 
 } // extern "C"
-

--- a/Modules/Sources/Core/ArchiveExtractor.swift
+++ b/Modules/Sources/Core/ArchiveExtractor.swift
@@ -189,6 +189,7 @@ final actor ArchiveExtractor {
         _ url: URL,
         archiveTypeId: String,
         to destination: URL,
+        requiresCompoundStream: Bool = false,
         onProgress: ArchiveExtractionProgress? = nil
     ) async throws {
         _ = destination.startAccessingSecurityScopedResource()
@@ -199,7 +200,20 @@ final actor ArchiveExtractor {
         }
 
         try await Sandbox.access(url: url) {
-            try await engine.extract(url, to: destination, passwordResolver: passwordResolver, onProgress: onProgress)
+            if requiresCompoundStream,
+               let streamingEngine = engine as? any CompoundArchiveStreamingEngine {
+                try await streamingEngine.extractCompoundArchive(
+                    url,
+                    to: destination,
+                    passwordResolver: passwordResolver,
+                    onProgress: onProgress)
+            } else {
+                try await engine.extract(
+                    url,
+                    to: destination,
+                    passwordResolver: passwordResolver,
+                    onProgress: onProgress)
+            }
         }
     }
 }

--- a/Modules/Sources/Core/ArchiveLoader.swift
+++ b/Modules/Sources/Core/ArchiveLoader.swift
@@ -14,6 +14,11 @@ import tb
 /// needs from a bug report, hence a real logger.
 private let log = tb.Logger(subsystem: "app.MacPacker", category: "loader")
 
+public enum CompoundArchiveLoadingStrategy: Sendable, Equatable {
+    case staged
+    case streamed
+}
+
 struct ArchiveLoaderLoadResult: Sendable {
     let type: ArchiveTypeDto
     let compositionType: CompositionTypeDto?
@@ -47,9 +52,12 @@ final actor ArchiveLoader {
     private let archiveEngineSelector: ArchiveEngineSelectorProtocol
     private let passwordResolver: ArchivePasswordResolver
     private let folderAccessResolver: ArchiveFolderAccessResolver
+    private let compoundLoadingStrategy: CompoundArchiveLoadingStrategy
+    private let tempDirectoryProvider: @Sendable () -> URL?
 
     private var entries: [UUID: ArchiveItem] = [:]
     private var engine: (any ArchiveEngine)?
+    private var loadCancelFlag: ExtractionCancelFlag?
     
     // status passthrough from the engine to the UI
     private var statusContinuation: AsyncStream<EngineStatus>.Continuation?
@@ -64,12 +72,18 @@ final actor ArchiveLoader {
         archiveTypeDetector: ArchiveTypeDetector,
         archiveEngineSelector: ArchiveEngineSelectorProtocol,
         passwordResolver: @escaping ArchivePasswordResolver,
-        folderAccessResolver: @escaping ArchiveFolderAccessResolver = { _ in true }
+        folderAccessResolver: @escaping ArchiveFolderAccessResolver = { _ in true },
+        compoundLoadingStrategy: CompoundArchiveLoadingStrategy = .staged,
+        tempDirectoryProvider: @escaping @Sendable () -> URL? = {
+            ArchiveSupportUtilities().createTempDirectory()?.url
+        }
     ) {
         self.archiveTypeDetector = archiveTypeDetector
         self.archiveEngineSelector = archiveEngineSelector
         self.passwordResolver = passwordResolver
         self.folderAccessResolver = folderAccessResolver
+        self.compoundLoadingStrategy = compoundLoadingStrategy
+        self.tempDirectoryProvider = tempDirectoryProvider
     }
 
     /// Whether the engine currently selected for `type` declares `capability`.
@@ -104,19 +118,44 @@ final actor ArchiveLoader {
     
     /// Cancels the loading progress
     public func cancel() async {
-        guard let engine else { return }
-        await engine.cancel()
+        loadCancelFlag?.cancel()
+        if let engine {
+            await engine.cancel()
+        }
     }
     
     /// Opens the given URL, assuming this is an archive. `loadEntries(url:)` will figure out the
     /// archive type, select the proper engine and then load all info like type info, entries,  ... . The hiarchy is built in a separate step.
     /// - Parameter url: The url to open
     public func loadEntries(url: URL) async throws -> ArchiveLoaderLoadResult {
+        let cancelFlag = ExtractionCancelFlag()
+        loadCancelFlag = cancelFlag
+        defer {
+            if loadCancelFlag === cancelFlag {
+                loadCancelFlag = nil
+            }
+        }
+
         // in case this is a compount `archiveUrl` will hold the extracted url
         var archiveUrl: URL? = url
         // for a split, the resolved first volume (adopted as the window identity)
         var firstVolumeURL: URL? = nil
         var compoundTempUrl: URL? = nil
+        var didTransferCompoundTempDirectory = false
+        var streamedCompound: (ArchiveEngineLoadResult, ArchiveEngineType?)? = nil
+        defer {
+            if let compoundTempUrl,
+               !didTransferCompoundTempDirectory {
+                do {
+                    try FileManager.default.removeItem(at: compoundTempUrl)
+                } catch {
+                    log.error("Could not remove failed compound staging directory", context: [
+                        "path": compoundTempUrl.path,
+                        "error": error.localizedDescription
+                    ])
+                }
+            }
+        }
         
         guard let detectorResult = archiveTypeDetector.detect(for: url, considerComposition: true) else {
             log.notice("No archive type detected", context: [
@@ -147,35 +186,58 @@ final actor ArchiveLoader {
             let forwardTaskCompound = forwardStatus(from: engine)
             defer { forwardTaskCompound.cancel() }
             
-            let archiveSupportUtilities = ArchiveSupportUtilities()
-            guard let temp = archiveSupportUtilities.createTempDirectory() else {
-                throw ArchiveError.extractionFailed("Could not create temporary directory")
-            }
-            compoundTempUrl = temp.url
-            yield(.processing(progress: nil, message: "temp dir created: \(temp.url)"))
-            
-            let loaderResult = try await Sandbox.access(url: url) {
-                try await engine.loadArchive(
-                    url: url,
-                    passwordResolver: passwordResolver
+            if compoundLoadingStrategy == .streamed,
+               let streamingEngine = engine as? any CompoundArchiveStreamingEngine {
+                let loaderResult = try await Sandbox.access(url: url) {
+                    try await streamingEngine.loadCompoundArchive(
+                        url: url,
+                        passwordResolver: passwordResolver
+                    )
+                }
+                try Task.checkCancellation()
+                guard !cancelFlag.isCancelled else { throw CancellationError() }
+                streamedCompound = (
+                    loaderResult,
+                    archiveEngineSelector.engineType(for: compound.components.last!)
                 )
+                yield(.processing(
+                    progress: nil,
+                    message: "inner archive streamed: \(loaderResult.items.count) entries"
+                ))
+            } else {
+                guard let tempURL = tempDirectoryProvider() else {
+                    throw ArchiveError.extractionFailed("Could not create temporary directory")
+                }
+                compoundTempUrl = tempURL
+                yield(.processing(progress: nil, message: "temp dir created: \(tempURL)"))
+
+                let loaderResult = try await Sandbox.access(url: url) {
+                    try await engine.loadArchive(
+                        url: url,
+                        passwordResolver: passwordResolver
+                    )
+                }
+                let entries = loaderResult.items
+                yield(.processing(progress: nil, message: "entries found: \(entries.count)"))
+
+                guard let entry = entries.values.first else {
+                    throw ArchiveError.extractionFailed("Extraction of \(url.lastPathComponent) resulted in no files")
+                }
+
+                let extractionResult = try await Sandbox.access(url: url) {
+                    try await engine.extract(
+                        items: [entry],
+                        from: url,
+                        to: tempURL,
+                        passwordResolver: passwordResolver,
+                        onProgress: { _, _ in !cancelFlag.isCancelled }
+                    )
+                }
+                try Task.checkCancellation()
+                guard !cancelFlag.isCancelled else { throw CancellationError() }
+                archiveUrl = try extractionResult.singleURL
+                yield(.processing(progress: nil, message: "entry extracted: \(String(describing: archiveUrl))"))
             }
-            let entries = loaderResult.items
-            yield(.processing(progress: nil, message: "entries found: \(entries.count)"))
-            
-            guard entries.count > 0 else {
-                throw ArchiveError.extractionFailed("Extraction of \(url.lastPathComponent) resulted in no files")
-            }
-            
-            archiveUrl = try await Sandbox.access(url: url) {
-                try await engine.extract(
-                    item: entries.first!.value,
-                    from: url,
-                    to: temp.url,
-                    passwordResolver: passwordResolver
-                )
-            }
-            yield(.processing(progress: nil, message: "entry extracted: \(String(describing: archiveUrl))"))
         } else if let split = detectorResult.split {
             // A split archive — same shape as the compound step: reduce any volume to
             // the real archive (its first segment). First the selected engine must be
@@ -199,41 +261,52 @@ final actor ArchiveLoader {
             throw ArchiveError.invalidArchive("Somehow we lost the archiveUrl while decompressing")
         }
         
-        // This is either the original archive, or the extracted archive from the
-        // compound
-        yield(.processing(progress: nil, message: "loading engine for: \(detectorResult.type.id)"))
-        guard let engine = archiveEngineSelector.engine(for: detectorResult.type.id) else {
-            yield(.processing(progress: nil, message: "invalid archive type: \(detectorResult.type.id)"))
-            log.error("No engine for archive type", context: ["type": detectorResult.type.id])
-            throw ArchiveError.invalidArchive(
-                "No engine is configured for \(detectorResult.type.name).")
+        let engineLoadResult: ArchiveEngineLoadResult
+        let usedEngine: ArchiveEngineType?
+
+        if let streamedCompound {
+            (engineLoadResult, usedEngine) = streamedCompound
+            log.info("Compound archive streamed", context: [
+                "file": url.lastPathComponent,
+                "type": detectorResult.type.id,
+                "engine": usedEngine?.configId ?? "unknown"
+            ])
+        } else {
+            // This is either the original archive, or the extracted archive from
+            // a staged compound.
+            yield(.processing(progress: nil, message: "loading engine for: \(detectorResult.type.id)"))
+            guard let engine = archiveEngineSelector.engine(for: detectorResult.type.id) else {
+                yield(.processing(progress: nil, message: "invalid archive type: \(detectorResult.type.id)"))
+                log.error("No engine for archive type", context: ["type": detectorResult.type.id])
+                throw ArchiveError.invalidArchive(
+                    "No engine is configured for \(detectorResult.type.name).")
+            }
+            self.engine = engine
+            // Which engine actually ran is the single most useful fact when an
+            // open fails — the same archive behaves differently on 7-Zip and XAD.
+            log.info("Engine selected", context: [
+                "file": url.lastPathComponent,
+                "type": detectorResult.type.id,
+                "engine": archiveEngineSelector.engineType(for: detectorResult.type.id)?.configId ?? "unknown"
+            ])
+            yield(.processing(progress: nil, message: "engine loaded: \(String(describing: type(of: engine))), for: \(detectorResult.type.id)"))
+
+            let forwardTask = forwardStatus(from: engine)
+            defer { forwardTask.cancel() }
+
+            (engineLoadResult, usedEngine) = try await loadArchiveWithFallback(
+                url: archiveUrl,
+                type: detectorResult.type,
+                selected: engine
+            )
         }
-        self.engine = engine
-        // Which engine actually ran is the single most useful fact when an open
-        // fails — the same archive behaves differently on 7-Zip and XAD.
-        log.info("Engine selected", context: [
-            "file": url.lastPathComponent,
-            "type": detectorResult.type.id,
-            "engine": archiveEngineSelector.engineType(for: detectorResult.type.id)?.configId ?? "unknown"
-        ])
-        yield(.processing(progress: nil, message: "engine loaded: \(String(describing: type(of: engine))), for: \(detectorResult.type.id)"))
-        
-        // build the status stream to forward the engine status to the UI
-        let forwardTask = forwardStatus(from: engine)
-        defer { forwardTask.cancel() }
-        
-        // set the entries
-        let (engineLoadResult, usedEngine) = try await loadArchiveWithFallback(
-            url: archiveUrl,
-            type: detectorResult.type,
-            selected: engine
-        )
         self.entries = engineLoadResult.items
         yield(.processing(progress: nil, message: "entries found: \(self.entries.count)"))
         
         // build the hierarchy
         let root = ArchiveItem(name: url.lastPathComponent, type: .root)
         root.set(url: archiveUrl, typeId: detectorResult.type.id)
+        root.requiresCompoundStream = streamedCompound != nil
         
         // Make sure top level entries are linked to the virtual root so they
         // are not orphaned
@@ -258,6 +331,7 @@ final actor ArchiveLoader {
             engineType: usedEngine,
             firstVolumeURL: firstVolumeURL
         )
+        didTransferCompoundTempDirectory = compoundTempUrl != nil
         return result
     }
     

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -117,6 +117,7 @@ public class ArchiveState: ObservableObject {
             : AutomaticEngineSelector(base: archiveEngineSelector, pinned: pinnedEngines)
     }
     private let archiveTypeDetector: ArchiveTypeDetector
+    private let compoundLoadingStrategy: CompoundArchiveLoadingStrategy
     
     private var tempDirectories: [URL] = []
     
@@ -140,10 +141,15 @@ public class ArchiveState: ObservableObject {
     public private(set) var openTask: Task<Void, any Error>?
     private var archiveLoader: ArchiveLoader?
     
-    public init(catalog: ArchiveTypeCatalog, engineSelector: ArchiveEngineSelectorProtocol) {
+    public init(
+        catalog: ArchiveTypeCatalog,
+        engineSelector: ArchiveEngineSelectorProtocol,
+        compoundLoadingStrategy: CompoundArchiveLoadingStrategy = .staged
+    ) {
         self.catalog = catalog
         self.archiveEngineSelector = engineSelector
         self.archiveTypeDetector = ArchiveTypeDetector(catalog: catalog)
+        self.compoundLoadingStrategy = compoundLoadingStrategy
     }
 }
 
@@ -813,7 +819,8 @@ extension ArchiveState {
                     archiveTypeDetector: self.archiveTypeDetector,
                     archiveEngineSelector: self.effectiveEngineSelector,
                     passwordResolver: passwordResolver,
-                    folderAccessResolver: makeFolderAccessResolver()
+                    folderAccessResolver: makeFolderAccessResolver(),
+                    compoundLoadingStrategy: compoundLoadingStrategy
                 )
                 self.archiveLoader = archiveLoader
                 
@@ -1120,7 +1127,8 @@ extension ArchiveState {
                     archiveTypeDetector: self.archiveTypeDetector,
                     archiveEngineSelector: self.effectiveEngineSelector,
                     passwordResolver: passwordResolver,
-                    folderAccessResolver: makeFolderAccessResolver()
+                    folderAccessResolver: makeFolderAccessResolver(),
+                    compoundLoadingStrategy: compoundLoadingStrategy
                 )
                 
                 let stream = await archiveLoader.statusStream()
@@ -1380,6 +1388,7 @@ extension ArchiveState {
                     archiveUrl,
                     archiveTypeId: archiveTypeId,
                     to: destination,
+                    requiresCompoundStream: root.requiresCompoundStream,
                     onProgress: makeEngineProgress(jobId: jobId, cancelFlag: cancelFlag)
                 )
                 progressCenter.finish(jobId, .done)
@@ -1504,4 +1513,3 @@ extension ArchiveState {
         return adjustedSelection
     }
 }
-

--- a/Modules/Sources/Core/Engine/Archive7ZipEngine.swift
+++ b/Modules/Sources/Core/Engine/Archive7ZipEngine.swift
@@ -8,8 +8,9 @@
 import Foundation
 import Swift7zip
 
-final actor Archive7ZipEngine: ArchiveEngine {
+final actor Archive7ZipEngine: ArchiveEngine, CompoundArchiveStreamingEngine {
     private var statusContinuation: AsyncStream<EngineStatus>.Continuation?
+    private var openCancelFlag: ExtractionCancelFlag?
     
     func statusStream() -> AsyncStream<EngineStatus> {
         AsyncStream { continuation in
@@ -23,24 +24,77 @@ final actor Archive7ZipEngine: ArchiveEngine {
     }
     
     func cancel() async {
+        openCancelFlag?.cancel()
     }
 
     func loadArchive(
         url: URL,
         passwordResolver: @escaping ArchivePasswordResolver
     ) async throws -> ArchiveEngineLoadResult {
+        let cancelFlag = ExtractionCancelFlag()
+        openCancelFlag = cancelFlag
+        defer {
+            if openCancelFlag === cancelFlag {
+                openCancelFlag = nil
+            }
+        }
+
         // Split/multi-volume archives are read in place. The caller resolves the
         // canonical entry (`.zip` for spanned, `.001` for numeric) and holds a
         // security-scoped grant on the containing folder, so the C bridge's
         // volume callback opens sibling volumes directly — no staging needed.
-        let szip = try await Self.open(url: url, passwordResolver: passwordResolver)
+        do {
+            let szip = try await Self.open(
+                url: url,
+                passwordResolver: passwordResolver,
+                openProgress: { _, _ in !cancelFlag.isCancelled }
+            )
+            return try Self.loadResult(from: szip)
+        } catch SevenZipError.cancelled {
+            throw CancellationError()
+        }
+    }
+
+    func loadCompoundArchive(
+        url: URL,
+        passwordResolver: @escaping ArchivePasswordResolver
+    ) async throws -> ArchiveEngineLoadResult {
+        let cancelFlag = ExtractionCancelFlag()
+        openCancelFlag = cancelFlag
+        defer {
+            if openCancelFlag === cancelFlag {
+                openCancelFlag = nil
+            }
+        }
+
+        do {
+            let szip = try await Self.open(
+                url: url,
+                passwordResolver: passwordResolver,
+                openProgress: { _, _ in !cancelFlag.isCancelled },
+                drillSingleStream: true
+            )
+            let result = try Self.loadResult(from: szip)
+            for item in result.items.values {
+                item.requiresCompoundStream = true
+            }
+            return result
+        } catch SevenZipError.cancelled {
+            throw CancellationError()
+        }
+    }
+
+    private static func loadResult(
+        from szip: SevenZipArchive
+    ) throws -> ArchiveEngineLoadResult {
+        let entries = try szip.entries
 
         var items: [UUID: ArchiveItem] = [:]
         var uncompressedSizeOverall: Int64 = 0
         var idToUUIDMap: [UInt32: UUID] = [:]
         var isEncrypted = false
 
-        try szip.entries.forEach { entry in
+        entries.forEach { entry in
             if entry.isEncrypted { isEncrypted = true }
 
             var name = entry.path
@@ -68,7 +122,7 @@ final actor Archive7ZipEngine: ArchiveEngine {
         if szip.isTree {
             // The file type (usually disk images) already provide the hierarchy.
             // So there is no need to recalculate this later. Just one pass here.
-            try szip.entries.forEach { entry in
+            entries.forEach { entry in
                 let index = entry.index
                 if
                     // the item itself
@@ -124,7 +178,10 @@ final actor Archive7ZipEngine: ArchiveEngine {
         }
         let sorted = indices.keys.sorted { $0 < $1 }
         
-        let szip = try await Self.open(url: url, passwordResolver: passwordResolver)
+        let szip = try await Self.open(
+            url: url,
+            passwordResolver: passwordResolver,
+            drillSingleStream: items.contains { $0.requiresCompoundStream })
 
         var attempt = 0
         // Loops until the archive extracts, the user cancels the prompt, or the
@@ -176,7 +233,39 @@ final actor Archive7ZipEngine: ArchiveEngine {
         passwordResolver: @escaping ArchivePasswordResolver,
         onProgress: ArchiveExtractionProgress?
     ) async throws {
-        let szip = try await Self.open(url: url, passwordResolver: passwordResolver)
+        try await extractArchive(
+            url,
+            to: destination,
+            passwordResolver: passwordResolver,
+            onProgress: onProgress,
+            drillSingleStream: false)
+    }
+
+    func extractCompoundArchive(
+        _ url: URL,
+        to destination: URL,
+        passwordResolver: @escaping ArchivePasswordResolver,
+        onProgress: ArchiveExtractionProgress?
+    ) async throws {
+        try await extractArchive(
+            url,
+            to: destination,
+            passwordResolver: passwordResolver,
+            onProgress: onProgress,
+            drillSingleStream: true)
+    }
+
+    private func extractArchive(
+        _ url: URL,
+        to destination: URL,
+        passwordResolver: @escaping ArchivePasswordResolver,
+        onProgress: ArchiveExtractionProgress?,
+        drillSingleStream: Bool
+    ) async throws {
+        let szip = try await Self.open(
+            url: url,
+            passwordResolver: passwordResolver,
+            drillSingleStream: drillSingleStream)
 
         var attempt = 0
         // Same retry shape as extract(items:): loop until the archive
@@ -209,13 +298,20 @@ final actor Archive7ZipEngine: ArchiveEngine {
     /// the same wherever the archive is opened.
     private static func open(
         url: URL,
-        passwordResolver: ArchivePasswordResolver
+        passwordResolver: ArchivePasswordResolver,
+        openProgress: SevenZipArchive.OpenProgressHandler? = nil,
+        drillSingleStream: Bool = false
     ) async throws -> SevenZipArchive {
         var password: String?
         var attempt = 0
         while true {
             do {
-                return try SevenZipArchive(url: url, password: password)
+                return try SevenZipArchive(
+                    url: url,
+                    password: password,
+                    openProgress: openProgress,
+                    drillSingleStream: drillSingleStream
+                )
             } catch SevenZipError.passwordMissing, SevenZipError.passwordWrong {
                 attempt += 1
                 password = try await nextPassword(

--- a/Modules/Sources/Core/Engine/ArchiveEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveEngine.swift
@@ -153,6 +153,22 @@ public protocol ArchiveEngine: Sendable {
     ) async throws
 }
 
+/// An engine that can unwrap one single-entry compression container and parse
+/// the archive inside it without materialising that inner archive on disk.
+protocol CompoundArchiveStreamingEngine: ArchiveEngine {
+    func loadCompoundArchive(
+        url: URL,
+        passwordResolver: @escaping ArchivePasswordResolver
+    ) async throws -> ArchiveEngineLoadResult
+
+    func extractCompoundArchive(
+        _ url: URL,
+        to destination: URL,
+        passwordResolver: @escaping ArchivePasswordResolver,
+        onProgress: ArchiveExtractionProgress?
+    ) async throws
+}
+
 public extension ArchiveEngine {
     func extract(
         items: [ArchiveItem],

--- a/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
@@ -330,6 +330,7 @@ private func isContained(_ url: URL, in directory: URL) -> Bool {
 
 final actor ArchiveXadEngine: ArchiveEngine {
     private var statusContinuation: AsyncStream<EngineStatus>.Continuation?
+    private var loadCancelFlag: ExtractionCancelFlag?
 
     func statusStream() -> AsyncStream<EngineStatus> {
         AsyncStream { continuation in
@@ -343,23 +344,41 @@ final actor ArchiveXadEngine: ArchiveEngine {
     }
     
     func cancel() async {
+        loadCancelFlag?.cancel()
     }
     
     func loadArchive(
         url: URL,
         passwordResolver: @escaping ArchivePasswordResolver
     ) async throws -> ArchiveEngineLoadResult {
+        let cancelFlag = ExtractionCancelFlag()
+        loadCancelFlag = cancelFlag
+        defer {
+            if loadCancelFlag === cancelFlag {
+                loadCancelFlag = nil
+            }
+        }
+
+        func checkCancellation() throws {
+            try Task.checkCancellation()
+            guard !cancelFlag.isCancelled else { throw CancellationError() }
+        }
+
+        try checkCancellation()
         let archive = try XADArchiveWithPasswordSupport(
             url: url,
             passwordResolver: passwordResolver
         )
         try await archive.setNameEncoding(NSUTF8StringEncoding)
+        try checkCancellation()
 
         var entries: [UUID: ArchiveItem] = [:]
         var uncompressedSizeOverall: Int64 = 0
         var isEncrypted = false
         let numberOfEntries = try await archive.numberOfEntries()
+        try checkCancellation()
         for index in 0..<numberOfEntries {
+            try checkCancellation()
             // name
             let path = try await archive.name(ofEntry: index)
             let isDir = try await archive.entryIsDirectory(index)
@@ -413,7 +432,8 @@ final actor ArchiveXadEngine: ArchiveEngine {
             // `max(0, …)` clamp the extraction side applies for its byte totals.
             uncompressedSizeOverall += Int64(Swift.max(0, entry.uncompressedSize))
         }
-        
+
+        try checkCancellation()
         emit(.done)
         
         return ArchiveEngineLoadResult(

--- a/Modules/Sources/Core/Models/ArchiveItem.swift
+++ b/Modules/Sources/Core/Models/ArchiveItem.swift
@@ -33,6 +33,11 @@ public class ArchiveItem: Identifiable, Hashable, @unchecked Sendable {
     public let uncompressedSize: Int
     public let modificationDate: Date?
     public let posixPermissions: Int?
+
+    /// The item's indices belong to the archive inside a single-stream
+    /// compressor, not to the outer compressor entry. Internal extraction
+    /// routing uses this instead of guessing from the source filename.
+    var requiresCompoundStream = false
     
     // hierarchy
     public var parent: UUID?

--- a/Modules/Sources/Swift7zip/SevenZipArchive.swift
+++ b/Modules/Sources/Swift7zip/SevenZipArchive.swift
@@ -4,6 +4,19 @@ import CSevenZip
 /// An open 7-zip archive.
 public class SevenZipArchive {
 
+    public typealias OpenProgressHandler = (_ completed: UInt64, _ total: UInt64) -> Bool
+
+    private final class OpenProgressBox {
+        let handler: OpenProgressHandler
+        init(_ handler: @escaping OpenProgressHandler) { self.handler = handler }
+    }
+
+    private static let openProgressThunk: sz_progress_callback = { completed, total, context in
+        guard let context else { return true }
+        let box = Unmanaged<OpenProgressBox>.fromOpaque(context).takeUnretainedValue()
+        return box.handler(completed, total)
+    }
+
     let handle: BridgeHandle
     /// The URL of the archive file.
     public let url: URL
@@ -18,26 +31,61 @@ public class SevenZipArchive {
     ///   - password: Password for formats that encrypt their header (7z
     ///     `-mhe=on`, RAR `-hp`), which cannot even be listed without one.
     ///     Also pre-sets the extraction password.
+    ///   - drillSingleStream: Whether to probe a compressor's sole output
+    ///     stream as a nested archive, for example the tar inside tar.xz.
     /// - Throws: ``SevenZipError/passwordMissing`` when the header is encrypted
     ///   and no password was given, ``SevenZipError/passwordWrong`` when the
     ///   given one did not decrypt it, ``SevenZipError/openFailed(_:)`` if the
     ///   file cannot be opened or no supported format is detected.
-    public init(url: URL, password: String? = nil) throws {
+    public init(
+        url: URL,
+        password: String? = nil,
+        openProgress: OpenProgressHandler? = nil,
+        drillSingleStream: Bool = false
+    ) throws {
         self.url = url
-        self.handle = try Self.openHandle(at: url, password: password)
+        self.handle = try Self.openHandle(
+            at: url,
+            password: password,
+            progress: openProgress,
+            drillSingleStream: drillSingleStream
+        )
         self.hasPassword = password != nil
     }
 
     /// Opens the C bridge handle at the given URL.
-    private static func openHandle(at url: URL, password: String?) throws -> BridgeHandle {
+    private static func openHandle(
+        at url: URL,
+        password: String?,
+        progress: OpenProgressHandler?,
+        drillSingleStream: Bool
+    ) throws -> BridgeHandle {
         var errorPtr: UnsafeMutablePointer<CChar>?
         var needsPassword = false
-        guard let ref = sz_open(url.path, password, &needsPassword, &errorPtr) else {
+        var cancelled = false
+        let progressBox = progress.map(OpenProgressBox.init)
+        let context = progressBox.map { Unmanaged.passUnretained($0).toOpaque() }
+        let ref = withExtendedLifetime(progressBox) {
+            sz_open(
+                url.path,
+                password,
+                progressBox == nil ? nil : Self.openProgressThunk,
+                context,
+                drillSingleStream,
+                &needsPassword,
+                &cancelled,
+                &errorPtr
+            )
+        }
+        guard let ref else {
             let msg = errorPtr.map { ptr -> String in
                 let str = String(cString: ptr)
                 free(ptr)
                 return str
             } ?? "Unknown error"
+            if cancelled {
+                throw SevenZipError.cancelled
+            }
             if needsPassword {
                 throw password == nil
                     ? SevenZipError.passwordMissing
@@ -66,6 +114,12 @@ public class SevenZipArchive {
     /// is `nil`.
     public var isTree: Bool {
         sz_is_tree(handle.ref)
+    }
+
+    /// Whether compound opening used the bounded-memory decoder stream instead
+    /// of 7-Zip's seek cache, whose size equals the largest unpacked XZ block.
+    var usesBoundedCompoundStream: Bool {
+        sz_uses_bounded_compound_stream(handle.ref)
     }
 
     /// All entries in the archive.

--- a/Modules/Sources/Swift7zip/SevenZipError.swift
+++ b/Modules/Sources/Swift7zip/SevenZipError.swift
@@ -13,7 +13,7 @@ public enum SevenZipError: Error, LocalizedError, Sendable {
     case passwordMissing
     /// The entry is encrypted and the password that was set did not decrypt it.
     case passwordWrong
-    /// The extraction was aborted through the progress callback.
+    /// The operation was aborted through a progress callback.
     case cancelled
     /// Archive creation or update failed.
     case writeFailed(String)
@@ -32,7 +32,7 @@ public enum SevenZipError: Error, LocalizedError, Sendable {
         case .passwordWrong:
             return "The password is incorrect"
         case .cancelled:
-            return "Extraction was cancelled"
+            return "Operation was cancelled"
         case .writeFailed(let msg):
             return "Archive write failed: \(msg)"
         }

--- a/Modules/Tests/CoreTests/CompoundArchiveStreamingTests.swift
+++ b/Modules/Tests/CoreTests/CompoundArchiveStreamingTests.swift
@@ -1,0 +1,330 @@
+//
+//  CompoundArchiveStreamingTests.swift
+//  Modules
+//
+
+import Foundation
+import Testing
+@testable import Core
+@testable import ArchivePreviewUI
+@testable import Swift7zip
+
+private final class StagedCompoundCancellationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _started = false
+    private var _usedProgress = false
+    private var _observedCancellation = false
+
+    var started: Bool { withLock { _started } }
+    var usedProgress: Bool { withLock { _usedProgress } }
+    var observedCancellation: Bool { withLock { _observedCancellation } }
+
+    func markStarted(usingProgress: Bool) {
+        withLock {
+            _started = true
+            _usedProgress = usingProgress
+        }
+    }
+
+    func markCancellationObserved() {
+        withLock { _observedCancellation = true }
+    }
+
+    @discardableResult
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+}
+
+private actor StagedCompoundCancellationEngine: ArchiveEngine {
+    private let probe: StagedCompoundCancellationProbe
+
+    init(probe: StagedCompoundCancellationProbe) {
+        self.probe = probe
+    }
+
+    func statusStream() -> AsyncStream<EngineStatus> {
+        AsyncStream { $0.yield(.idle) }
+    }
+
+    func cancel() async {}
+
+    func loadArchive(
+        url: URL,
+        passwordResolver: @escaping ArchivePasswordResolver
+    ) async throws -> ArchiveEngineLoadResult {
+        let item = ArchiveItem(
+            index: 0,
+            name: "inner.tar",
+            virtualPath: "inner.tar",
+            type: .file,
+            uncompressedSize: 1024)
+        return ArchiveEngineLoadResult(
+            items: [item.id: item],
+            hasTree: false,
+            uncompressedSize: 1024)
+    }
+
+    func extract(
+        items: [ArchiveItem],
+        from url: URL,
+        to destination: URL,
+        passwordResolver: @escaping ArchivePasswordResolver
+    ) async throws -> ArchiveExtractionResult {
+        probe.markStarted(usingProgress: false)
+        try await Task.sleep(for: .milliseconds(300))
+        throw ArchiveError.extractionFailed("staged extraction did not receive a cancellation callback")
+    }
+
+    func extract(
+        items: [ArchiveItem],
+        from url: URL,
+        to destination: URL,
+        passwordResolver: @escaping ArchivePasswordResolver,
+        onProgress: ArchiveExtractionProgress?
+    ) async throws -> ArchiveExtractionResult {
+        probe.markStarted(usingProgress: true)
+        while onProgress?(0, 1024) != false {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        probe.markCancellationObserved()
+        throw CancellationError()
+    }
+
+    func extract(
+        _ url: URL,
+        to destination: URL,
+        passwordResolver: @escaping ArchivePasswordResolver
+    ) async throws {
+        throw ArchiveError.extractionFailed("not used by this test")
+    }
+}
+
+private struct StagedCompoundCancellationSelector: ArchiveEngineSelectorProtocol {
+    let engineInstance: StagedCompoundCancellationEngine
+
+    func engine(for id: String) -> (any ArchiveEngine)? { engineInstance }
+    func engine(for type: ArchiveEngineType) -> any ArchiveEngine { engineInstance }
+    func engineType(for id: String) -> ArchiveEngineType? { .xad }
+}
+
+private func matchesDefaultArchivePayload(_ extracted: URL, path: String) -> Bool {
+    let source = Bundle.module
+        .url(forResource: "defaultArchiveContent", withExtension: nil)!
+        .appendingPathComponent(path)
+    guard let extractedData = try? Data(contentsOf: extracted),
+          let sourceData = try? Data(contentsOf: source)
+    else { return false }
+    return extractedData == sourceData
+}
+
+extension AllCoreTests {
+
+    @MainActor struct CompoundArchiveStreamingTests {
+
+        @Test func sevenZipStreamedCompoundLoadDoesNotCreateAStagingDirectory() async throws {
+            let catalog = ArchiveTypeCatalog()
+            let loader = ArchiveLoader(
+                archiveTypeDetector: ArchiveTypeDetector(catalog: catalog),
+                archiveEngineSelector: ArchiveEngineSelector7zip(),
+                passwordResolver: { _ in nil },
+                compoundLoadingStrategy: .streamed,
+                tempDirectoryProvider: {
+                    Issue.record("streamed compound loading must not stage the inner tar")
+                    return nil
+                }
+            )
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let archive = fixtures.appendingPathComponent("defaultArchive.tar.xz")
+
+            let result = try await loader.loadEntries(url: archive)
+            let names = Set(result.entries.values.map(\.name))
+
+            #expect(result.compositionType?.id == "tar.xz")
+            #expect(result.tempDirectory == nil)
+            #expect(names == ["folder", "README.md", "NestedArchive.zip", "hello world.txt"])
+        }
+
+        @Test func sevenZipRejectsDamagedBoundedXzStream() throws {
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let source = fixtures.appendingPathComponent("defaultArchive.tar.xz")
+            let damaged = FileManager.default.temporaryDirectory
+                .appendingPathComponent("damaged-\(UUID().uuidString).tar.xz")
+            defer { try? FileManager.default.removeItem(at: damaged) }
+
+            // Keep the real archive's XZ header, index, and footer intact so
+            // 7-Zip selects the bounded compound path, but damage compressed
+            // bytes that the inner tar scan must decode.
+            var bytes = try Data(contentsOf: source)
+            let damagedIndex = bytes.index(bytes.startIndex, offsetBy: bytes.count / 2)
+            bytes[damagedIndex] ^= 0xFF
+            try bytes.write(to: damaged)
+
+            #expect(throws: SevenZipError.self) {
+                _ = try SevenZipArchive(
+                    url: damaged,
+                    drillSingleStream: true
+                )
+            }
+        }
+
+        @Test func cancellingAStagedCompoundStopsExtractionAndRemovesItsTemporaryDirectory() async throws {
+            let probe = StagedCompoundCancellationProbe()
+            let engine = StagedCompoundCancellationEngine(probe: probe)
+            let stagingDirectory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(
+                at: stagingDirectory,
+                withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: stagingDirectory) }
+
+            let catalog = ArchiveTypeCatalog()
+            let loader = ArchiveLoader(
+                archiveTypeDetector: ArchiveTypeDetector(catalog: catalog),
+                archiveEngineSelector: StagedCompoundCancellationSelector(engineInstance: engine),
+                passwordResolver: { _ in nil },
+                tempDirectoryProvider: { stagingDirectory })
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let archive = fixtures.appendingPathComponent("defaultArchive.tar.gz")
+
+            let loadTask = Task {
+                try await loader.loadEntries(url: archive)
+            }
+            for _ in 0..<100 where !probe.started {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(probe.started)
+
+            await loader.cancel()
+
+            do {
+                _ = try await loadTask.value
+                Issue.record("staged compound loading ignored cancellation")
+            } catch is CancellationError {
+                // Expected.
+            } catch {
+                Issue.record("expected cancellation, got \(error)")
+            }
+
+            #expect(probe.usedProgress)
+            #expect(probe.observedCancellation)
+            #expect(!FileManager.default.fileExists(atPath: stagingDirectory.path))
+        }
+
+        @Test(arguments: [
+            "defaultArchive.tar.gz",
+            "defaultArchive.tar.bz2",
+            "defaultArchive.tar.Z"
+        ])
+        func xadOuterCompressionHonorsTheStagedCancellationCallback(name: String) async throws {
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let archive = fixtures.appendingPathComponent(name)
+            let engine = ArchiveXadEngine()
+            let loaded = try await engine.loadArchive(
+                url: archive,
+                passwordResolver: { _ in nil })
+            let entry = try #require(loaded.items.values.first)
+            let destination = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(
+                at: destination,
+                withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: destination) }
+
+            do {
+                _ = try await engine.extract(
+                    items: [entry],
+                    from: archive,
+                    to: destination,
+                    passwordResolver: { _ in nil },
+                    onProgress: { _, _ in false })
+                Issue.record("XAD ignored the staged cancellation callback for \(name)")
+            } catch is CancellationError {
+                // Expected.
+            }
+        }
+
+        @Test func xadListingHonorsTaskCancellation() async throws {
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let archive = fixtures.appendingPathComponent("defaultArchive.tar")
+
+            let loadTask = Task {
+                withUnsafeCurrentTask { $0?.cancel() }
+                return try await ArchiveXadEngine().loadArchive(
+                    url: archive,
+                    passwordResolver: { _ in nil })
+            }
+
+            do {
+                _ = try await loadTask.value
+                Issue.record("XAD listing ignored task cancellation")
+            } catch is CancellationError {
+                // Expected.
+            }
+        }
+
+        @Test func previewUsesCancellable7ZipStreamingForTarXz() async throws {
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let archive = fixtures.appendingPathComponent("defaultArchive.tar.xz")
+            let state = ArchivePreviewLoader.makeState()
+
+            state.open(url: archive)
+            try await state.openTask?.value
+
+            #expect(state.activeEngine == .`7zip`)
+            #expect(state.compositionType?.id == "tar.xz")
+            #expect(state.itemCount == 4)
+        }
+
+        @Test func streamedTarXzEntriesCanStillBeExtracted() async throws {
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let archive = fixtures.appendingPathComponent("defaultArchive.tar.xz")
+            let engine = Archive7ZipEngine()
+            let loaded = try await engine.loadCompoundArchive(
+                url: archive,
+                passwordResolver: { _ in nil })
+            let readme = try #require(loaded.items.values.first { $0.name == "README.md" })
+            let destination = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(
+                at: destination, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: destination) }
+
+            let result = try await engine.extract(
+                items: [readme],
+                from: archive,
+                to: destination,
+                passwordResolver: { _ in nil })
+
+            let extracted = try #require(result[readme])
+            #expect(FileManager.default.fileExists(atPath: extracted.path))
+            #expect(matchesDefaultArchivePayload(
+                extracted,
+                path: "folder/README.md"))
+        }
+
+        @Test func streamedTarXzCanStillBeExtractedInFull() async throws {
+            let fixtures = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let archive = fixtures.appendingPathComponent("defaultArchive.tar.xz")
+            let destination = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(
+                at: destination, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: destination) }
+
+            try await Archive7ZipEngine().extractCompoundArchive(
+                archive,
+                to: destination,
+                passwordResolver: { _ in nil },
+                onProgress: nil)
+
+            let extracted = destination.appendingPathComponent("folder/README.md")
+            #expect(FileManager.default.fileExists(atPath: extracted.path))
+            #expect(matchesDefaultArchivePayload(
+                extracted,
+                path: "folder/README.md"))
+        }
+    }
+}

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@testable import Swift7zip
 import Testing
 @testable import Core
 
@@ -35,6 +36,44 @@ extension AllCoreTests {
             let result = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
 
             #expect(result.items.count > 0)
+        }
+
+        @Test func sevenZipCanDrillIntoCompressedTarStream() throws {
+            let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let url = folderURL.appendingPathComponent("defaultArchive.tar.xz")
+
+            let archive = try SevenZipArchive(
+                url: url,
+                drillSingleStream: true
+            )
+            let names = Set(try archive.entries.map(\.name))
+
+            #expect(archive.usesBoundedCompoundStream)
+            #expect(names.contains("README.md"))
+            #expect(names.contains("hello world.txt"))
+        }
+
+        @Test func sevenZipOpenCanCancelDuringCompressedInputRead() throws {
+            let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let url = folderURL.appendingPathComponent("defaultArchive.tar.xz")
+            var readCompressedInput = false
+
+            do {
+                _ = try SevenZipArchive(
+                    url: url,
+                    openProgress: { completed, _ in
+                        guard completed > 0 else { return true }
+                        readCompressedInput = true
+                        return false
+                    },
+                    drillSingleStream: true
+                )
+                Issue.record("7-Zip archive opening ignored cancellation")
+            } catch SevenZipError.cancelled {
+                #expect(readCompressedInput)
+            } catch {
+                Issue.record("Expected cancellation, got \(error)")
+            }
         }
 
         @Test func loadArchiveIsoReturnsEntries() async throws {

--- a/Modules/Tests/CoreTests/PasswordTests.swift
+++ b/Modules/Tests/CoreTests/PasswordTests.swift
@@ -52,6 +52,33 @@ private actor PasswordAnswers {
     var callCount: Int { attempts.count }
 }
 
+/// Holds a header-password request open so a test can cancel the engine before
+/// allowing the archive open to resume.
+private actor PasswordGate {
+    private var requested = false
+    private var continuation: CheckedContinuation<String?, Never>?
+
+    nonisolated var resolver: ArchivePasswordResolver {
+        { [self] _ in await suspend() }
+    }
+
+    private func suspend() async -> String? {
+        requested = true
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilRequested() async {
+        while !requested {
+            await Task.yield()
+        }
+    }
+
+    func answer(_ password: String?) {
+        continuation?.resume(returning: password)
+        continuation = nil
+    }
+}
+
 /// Resolver that never answers — extraction must fail, not stall.
 private let neverResolves: ArchivePasswordResolver = { _ in nil }
 
@@ -432,6 +459,25 @@ extension AllCoreTests {
                     url: fixture("7z_encrypted_header.7z"),
                     passwordResolver: neverResolves
                 )
+            }
+        }
+
+        @Test func cancellingPlainSevenZipLoadStopsTheResumedOpen() async throws {
+            let engine = Archive7ZipEngine()
+            let gate = PasswordGate()
+            let loadTask = Task {
+                try await engine.loadArchive(
+                    url: fixture("7z_encrypted_header.7z"),
+                    passwordResolver: gate.resolver
+                )
+            }
+
+            await gate.waitUntilRequested()
+            await engine.cancel()
+            await gate.answer(correctPassword)
+
+            await #expect(throws: CancellationError.self) {
+                _ = try await loadTask.value
             }
         }
     }

--- a/QuickLookExtension/PreviewViewController.swift
+++ b/QuickLookExtension/PreviewViewController.swift
@@ -20,7 +20,12 @@ class PreviewViewController: NSViewController, QLPreviewingController {
         view = preview.view
     }
 
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        preview.cancelPreviewLoad()
+    }
+
     func preparePreviewOfFile(at url: URL) async throws {
-        try await preview.loadPreview(of: url)
+        preview.beginLoadingPreview(of: url)
     }
 }


### PR DESCRIPTION
## What & why

Quick Look previously staged compound archives before listing them and did not propagate cancellation through every archive engine. Closing the preview could therefore leave archive scanning and disk activity running; large `tar.xz` archives could also consume several gigabytes of memory while seeking through the inner tar.

This change streams Quick Look `tar.xz` scans through the existing 7-Zip bridge with bounded reads, propagates cancellation through streamed and staged compound scans, and removes partial staging directories after cancellation. The main app keeps its existing staged extraction behavior, and vendored 7-Zip sources remain unchanged.

AI disclosure: Codex was the primary code author. I reviewed the final diff and manually verified the behavior in Finder.

## How it was verified

Manual verification:

- Previewed a large `tar.xz` archive in Finder and closed Quick Look while it was scanning.
- The fresh Quick Look extension stopped immediately, produced no complete staged inner tar, and peaked at about 31.2 MB physical footprint with no swap.
- Before the bounded stream fix, the same archive reached about 4 GB physical footprint and 3.5 GB swap.

Automated verification:

- `swift test --package-path Modules`: 399 tests in 118 suites passed.
- Real repository fixtures confirm XAD cancellation for `tar.gz`, `tar.bz2`, and `tar.Z`.
- A deterministic staged-extraction test confirms cancellation propagation and cleanup of partial staging directories.
- Regression tests cover plain 7-Zip open cancellation and damaged bounded XZ streams.
- `xcodebuild -scheme MacPacker -configuration Debug build`: BUILD SUCCEEDED.

Not manually verified:

- Cancellation latency with a large real-world `tar.gz` or `tar.bz2` archive.

## Checklist

- [x] Verification evidence is included above
- [x] Changelog entry added to `Config/products/macpacker.json`
- [x] AI involvement disclosed, if AI was the primary author — see [AI_CONTRIBUTING.md](../AI_CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Closing Quick Look now stops active archive previews and `tar.xz` scanning.
  - Cancelled archive operations no longer continue processing in the background.
  - Improved handling of archive loading failures, including cancellation and encrypted archives.

- **Improvements**
  - Added streamed handling for compressed compound archives, including TAR.XZ.
  - Improved progress reporting and cancellation during archive opening and extraction.
  - Added support for extracting streamed compound archives without unnecessary temporary staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->