### PR TITLE
fix: detect empty ZIP archives by their EOCD magic bytes

### DIFF
--- a/Modules/Sources/Core/Formats/Catalog.json
+++ b/Modules/Sources/Core/Formats/Catalog.json
@@ -520,8 +520,7 @@
       "rules": [
         { "policy": "any", "tests": [
           {"type": "signature", "bytes": "50 4B 03 04", "offset": 0},
-          {"type": "signature", "bytes": "50 4B 03 06", "offset": 0},
-          {"type": "signature", "bytes": "50 4B 03 08", "offset": 0}
+          {"type": "signature", "bytes": "50 4B 05 06", "offset": 0}
           ] }
       ],
       "engines": [
@@ -540,8 +539,7 @@
       "rules": [
         { "policy": "any", "tests": [
           {"type": "signature", "bytes": "50 4B 03 04", "offset": 0},
-          {"type": "signature", "bytes": "50 4B 03 06", "offset": 0},
-          {"type": "signature", "bytes": "50 4B 03 08", "offset": 0}
+          {"type": "signature", "bytes": "50 4B 05 06", "offset": 0}
           ] }
       ],
       "engines": [

--- a/Modules/Tests/CoreTests/MagicNumberTests.swift
+++ b/Modules/Tests/CoreTests/MagicNumberTests.swift
@@ -39,12 +39,97 @@ extension AllCoreTests {
             let id = arg.1
             let detector = ArchiveTypeDetector(catalog: ArchiveTypeCatalog())
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
-            
+
             let url = folderURL.appendingPathComponent("defaultArchive.\(ext)")
-            
+
             let result = detector.detectByMagicNumber(for: url)
-            
+
             #expect(result?.type.id == id)
+        }
+
+        // MARK: - ZIP magic-bytes coverage (EOCD vs spanned-marker collision)
+        //
+        // A normal ZIP begins with the local-file-header signature `50 4B 03 04`,
+        // but an EMPTY zip is just a lone 22-byte End-of-Central-Directory record
+        // (`50 4B 05 06` + 18 zero bytes). That same `50 4B 05 06` signature is
+        // also the zip-spanned split marker in Catalog.json — these tests prove the
+        // two uses do not collide: an empty EOCD is matched as plain `zip`, while a
+        // spanned terminal volume (EOCD with a non-zero disk field) still wins the
+        // spanned classification. Each case uses in-memory bytes + a temp file
+        // (same shape as the fixture-less EdgeCaseTests), since the real
+        // `empty.zip` / spanned fixtures live in the MacPacker-TestArchives
+        // submodule (a maintainer follow-up to add there).
+
+        private func writeTemp(_ bytes: [UInt8], named name: String) -> URL {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+            FileManager.default.createFile(atPath: url.path, contents: Data(bytes))
+            return url
+        }
+
+        /// A 22-byte End-of-Central-Directory record (a lone-EOCD / empty ZIP).
+        /// `diskNumber` is the 2-byte field at offset 4 — the field the
+        /// zip-spanned marker tests for `nonzero`. 0 = a real empty ZIP;
+        /// >0 emulates a spanned terminal volume.
+        private func eocd(diskNumber: UInt16 = 0) -> [UInt8] {
+            var b = [UInt8](repeating: 0x00, count: 22)
+            b[0] = 0x50; b[1] = 0x4B; b[2] = 0x05; b[3] = 0x06   // EOCD signature
+            b[4] = UInt8(diskNumber & 0xFF)                       // number of this disk (LE)
+            b[5] = UInt8((diskNumber >> 8) & 0xFF)
+            return b
+        }
+
+        @Test func magicNumberNormalZipByBytes() {
+            // Local-file-header signature → matched as plain `zip` by magic.
+            let detector = ArchiveTypeDetector(catalog: ArchiveTypeCatalog())
+            let normalZip = [0x50, 0x4B, 0x03, 0x04] + [UInt8](repeating: 0x00, count: 28)
+            let url = writeTemp(normalZip, named: "normal_\(UUID().uuidString).bin")
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            let result = detector.detectByMagicNumber(for: url)
+
+            #expect(result?.type.id == "zip")
+            #expect(result?.source == .magic)
+        }
+
+        @Test func magicNumberEmptyZip() {
+            // A lone 22-byte EOCD (entry count = 0) is an empty ZIP — detected as
+            // `zip` from the `50 4B 05 06` magic, not left unidentified.
+            let detector = ArchiveTypeDetector(catalog: ArchiveTypeCatalog())
+            let url = writeTemp(eocd(), named: "empty_\(UUID().uuidString).bin")
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            let result = detector.detectByMagicNumber(for: url)
+
+            #expect(result?.type.id == "zip")
+            #expect(result?.source == .magic)
+        }
+
+        @Test func emptyZipEocdIsNotFlaggedAsSpanned() {
+            // The empty EOCD shares `50 4B 05 06` with the zip-spanned marker, yet
+            // its disk field is 0 — so it must NOT be classified as a split.
+            let detector = ArchiveTypeDetector(catalog: ArchiveTypeCatalog())
+            let url = writeTemp(eocd(), named: "empty_\(UUID().uuidString).bin")
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            let result = detector.detect(for: url)
+
+            #expect(result?.type.id == "zip")
+            #expect(result?.source == .magic)
+            #expect(result?.split == nil, "an empty ZIP (disk field 0) must not look like a spanned volume")
+        }
+
+        @Test func spannedZipEocdIsNotSwallowedByPlainZipMagic() {
+            // An EOCD with a non-zero disk field is the terminal volume of a
+            // spanned set. Adding `50 4B 05 06` to zip's magic must not make the
+            // plain-zip match swallow it — the detector reclassifies it as spanned.
+            let detector = ArchiveTypeDetector(catalog: ArchiveTypeCatalog())
+            let url = writeTemp(eocd(diskNumber: 2), named: "spanned_\(UUID().uuidString).bin")
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            let result = detector.detect(for: url)
+
+            #expect(result?.type.id == "zip")
+            #expect(result?.split?.scheme == "spanned", "a non-zero disk field must keep the spanned classification")
         }
     }
 }


### PR DESCRIPTION
# Worker report — w-top-macpacker-1

**Task:** Find ONE real NEW functional bug in MacPacker, verify at HEAD, fix minimally with a regression test, run the gate, COMMIT (no push).
**Repo:** `sarensw/MacPacker` (fork `YuriNachos/MacPacker`), default `main`.
**Base (upstream/main):** `3de1e7c` — `fix: extract a selected folder as one folder, not its loose contents (#177)`.
**Worktree HEAD after fix:** `db63ee9` — `fix: detect empty ZIP archives by their EOCD magic bytes` (1 commit on top of base; **not pushed**).

---

## 1. Dup-check (done first)

- Our merged PRs (author `YuriNachos`, all states): **#176** (XAD uncompressed-size per-directory undercount), **#171** (split-volume suffix in extract-to-folder name), **#170** (uppercase ext in extract-to-folder name), **#168** (localize "Edited" subtitle). → Avoided: XAD size math, extract-to-folder naming, localization.
- Open issues upstream (#174, #165, #157, #153, #149, #148, #140, #138, …) and open PRs (#179 `pincetgore/fix/finder-toolbar-localization`) — none covers ZIP magic detection.
- **Local in-flight branch to avoid:** `fix/swc-lz4-extract-key` (commit `4fcd3c9` "fix: LZ4 extract-to-folder left the destination empty") already fixes the ArchiveSwcEngine result-key bug (`[UUID(): …]` → `[items.first!.id: …]`). The whole SWC-extract area was therefore treated as touched and **left alone**, including a separate (real, non-duplicate) bug there: `ArchiveSwcEngine.extract(_:to:)` swallows LZ4 decompression errors and reports success. Not fixed here to stay out of the in-flight area.

## 2. The bug

**File:** `Modules/Sources/Core/Formats/Catalog.json` — `zip` (lines 522–524) and `zipx` (lines 542–544) format magic rules.

Both listed three offset-0 signatures:

```
50 4B 03 04   ← local file header (valid)
50 4B 03 06   ← NOT a ZIP signature (0x06034b50 — no such record)
50 4B 03 08   ← NOT a ZIP signature (0x08034b50 — no such record)
```

The End-of-Central-Directory signature `50 4B 05 06` (0x06054b50) — which is the **first** bytes of an empty ZIP archive — was not listed (it appears only as a split `marker` at line 590, never as an offset-0 format signature).

**Concrete reproducer:** A valid empty ZIP is a lone 22-byte EOCD record (`50 4B 05 06` + 18 zero bytes; no entries, no comment). Given a file like that with no recognized extension, `ArchiveTypeDetector.detectByMagicNumber(for:)` matched none of `03 04`/`03 06`/`03 08`, returned `nil`, and `ArchiveLoader.loadEntries` threw `invalidArchive("… is not a recognised archive type.")` — MacPacker refused to open a valid (empty) ZIP. The two bogus entries could also only ever cause harm: a non-archive file whose first four bytes happen to be `50 4B 03 06`/`50 4B 03 08` would be misdetected as ZIP.

Verified at HEAD `3de1e7c` with a regression test (see §5): before the fix the test fails with `result → nil`.

## 3. The fix (minimal)

Replace the two invalid signatures with the EOCD signature, in **both** `zip` and `zipx`:

```
50 4B 03 04   ← local file header (non-empty ZIPs — unchanged)
50 4B 05 06   ← EOCD (empty ZIPs — added)
```

Non-empty ZIPs still match `50 4B 03 04` (so all existing detection is unchanged — confirmed: all 18 cases in `MagicNumberTests` still pass). Empty ZIPs now match `50 4B 05 06`. ZIP-record signatures are 32-bit little-endian; `50 4B 05 06` is the spec-defined EOCD (`0x06054b50`), so the fix is correct by the ZIP spec, not a guess.

## 4. Files changed (only the fix + test)

```
Modules/Sources/Core/Formats/Catalog.json      |  6 ++----   (zip + zipx: 03 06/03 08 → 05 06)
Modules/Tests/CoreTests/MagicNumberTests.swift  | 24 ++++++++++++++++   (+ magicNumberEmptyZip)
2 files changed, 26 insertions(+), 4 deletions(-)
```

No other modules, formatting, deps, or strings touched. (No changelog entry added — see §7.)

## 5. Regression test (red → green)

`Modules/Tests/CoreTests/MagicNumberTests.swift` → new `@Test func magicNumberEmptyZip()`:
builds a 22-byte EOCD-only empty ZIP in the temp dir with a `.bin` extension (forces magic detection), then asserts `detectByMagicNumber` returns `type.id == "zip"`, `source == .magic`.

- **RED on buggy HEAD** (`3de1e7c`, before Catalog.json edit):
  `magicNumberEmptyZip() failed … Expectation failed: (result → nil) != nil` (3 issues). All 18 existing magic cases passed.
- **GREEN after fix** (`db63ee9`): `magicNumberEmptyZip() passed`; all 18 existing magic cases still passed.

The test synthesizes the EOCD bytes (spec-exact, 22 bytes), consistent with how `EdgeCaseTests` already synthesizes tiny byte files for `ArchiveTypeDetector`. It does **not** add an archive fixture to the submodule (none is needed for a magic-byte detection test).

## 6. Gate (both green)

```bash
cd Modules && swift test
# ✔ Test run with 389 tests in 117 suites passed after 14.989 seconds

xcodebuild -scheme MacPacker -configuration Debug build
# ** BUILD SUCCEEDED **  (ad-hoc codesigning; no CODE_SIGNING_ALLOWED workaround needed)
```

`git submodule update --init --recursive` was run first (required for the build; `CSevenZip/vendor/7zip` + `MacPacker-TestArchives`).

## 7. Notes for the owner at push time

- **Do not push / open a PR** was honored: commit `db63ee9` is local on branch `YuriNachos/w-top-macpacker-1-2` only.
- **Changelog entry deferred.** `Config/products/macpacker.json` `changelog` requires `issues` to be non-empty, and the only honest value is this PR's own number — which does not exist until the PR is open (the repo's own rule: "add it in a second push. Never guess one."). There is no matching open issue. Suggested entry to add with the PR number at push time (newest block is `0.20.0`, not tagged):

  ```jsonc
  {
    "type": "fix",
    "title": { "en": "Open empty ZIP archives", /* …translate per existing languages… */ },
    "issues": ["<this PR's number>"]
  }
  ```
- **Catalog.json** is a `.copy` resource of the `Core` target, so the edit takes effect after a rebuild (verified by the green test run).

## 8. PR-body draft (for the later push)

**Summary**
Empty ZIP archives (a lone End-of-Central-Directory record) were not recognized by content and were rejected as "not a recognised archive type" when the file had no recognized extension. The zip/zipx magic rules listed two non-existent ZIP signatures and omitted the EOCD signature.

**Root cause**
`Catalog.json` listed `50 4B 03 06` and `50 4B 03 08` as offset-0 ZIP signatures. Neither is a real ZIP record signature (ZIP signatures are 32-bit little-endian; no record decodes to those bytes). The valid first-bytes of an empty ZIP — the EOCD signature `50 4B 05 06` — was missing, so an EOCD-only file matched no rule.

**Changes**
- `Modules/Sources/Core/Formats/Catalog.json`: zip and zipx offset-0 signatures are now `50 4B 03 04` (local file header) and `50 4B 05 06` (EOCD). Non-empty ZIPs are unaffected.
- `Modules/Tests/CoreTests/MagicNumberTests.swift`: `magicNumberEmptyZip()` builds a 22-byte EOCD-only ZIP and asserts it is detected as `zip` by magic (fails before, passes after).

**Test plan**
- `cd Modules && swift test` → 389 tests pass (includes the new test and all 18 existing magic-number cases).
- `xcodebuild -scheme MacPacker -configuration Debug build` → BUILD SUCCEEDED.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP and ZIPX detection for empty archives.
  * Removed outdated signatures that could incorrectly identify certain files.
  * Improved distinction between empty and spanned ZIP archives.

* **Tests**
  * Added coverage for standard ZIP files, empty ZIP archives, and spanned ZIP markers.
  * Verified detection using ZIP magic numbers and end-of-central-directory records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->