### PR TITLE
cbz, cbr support

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -37,6 +37,29 @@
         "version": "0.21.0",
         "items": [
           {
+            "type": "feat",
+            "title": {
+                "en": "cbz, cbr support",
+                "zh-Hans": "支持 cbz 和 cbr",
+                "fr": "Prise en charge de cbz et cbr",
+                "de": "Unterstützung für cbz und cbr",
+                "it": "Supporto per cbz e cbr",
+                "ja": "cbz、cbr に対応",
+                "fa": "پشتیبانی از cbz و cbr",
+                "pl": "Obsługa cbz i cbr",
+                "pt-BR": "Suporte a cbz e cbr",
+                "ru": "Поддержка cbz и cbr",
+                "uk": "Підтримка cbz і cbr",
+                "es-MX": "Compatibilidad con cbz y cbr",
+                "ko": "cbz, cbr 지원",
+                "nl": "Ondersteuning voor cbz en cbr",
+                "tr": "cbz ve cbr desteği"
+            },
+            "issues": [
+                "187"
+            ]
+          },
+          {
             "type": "lang",
             "title": {
               "en": "Language support for Turkish",

--- a/MacPacker/Info.plist
+++ b/MacPacker/Info.plist
@@ -132,6 +132,34 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
+				<string>cbz</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Comic Book ZIP Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>cbr</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Comic Book RAR Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
 				<string>xz</string>
 			</array>
 			<key>CFBundleTypeName</key>
@@ -975,7 +1003,7 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
-    <key>ITSEncryptionExportComplianceCode</key>
-    <string>9eed8f58-eaf9-44e9-a757-f5e0a65c922a</string>
+	<key>ITSEncryptionExportComplianceCode</key>
+	<string>9eed8f58-eaf9-44e9-a757-f5e0a65c922a</string>
 </dict>
 </plist>

--- a/MacPacker/Info_Store.plist
+++ b/MacPacker/Info_Store.plist
@@ -129,6 +129,34 @@
 			<key>LSTypeIsPackage</key>
 			<false/>
 		</dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>cbz</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>Comic Book ZIP Archive</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Default</string>
+            <key>LSTypeIsPackage</key>
+            <false/>
+        </dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>cbr</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>Comic Book RAR Archive</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Default</string>
+            <key>LSTypeIsPackage</key>
+            <false/>
+        </dict>
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>

--- a/Modules/Sources/Core/Formats/Catalog.json
+++ b/Modules/Sources/Core/Formats/Catalog.json
@@ -291,8 +291,8 @@
       "name": "RAR Archive",
       "kind": "archive",
       "uti": ["com.rarlab.rar-archive"],
-      "extensions": ["rar"],
-      "mime": ["application/x-rar-compressed", "application/vnd.rar"],
+      "extensions": ["rar", "cbr"],
+      "mime": ["application/x-rar-compressed", "application/vnd.rar", "application/vnd.comicbook-rar"],
       "rules": [
         { "policy": "any", "tests": [
           {"type": "signature", "bytes": "52 61 72 21 1A 07 00", "offset": 0},
@@ -515,8 +515,8 @@
       "name": "ZIP Archive",
       "kind": "archive",
       "uti": ["public.zip-archive", "com.pkware.zip-archive", "com.sun.java-archive", "com.android.package-archive"],
-      "extensions": ["zip", "jar", "aar", "apk"],
-      "mime": ["application/zip", "application/x-zip-compressed", "application/zip-compressed", "multipart/x-zip", "application/java-archive", "application/vnd.android.package-archive"],
+      "extensions": ["zip", "jar", "aar", "apk", "cbz"],
+      "mime": ["application/zip", "application/x-zip-compressed", "application/zip-compressed", "multipart/x-zip", "application/java-archive", "application/vnd.android.package-archive", "application/vnd.comicbook+zip"],
       "rules": [
         { "policy": "any", "tests": [
           {"type": "signature", "bytes": "50 4B 03 04", "offset": 0},


### PR DESCRIPTION


<!-- Thanks for contributing to MacPacker. Keep this short — a few sentences is fine. -->

## What & why

<!-- What changes, and what problem it solves. -->
CBZ and CBR are zip files that can be opened through the app in varius ways. This works because we check for magic numbers. Now we add support for those two.

Closes #187

## How it was verified
cbz file created and opened via Finder > right click > Open With MacPacker

## Checklist

- [x] Verification evidence is included above
- [x] Changelog entry added to `Config/products/macpacker.json`
- [x] AI involvement disclosed, if AI was the primary author — see [AI_CONTRIBUTING.md](../AI_CONTRIBUTING.md)
