### PR TITLE
fix: unpack AppleDouble sidecars instead of extracting them as files

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -74,7 +74,7 @@
               "ru": "Извлечённые приложения считаются повреждёнными",
               "uk": "Видобуті програми вважаються пошкодженими",
               "es-MX": "Apps extraídas reportadas como dañadas",
-              "ko": "추출한 앱이 손상됨으로 표시됨",
+              "ko": "추출한 앱이 손상된 것으로 표시됨",
               "nl": "Uitgepakte apps gemeld als beschadigd",
               "tr": "Çıkarılan uygulamalar hasarlı olarak bildiriliyor"
             },

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -83,6 +83,29 @@
             ]
           },
           {
+            "type": "fix",
+            "title": {
+              "en": "macOS metadata files clutter the archive list",
+              "zh-Hans": "压缩包列表中显示 macOS 元数据文件",
+              "fr": "Les fichiers de métadonnées macOS encombrent la liste",
+              "de": "macOS-Metadatendateien überladen die Archivliste",
+              "it": "I file di metadati macOS ingombrano l'elenco",
+              "ja": "macOS のメタデータファイルが一覧を埋める",
+              "fa": "فایل‌های فراداده macOS فهرست آرشیو را شلوغ می‌کنند",
+              "pl": "Pliki metadanych macOS zaśmiecają listę archiwum",
+              "pt-BR": "Arquivos de metadados do macOS poluem a lista",
+              "ru": "Файлы метаданных macOS засоряют список архива",
+              "uk": "Файли метаданих macOS засмічують список архіву",
+              "es-MX": "Los archivos de metadatos de macOS saturan la lista",
+              "ko": "macOS 메타데이터 파일이 목록을 어지럽힘",
+              "nl": "macOS-metadatabestanden vervuilen de archieflijst",
+              "tr": "macOS meta veri dosyaları arşiv listesini dolduruyor"
+            },
+            "issues": [
+                "189"
+            ]
+          },
+          {
             "type": "lang",
             "title": {
               "en": "Language support for Turkish",

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -60,6 +60,29 @@
             ]
           },
           {
+            "type": "fix",
+            "title": {
+              "en": "Extracted apps reported as damaged",
+              "zh-Hans": "解压后的应用提示已损坏",
+              "fr": "Apps extraites signalées comme endommagées",
+              "de": "Entpackte Apps werden als beschädigt gemeldet",
+              "it": "App estratte segnalate come danneggiate",
+              "ja": "展開したアプリが壊れていると表示される",
+              "fa": "برنامه‌های استخراج‌شده آسیب‌دیده گزارش می‌شوند",
+              "pl": "Wypakowane aplikacje zgłaszane jako uszkodzone",
+              "pt-BR": "Apps extraídos relatados como danificados",
+              "ru": "Извлечённые приложения считаются повреждёнными",
+              "uk": "Видобуті програми вважаються пошкодженими",
+              "es-MX": "Apps extraídas reportadas como dañadas",
+              "ko": "추출한 앱이 손상됨으로 표시됨",
+              "nl": "Uitgepakte apps gemeld als beschadigd",
+              "tr": "Çıkarılan uygulamalar hasarlı olarak bildiriliyor"
+            },
+            "issues": [
+                "189"
+            ]
+          },
+          {
             "type": "lang",
             "title": {
               "en": "Language support for Turkish",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -453,9 +453,9 @@ let package = Package(
                 .copy("TestArchives/stuffit"),
                 .copy("TestArchives/zip"),
                 .copy("TestArchives/password"),
-                // Archives from the tools people actually use, so extraction can be
-                // checked against files nobody tailored to this implementation.
-                .copy("TestArchives/realworld")
+                // One app bundle per archiver, so extraction can be checked against
+                // files nobody here tailored to it.
+                .copy("TestArchives/archivers")
             ]
         )
     ]

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -452,7 +452,10 @@ let package = Package(
                 .copy("TestArchives/lzx"),
                 .copy("TestArchives/stuffit"),
                 .copy("TestArchives/zip"),
-                .copy("TestArchives/password")
+                .copy("TestArchives/password"),
+                // Archives from the tools people actually use, so extraction can be
+                // checked against files nobody tailored to this implementation.
+                .copy("TestArchives/realworld")
             ]
         )
     ]

--- a/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
+++ b/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
@@ -35,6 +35,13 @@ void sz_close(SZArchiveRef archive);
 /// Number of entries in the archive, or -1 on error.
 int32_t sz_entry_count(SZArchiveRef archive);
 
+/// Index of the entry an AppleDouble sidecar describes, or -1 when `index` is
+/// not a sidecar for another entry of this archive. Sidecars carry a file's
+/// extended attributes and resource fork, so they are that file's metadata: a
+/// rewrite that drops the file has to drop them with it, or the archive keeps
+/// metadata for something it no longer holds.
+int32_t sz_sidecar_target(SZArchiveRef archive, uint32_t index);
+
 typedef struct {
     uint32_t index;
     const char *path;        // UTF-8; pointer valid until sz_close()

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -15,6 +15,8 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <copyfile.h>
+#include <sys/xattr.h>
+#include <cerrno>
 
 #include "Common/MyWindows.h"
 #include "Common/MyCom.h"
@@ -533,9 +535,32 @@ static void unpackAppleDoubleSidecars(const std::vector<std::string> &sidecars,
         if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode))
             continue;
 
+        // COPYFILE_UNPACK replaces the target's extended attributes rather than
+        // merging into them, and macOS keeps Gatekeeper's verdict in one of them.
+        // Left alone, an archive could ship `Evil.app` beside a `._Evil.app`
+        // carrying no quarantine and have this extraction lift it off the bundle
+        // -- so the value is read first and put back afterwards, and whatever the
+        // archive had to say about it is discarded. Absent before means absent
+        // after, even if the sidecar tried to supply one.
+        static const char *const kQuarantine = "com.apple.quarantine";
+        char quarantine[1024];
+        const ssize_t quarantineLen = getxattr(target.c_str(), kQuarantine,
+                                               quarantine, sizeof(quarantine),
+                                               0, XATTR_NOFOLLOW);
+        // Anything other than "there is none" means we cannot restore what is
+        // there, so leave the sidecar alone rather than risk clearing it.
+        if (quarantineLen < 0 && errno != ENOATTR)
+            continue;
+
         if (copyfile(sidecar.c_str(), target.c_str(), nullptr,
-                     COPYFILE_UNPACK | COPYFILE_XATTR | COPYFILE_ACL) == 0)
+                     COPYFILE_UNPACK | COPYFILE_XATTR | COPYFILE_ACL) == 0) {
+            if (quarantineLen >= 0)
+                setxattr(target.c_str(), kQuarantine, quarantine,
+                         (size_t)quarantineLen, 0, XATTR_NOFOLLOW);
+            else
+                removexattr(target.c_str(), kQuarantine, XATTR_NOFOLLOW);
             unlink(sidecar.c_str());
+        }
     }
 }
 

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -321,6 +321,8 @@ public:
     /// a sidecar's name is not ours to touch.
     std::set<std::string> extractedPaths;
 
+    std::string destDir() const { return std::string(_destDir.Ptr(), (size_t)_destDir.Len()); }
+
 private:
     /// Creates `dir` and records the levels that did not exist beforehand.
     /// CreateComplexDir is mkdir -p: it reports success on a directory that was
@@ -475,10 +477,20 @@ void CExtractCallback::createDirsRecordingNew(const FString &dir) {
         extractedPaths.insert(level);
 }
 
-/// Maps "dir/._name" to the file it describes, "dir/name". Empty when `path` is
+/// The `__MACOSX/` mirror tree, as a path component under the destination root.
+static const char kSequesteredDir[] = "/__MACOSX/";
+
+/// Maps "dir/._name" to the entry it describes, "dir/name". Empty when `path` is
 /// not of that shape, including a bare "._" with nothing after it -- that would
 /// name the parent directory, which must never be an unpack target.
-static std::string appleDoubleTargetPath(const std::string &path) {
+///
+/// Sidecars come in two arrangements and both have to fold onto the real entry.
+/// Beside their file is one. The other is a top-level `__MACOSX/` mirror of the
+/// whole tree, which is what `ditto --sequesterRsrc` writes -- and therefore what
+/// Finder's "Compress" produces, so it is the common case rather than the exotic
+/// one. `rootLen` is the length of the destination path, which is what makes
+/// "top-level" meaningful; a `__MACOSX` further down is an ordinary directory.
+static std::string appleDoubleTargetPath(const std::string &path, size_t rootLen) {
     const size_t slash = path.rfind('/');
     const size_t base = (slash == std::string::npos) ? 0 : slash + 1;
     if (path.size() < base + 3 || path.compare(base, 2, "._") != 0)
@@ -486,6 +498,12 @@ static std::string appleDoubleTargetPath(const std::string &path) {
 
     std::string target = path;
     target.erase(base, 2);
+
+    const size_t sequesteredLen = sizeof(kSequesteredDir) - 1;
+    if (target.size() > rootLen + sequesteredLen &&
+        target.compare(rootLen, sequesteredLen, kSequesteredDir) == 0)
+        target.erase(rootLen + 1, sequesteredLen - 1);
+
     return target;
 }
 
@@ -548,9 +566,12 @@ static bool readExtendedAttributes(
 /// the extraction wrote it, so the worst case is the previous behaviour rather
 /// than a failed extraction.
 static void unpackAppleDoubleSidecars(const std::vector<std::string> &sidecars,
-                                      const std::set<std::string> &extractedPaths) {
+                                      const std::set<std::string> &extractedPaths,
+                                      const std::string &destDir) {
+    const size_t rootLen = destDir.size();
+
     for (const std::string &sidecar : sidecars) {
-        const std::string target = appleDoubleTargetPath(sidecar);
+        const std::string target = appleDoubleTargetPath(sidecar, rootLen);
         if (target.empty())
             continue;
 
@@ -614,6 +635,17 @@ static void unpackAppleDoubleSidecars(const std::vector<std::string> &sidecars,
 
         unlink(sidecar.c_str());
     }
+
+    // Emptying a `__MACOSX/` mirror leaves its directories behind, and they are
+    // nothing on their own -- they only ever held sidecars. Deepest first, since
+    // the set is sorted and a child sorts after its parent. rmdir refuses a
+    // directory that still holds something, which is exactly the guard wanted:
+    // anything the archive really kept in there stays, and so does its tree.
+    const std::string sequestered = destDir + kSequesteredDir;
+    for (auto it = extractedPaths.rbegin(); it != extractedPaths.rend(); ++it)
+        if (it->compare(0, sequestered.size(), sequestered) == 0)
+            rmdir(it->c_str());
+    rmdir((destDir + "/__MACOSX").c_str());
 }
 
 // Runs once per entry after its stream is fully written. Restores POSIX metadata
@@ -694,7 +726,8 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
     // the archive.
     extractedPaths.insert(path);
 
-    if (!_currentIsSymlink && !appleDoubleTargetPath(path).empty())
+    if (!_currentIsSymlink &&
+        !appleDoubleTargetPath(path, (size_t)_destDir.Len()).empty())
         appleDoubleSidecars.push_back(path);
 
     _currentIsSymlink = false;
@@ -742,7 +775,8 @@ static int finishExtract(CExtractCallback *callback, HRESULT hr, char **error_ou
     // Every entry is on disk now, so a sidecar and the file it describes have
     // both landed whichever order the archive stored them in. Runs even when an
     // entry failed: the files that did extract should still come out complete.
-    unpackAppleDoubleSidecars(callback->appleDoubleSidecars, callback->extractedPaths);
+    unpackAppleDoubleSidecars(callback->appleDoubleSidecars, callback->extractedPaths,
+                              callback->destDir());
 
     const Int32 opRes = callback->failedOpResult;
     const bool entryFailed = opRes != NArchive::NExtract::NOperationResult::kOK;

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -16,6 +16,7 @@
 #include <fcntl.h>
 #include <copyfile.h>
 #include <sys/xattr.h>
+#include <utility>
 #include <cerrno>
 
 #include "Common/MyWindows.h"
@@ -488,6 +489,39 @@ static std::string appleDoubleTargetPath(const std::string &path) {
     return target;
 }
 
+/// Name/value of every extended attribute on `path`. False means the set could
+/// not be read in full, which is the caller's cue to leave the file alone rather
+/// than run something over it that it cannot put back.
+static bool readExtendedAttributes(
+    const char *path, std::vector<std::pair<std::string, std::string>> &out)
+{
+    const ssize_t namesLen = listxattr(path, nullptr, 0, XATTR_NOFOLLOW);
+    if (namesLen < 0) return false;
+    if (namesLen == 0) return true;
+
+    std::string names((size_t)namesLen, '\0');
+    if (listxattr(path, &names[0], (size_t)namesLen, XATTR_NOFOLLOW) != namesLen)
+        return false;
+
+    // listxattr hands back NUL-separated names in one buffer.
+    for (size_t i = 0; i < (size_t)namesLen; ) {
+        const std::string name(names.c_str() + i);
+        i += name.size() + 1;
+        if (name.empty()) continue;
+
+        const ssize_t valueLen = getxattr(path, name.c_str(), nullptr, 0, 0, XATTR_NOFOLLOW);
+        if (valueLen < 0) return false;
+
+        std::string value((size_t)valueLen, '\0');
+        if (valueLen > 0 &&
+            getxattr(path, name.c_str(), &value[0], (size_t)valueLen, 0, XATTR_NOFOLLOW) != valueLen)
+            return false;
+
+        out.emplace_back(name, value);
+    }
+    return true;
+}
+
 /// Folds the AppleDouble sidecars collected during extraction into the files and
 /// directories they describe, then removes them.
 ///
@@ -535,32 +569,50 @@ static void unpackAppleDoubleSidecars(const std::vector<std::string> &sidecars,
         if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode))
             continue;
 
-        // COPYFILE_UNPACK replaces the target's extended attributes rather than
-        // merging into them, and macOS keeps Gatekeeper's verdict in one of them.
-        // Left alone, an archive could ship `Evil.app` beside a `._Evil.app`
-        // carrying no quarantine and have this extraction lift it off the bundle
-        // -- so the value is read first and put back afterwards, and whatever the
-        // archive had to say about it is discarded. Absent before means absent
-        // after, even if the sidecar tried to supply one.
+        // COPYFILE_UNPACK *replaces* the target's extended attributes rather than
+        // merging into them, so everything the file already wore has to be caught
+        // first and put back after. Two different reasons for that:
+        //
+        //   Quarantine is where macOS keeps Gatekeeper's verdict. Without this an
+        //   archive could ship `Evil.app` beside a `._Evil.app` carrying no
+        //   quarantine and have this extraction lift it off the bundle -- the
+        //   archive deciding its own contents are trusted.
+        //
+        //   Everything else is the user's. An entry replaces a file that was
+        //   already there, the same as `ditto` does, but the plain write keeps that
+        //   file's attributes -- so Finder tags and comments survive an overwrite.
+        //   They must not stop surviving just because the archive happened to carry
+        //   a sidecar for that one file.
         static const char *const kQuarantine = "com.apple.quarantine";
-        char quarantine[1024];
-        const ssize_t quarantineLen = getxattr(target.c_str(), kQuarantine,
-                                               quarantine, sizeof(quarantine),
-                                               0, XATTR_NOFOLLOW);
-        // Anything other than "there is none" means we cannot restore what is
-        // there, so leave the sidecar alone rather than risk clearing it.
-        if (quarantineLen < 0 && errno != ENOATTR)
+        std::vector<std::pair<std::string, std::string>> before;
+        if (!readExtendedAttributes(target.c_str(), before))
             continue;
 
+        bool hadQuarantine = false;
+        for (const auto &attr : before)
+            hadQuarantine |= (attr.first == kQuarantine);
+
         if (copyfile(sidecar.c_str(), target.c_str(), nullptr,
-                     COPYFILE_UNPACK | COPYFILE_XATTR | COPYFILE_ACL) == 0) {
-            if (quarantineLen >= 0)
-                setxattr(target.c_str(), kQuarantine, quarantine,
-                         (size_t)quarantineLen, 0, XATTR_NOFOLLOW);
-            else
-                removexattr(target.c_str(), kQuarantine, XATTR_NOFOLLOW);
-            unlink(sidecar.c_str());
+                     COPYFILE_UNPACK | COPYFILE_XATTR | COPYFILE_ACL) != 0)
+            continue;
+
+        for (const auto &attr : before) {
+            // Where both speak, the sidecar wins -- it is describing this very
+            // file. Quarantine is the exception: it is the system's verdict on
+            // where the file came from, never the archive's to restate.
+            if (attr.first != kQuarantine &&
+                getxattr(target.c_str(), attr.first.c_str(), nullptr, 0, 0,
+                         XATTR_NOFOLLOW) >= 0)
+                continue;
+            setxattr(target.c_str(), attr.first.c_str(), attr.second.data(),
+                     attr.second.size(), 0, XATTR_NOFOLLOW);
         }
+
+        // No quarantine before means none after, whatever the sidecar supplied.
+        if (!hadQuarantine)
+            removexattr(target.c_str(), kQuarantine, XATTR_NOFOLLOW);
+
+        unlink(sidecar.c_str());
     }
 }
 

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <deque>
 #include <vector>
+#include <set>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -309,8 +310,19 @@ public:
     /// order an archiver walking a directory tends to produce. finishExtract()
     /// drains this once every entry is on disk.
     std::vector<std::string> appleDoubleSidecars;
+    /// Every path this extraction created -- files as they finish, directories as
+    /// they are made. A sidecar is only ever folded into one of these. The
+    /// destination is not always empty: "Extract here" writes straight into a
+    /// folder of the user's own files, and "Extract to folder" reuses an existing
+    /// folder on a second run. A file already sitting there that happens to match
+    /// a sidecar's name is not ours to touch.
+    std::set<std::string> extractedPaths;
 
 private:
+    /// Records `dir` and every level above it up to the destination root.
+    /// CreateComplexDir makes the whole chain, so the whole chain is ours.
+    void rememberCreatedDirs(const FString &dir);
+
     IInArchive *_archive;
     FString _destDir;
     CMyComPtr<ISequentialOutStream> _outFileStream;
@@ -390,6 +402,7 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
 
     if (isDir) {
         NWindows::NFile::NDir::CreateComplexDir(fullPath);
+        rememberCreatedDirs(fullPath);
         return S_OK;
     }
 
@@ -398,6 +411,7 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     if (slashPos >= 0) {
         FString parentDir = fullPath.Left((unsigned)slashPos);
         NWindows::NFile::NDir::CreateComplexDir(parentDir);
+        rememberCreatedDirs(parentDir);
     }
 
     auto *outFileStreamSpec = new COutFileStream;
@@ -420,6 +434,20 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     _outFileStream = outStreamRef;
     *outStream = outStreamRef.Detach();
     return S_OK;
+}
+
+void CExtractCallback::rememberCreatedDirs(const FString &dir) {
+    const size_t rootLen = (size_t)_destDir.Len();
+    std::string path(dir.Ptr(), (size_t)dir.Len());
+
+    // Walk up to the destination root. insert() returning false means this level
+    // was recorded earlier, and so was everything above it -- stop there.
+    while (path.size() > rootLen && extractedPaths.insert(path).second) {
+        const size_t slash = path.rfind('/');
+        if (slash == std::string::npos || slash < rootLen)
+            break;
+        path.erase(slash);
+    }
 }
 
 /// Maps "dir/._name" to the file it describes, "dir/name". Empty when `path` is
@@ -461,10 +489,17 @@ static std::string appleDoubleTargetPath(const std::string &path) {
 /// Failures are silent by design. Anything not unpacked is left exactly where
 /// the extraction wrote it, so the worst case is the previous behaviour rather
 /// than a failed extraction.
-static void unpackAppleDoubleSidecars(const std::vector<std::string> &sidecars) {
+static void unpackAppleDoubleSidecars(const std::vector<std::string> &sidecars,
+                                      const std::set<std::string> &extractedPaths) {
     for (const std::string &sidecar : sidecars) {
         const std::string target = appleDoubleTargetPath(sidecar);
         if (target.empty())
+            continue;
+
+        // Only ever fold into something this extraction wrote. The destination
+        // can be a folder that already held the user's files, and one of them
+        // matching a sidecar's name by chance is not ours to modify.
+        if (extractedPaths.count(target) == 0)
             continue;
 
         // Directories carry metadata too -- macOS emits `._Resources` next to a
@@ -558,6 +593,8 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
     // Note a possible AppleDouble sidecar for finishExtract to fold in later. It
     // cannot be resolved here: the file it describes may still be ahead of us in
     // the archive.
+    extractedPaths.insert(path);
+
     if (!_currentIsSymlink && !appleDoubleTargetPath(path).empty())
         appleDoubleSidecars.push_back(path);
 
@@ -606,7 +643,7 @@ static int finishExtract(CExtractCallback *callback, HRESULT hr, char **error_ou
     // Every entry is on disk now, so a sidecar and the file it describes have
     // both landed whichever order the archive stored them in. Runs even when an
     // entry failed: the files that did extract should still come out complete.
-    unpackAppleDoubleSidecars(callback->appleDoubleSidecars);
+    unpackAppleDoubleSidecars(callback->appleDoubleSidecars, callback->extractedPaths);
 
     const Int32 opRes = callback->failedOpResult;
     const bool entryFailed = opRes != NArchive::NExtract::NOperationResult::kOK;

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -11,6 +11,7 @@
 #include <deque>
 #include <vector>
 #include <set>
+#include <unordered_map>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -121,6 +122,27 @@ struct SZArchiveHandle {
     UInt32 numItems;
     std::string password;
     bool hasPassword = false;
+
+    /// Entries that are AppleDouble sidecars for some other entry in this
+    /// archive, and so are metadata rather than files of their own. Kept out of
+    /// the listing -- the same treatment alternate streams already get, which is
+    /// where 7-Zip puts this metadata when the format carries it natively.
+    std::set<UInt32> hiddenSidecars;
+    /// For each visible entry, the sidecars describing it. An extraction of that
+    /// entry has to take them along, or its metadata is left in the archive.
+    std::unordered_map<UInt32, std::vector<UInt32>> companions;
+
+    /// Expands `requested` with the sidecars of everything in it. Sorted, and
+    /// without duplicates, which is what IInArchive::Extract wants.
+    std::vector<UInt32> withCompanions(const UInt32 *requested, UInt32 count) const {
+        std::set<UInt32> all(requested, requested + count);
+        for (UInt32 i = 0; i < count; i++) {
+            auto found = companions.find(requested[i]);
+            if (found != companions.end())
+                all.insert(found->second.begin(), found->second.end());
+        }
+        return std::vector<UInt32>(all.begin(), all.end());
+    }
 
     const char* storeString(const std::string &s) {
         storedStrings.push_back(s);
@@ -799,6 +821,87 @@ static int finishExtract(CExtractCallback *callback, HRESULT hr, char **error_ou
 
 extern "C" {
 
+/// Normalizes an archive entry path for matching: forward slashes, no leading
+/// separator, and no `__MACOSX/` prefix. That prefix is where
+/// `ditto --sequesterRsrc` -- and so Finder's "Compress" -- keeps a mirror of the
+/// tree holding nothing but sidecars, so an entry under it names the same thing
+/// as the entry without it.
+static std::string normalizedEntryPath(std::string path, bool *wasSequestered) {
+    for (char &c : path)
+        if (c == '\\') c = '/';
+    while (!path.empty() && path[0] == '/')
+        path.erase(0, 1);
+
+    // The mirror's own directory entry has no trailing separator, so match it
+    // both ways or the root is left behind as a visible empty folder.
+    static const std::string kMirror = "__MACOSX";
+    const bool sequestered =
+        path.compare(0, kMirror.size(), kMirror) == 0 &&
+        (path.size() == kMirror.size() || path[kMirror.size()] == '/');
+    if (sequestered)
+        path.erase(0, std::min(path.size(), kMirror.size() + 1));
+    if (wasSequestered)
+        *wasSequestered = sequestered;
+    return path;
+}
+
+/// Works out which entries are AppleDouble sidecars for other entries, so the
+/// listing can leave them out and an extraction can take them along.
+///
+/// An entry qualifies on its name and on a sibling existing under the name it
+/// describes -- the content is not read here, which would mean decompressing
+/// every candidate just to open an archive. Extraction still validates it, so a
+/// real file that merely starts with `._` is written out as itself. The one
+/// consequence is that such a file is missing from the listing and then appears
+/// on disk; nothing the listing promised ever fails to arrive.
+static void sz_indexAppleDoubleSidecars(SZArchiveHandle *handle) {
+    IInArchive *arc = handle->activeArchive();
+
+    std::unordered_map<std::string, UInt32> indexByPath;
+    std::vector<std::string> paths(handle->numItems);
+    std::vector<bool> sequestered(handle->numItems, false);
+
+    for (UInt32 i = 0; i < handle->numItems; i++) {
+        NWindows::NCOM::CPropVariant propPath;
+        if (arc->GetProperty(i, kpidPath, &propPath) != S_OK) continue;
+
+        bool fromMirror = false;
+        paths[i] = normalizedEntryPath(PropVariantToUTF8(propPath), &fromMirror);
+        sequestered[i] = fromMirror;
+        // A mirror entry never wins the name: the real entry owns it.
+        if (!fromMirror && !paths[i].empty())
+            indexByPath[paths[i]] = i;
+    }
+
+    for (UInt32 i = 0; i < handle->numItems; i++) {
+        const std::string &path = paths[i];
+
+        // The mirror holds sidecars and the directories leading to them, and
+        // nothing else -- so none of it is a file. That includes the `__MACOSX`
+        // root, whose path is empty once the prefix comes off.
+        if (sequestered[i])
+            handle->hiddenSidecars.insert(i);
+
+        if (path.empty()) continue;
+
+        const size_t slash = path.rfind('/');
+        const size_t base = (slash == std::string::npos) ? 0 : slash + 1;
+        if (path.size() < base + 3 || path.compare(base, 2, "._") != 0)
+            continue;
+
+        std::string described = path;
+        described.erase(base, 2);
+
+        // Nothing here for it to describe: a file like any other, however it is
+        // named. Left visible unless it came out of the mirror.
+        auto target = indexByPath.find(described);
+        if (target == indexByPath.end()) continue;
+
+        handle->hiddenSidecars.insert(i);
+        handle->companions[target->second].push_back(i);
+    }
+}
+
 SZArchiveRef sz_open(const char *path, const char *password,
                      bool *needs_password_out, char **error_out) {
     if (needs_password_out) *needs_password_out = false;
@@ -918,6 +1021,8 @@ SZArchiveRef sz_open(const char *path, const char *password,
         handle->activeArchive()->GetNumberOfItems(&numItems);
         handle->numItems = numItems;
 
+        sz_indexAppleDoubleSidecars(handle);
+
         // Cache IArchiveGetRawProps if the archive supports it
         handle->activeArchive()->QueryInterface(
             IID_IArchiveGetRawProps_Local,
@@ -982,6 +1087,14 @@ bool sz_get_entry(SZArchiveRef archive, uint32_t index, SZEntry *entry_out) {
     try {
         auto *handle = static_cast<SZArchiveHandle *>(archive);
         if (index >= handle->numItems) return false;
+
+        // Skip AppleDouble sidecars and the `__MACOSX/` mirror that holds them.
+        // They carry another entry's extended attributes and resource fork, not
+        // contents of their own, and extraction folds them into the entry they
+        // describe -- so listing them would promise files that deliberately do
+        // not arrive. Alternate streams below are the same metadata in the form
+        // 7-Zip models natively, and have always been skipped.
+        if (handle->hiddenSidecars.count(index) != 0) return false;
 
         // Skip alternate streams (macOS xattr, NTFS ADS)
         IInArchive *arc = handle->activeArchive();
@@ -1147,8 +1260,13 @@ int sz_extract_entries(SZArchiveRef archive, const uint32_t *indices,
                                                 progress, progress_context);
         CMyComPtr<IArchiveExtractCallback> callbackRef(callback);
 
+        // Sidecars are not in the listing, so a selection cannot name them. Pull
+        // in the ones describing what was asked for, or the entries come out
+        // stripped of the metadata the archive was carrying for them.
+        const std::vector<UInt32> expanded = handle->withCompanions(indices, count);
+
         HRESULT hr = handle->activeArchive()->Extract(
-            indices, count, 0, callback);
+            expanded.data(), (UInt32)expanded.size(), 0, callback);
 
         return finishExtract(callback, hr, error_out);
     } catch (...) {

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <copyfile.h>
 
 #include "Common/MyWindows.h"
 #include "Common/MyCom.h"
@@ -302,6 +303,12 @@ public:
     /// through SetOperationResult and *still* returns S_OK from Extract(), so
     /// without this the caller cannot tell a wrong password from a success.
     Int32 failedOpResult = NArchive::NExtract::NOperationResult::kOK;
+    /// Extracted files whose name starts with "._", i.e. candidate AppleDouble
+    /// sidecars. They cannot be resolved as they arrive: a sidecar may be stored
+    /// before the entry it describes, and `._x` sorts before `x`, so that is the
+    /// order an archiver walking a directory tends to produce. finishExtract()
+    /// drains this once every entry is on disk.
+    std::vector<std::string> appleDoubleSidecars;
 
 private:
     IInArchive *_archive;
@@ -415,6 +422,66 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     return S_OK;
 }
 
+/// Maps "dir/._name" to the file it describes, "dir/name". Empty when `path` is
+/// not of that shape, including a bare "._" with nothing after it -- that would
+/// name the parent directory, which must never be an unpack target.
+static std::string appleDoubleTargetPath(const std::string &path) {
+    const size_t slash = path.rfind('/');
+    const size_t base = (slash == std::string::npos) ? 0 : slash + 1;
+    if (path.size() < base + 3 || path.compare(base, 2, "._") != 0)
+        return std::string();
+
+    std::string target = path;
+    target.erase(base, 2);
+    return target;
+}
+
+/// Folds the AppleDouble sidecars collected during extraction into the files and
+/// directories they describe, then removes them.
+///
+/// When macOS has to keep extended attributes and a resource fork somewhere that
+/// cannot hold them -- a FAT stick, an SMB share -- it splits them out into a
+/// sibling "._name" file. From that point the sidecar is an ordinary file on
+/// disk, so any archiver that walks the folder stores it. Nothing here is
+/// zip-specific: this runs per entry, for every format the bridge reads, and tar
+/// and 7z carry the same sidecars. Left on disk it adds an entry to the
+/// extracted tree, and inside a signed .app that breaks the code-signature seal
+/// -- macOS then reports the app as damaged.
+///
+/// "._" is a naming convention, not a reservation, so a real file may be named
+/// that way and hold anything. Two guards keep those intact:
+///
+///   1. The file the sidecar describes has to already exist as a regular file.
+///      copyfile() with a missing destination *creates* it from the sidecar,
+///      conjuring a file the archive never contained.
+///   2. The sidecar is removed only once copyfile() reports success. It rejects
+///      a source that is not AppleDouble, which makes it the discriminator too:
+///      a plain file that merely starts with "._" fails here and stays put.
+///
+/// Failures are silent by design. Anything not unpacked is left exactly where
+/// the extraction wrote it, so the worst case is the previous behaviour rather
+/// than a failed extraction.
+static void unpackAppleDoubleSidecars(const std::vector<std::string> &sidecars) {
+    for (const std::string &sidecar : sidecars) {
+        const std::string target = appleDoubleTargetPath(sidecar);
+        if (target.empty())
+            continue;
+
+        // Directories carry metadata too -- macOS emits `._Resources` next to a
+        // bundle's `Resources/` -- so both kinds are valid targets. A symlink is
+        // not: copyfile() follows it and would write to whatever it points at.
+        struct stat st;
+        if (lstat(target.c_str(), &st) != 0)
+            continue;
+        if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode))
+            continue;
+
+        if (copyfile(sidecar.c_str(), target.c_str(), nullptr,
+                     COPYFILE_UNPACK | COPYFILE_XATTR | COPYFILE_ACL) == 0)
+            unlink(sidecar.c_str());
+    }
+}
+
 // Runs once per entry after its stream is fully written. Restores POSIX metadata
 // that the plain file-write above drops: the execute bit (chmod) and symbolic
 // links (recreated from the target bytes 7-Zip wrote). Single choke point for all
@@ -488,6 +555,12 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
             errorMessage = "Failed to set file permissions";
     }
 
+    // Note a possible AppleDouble sidecar for finishExtract to fold in later. It
+    // cannot be resolved here: the file it describes may still be ahead of us in
+    // the archive.
+    if (!_currentIsSymlink && !appleDoubleTargetPath(path).empty())
+        appleDoubleSidecars.push_back(path);
+
     _currentIsSymlink = false;
     _currentMode = 0;
     _currentFilePath.Empty();
@@ -529,6 +602,11 @@ static const char *describeOpResult(Int32 opRes) {
 static int finishExtract(CExtractCallback *callback, HRESULT hr, char **error_out) {
     if (callback->aborted || hr == E_ABORT)
         return SZ_EXTRACT_ABORTED;
+
+    // Every entry is on disk now, so a sidecar and the file it describes have
+    // both landed whichever order the archive stored them in. Runs even when an
+    // entry failed: the files that did extract should still come out complete.
+    unpackAppleDoubleSidecars(callback->appleDoubleSidecars);
 
     const Int32 opRes = callback->failedOpResult;
     const bool entryFailed = opRes != NArchive::NExtract::NOperationResult::kOK;

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -319,9 +319,11 @@ public:
     std::set<std::string> extractedPaths;
 
 private:
-    /// Records `dir` and every level above it up to the destination root.
-    /// CreateComplexDir makes the whole chain, so the whole chain is ours.
-    void rememberCreatedDirs(const FString &dir);
+    /// Creates `dir` and records the levels that did not exist beforehand.
+    /// CreateComplexDir is mkdir -p: it reports success on a directory that was
+    /// already there, so only a probe before the call can tell ours from the
+    /// user's.
+    void createDirsRecordingNew(const FString &dir);
 
     IInArchive *_archive;
     FString _destDir;
@@ -401,8 +403,7 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     fullPath += us2fs(safePath);
 
     if (isDir) {
-        NWindows::NFile::NDir::CreateComplexDir(fullPath);
-        rememberCreatedDirs(fullPath);
+        createDirsRecordingNew(fullPath);
         return S_OK;
     }
 
@@ -410,8 +411,7 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     int slashPos = (int)fullPath.ReverseFind_PathSepar();
     if (slashPos >= 0) {
         FString parentDir = fullPath.Left((unsigned)slashPos);
-        NWindows::NFile::NDir::CreateComplexDir(parentDir);
-        rememberCreatedDirs(parentDir);
+        createDirsRecordingNew(parentDir);
     }
 
     auto *outFileStreamSpec = new COutFileStream;
@@ -436,18 +436,40 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     return S_OK;
 }
 
-void CExtractCallback::rememberCreatedDirs(const FString &dir) {
+void CExtractCallback::createDirsRecordingNew(const FString &dir) {
     const size_t rootLen = (size_t)_destDir.Len();
     std::string path(dir.Ptr(), (size_t)dir.Len());
 
-    // Walk up to the destination root. insert() returning false means this level
-    // was recorded earlier, and so was everything above it -- stop there.
-    while (path.size() > rootLen && extractedPaths.insert(path).second) {
-        const size_t slash = path.rfind('/');
+    // Already ours, so every level above it is too -- the common case, since
+    // consecutive entries share a directory. Nothing left to work out.
+    if (path.size() <= rootLen || extractedPaths.count(path) != 0) {
+        NWindows::NFile::NDir::CreateComplexDir(dir);
+        return;
+    }
+
+    // Work out which levels this extraction is about to bring into being, before
+    // creating them. A directory already on disk belongs to whoever put it there:
+    // the destination can be a folder of the user's own files, and their
+    // `Resources/` must not collect metadata out of this archive just because an
+    // entry happens to sit inside it. Stops at the first level that exists or is
+    // already ours -- everything above that is settled.
+    std::vector<std::string> fresh;
+    std::string probe = path;
+    while (probe.size() > rootLen && extractedPaths.count(probe) == 0) {
+        struct stat st;
+        if (lstat(probe.c_str(), &st) == 0)
+            break;
+        fresh.push_back(probe);
+        const size_t slash = probe.rfind('/');
         if (slash == std::string::npos || slash < rootLen)
             break;
-        path.erase(slash);
+        probe.erase(slash);
     }
+
+    NWindows::NFile::NDir::CreateComplexDir(dir);
+
+    for (const std::string &level : fresh)
+        extractedPaths.insert(level);
 }
 
 /// Maps "dir/._name" to the file it describes, "dir/name". Empty when `path` is

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -131,15 +131,35 @@ struct SZArchiveHandle {
     /// For each visible entry, the sidecars describing it. An extraction of that
     /// entry has to take them along, or its metadata is left in the archive.
     std::unordered_map<UInt32, std::vector<UInt32>> companions;
+    /// Sidecars describing a directory, keyed by that directory's path. Kept
+    /// apart because a directory need not have an entry of its own: extracting
+    /// anything inside it is what brings the directory into being, so anything
+    /// inside it has to bring the sidecar too.
+    std::unordered_map<std::string, std::vector<UInt32>> directoryCompanions;
+    /// Normalized path per entry, for walking those directories back up.
+    std::vector<std::string> pathByIndex;
 
-    /// Expands `requested` with the sidecars of everything in it. Sorted, and
-    /// without duplicates, which is what IInArchive::Extract wants.
+    /// Expands `requested` with the sidecars of everything in it, and of every
+    /// directory leading to it. Sorted and without duplicates, which is what
+    /// IInArchive::Extract wants.
     std::vector<UInt32> withCompanions(const UInt32 *requested, UInt32 count) const {
         std::set<UInt32> all(requested, requested + count);
         for (UInt32 i = 0; i < count; i++) {
             auto found = companions.find(requested[i]);
             if (found != companions.end())
                 all.insert(found->second.begin(), found->second.end());
+
+            if (directoryCompanions.empty() || requested[i] >= pathByIndex.size())
+                continue;
+            std::string path = pathByIndex[requested[i]];
+            for (size_t slash = path.rfind('/'); slash != std::string::npos;
+                 slash = path.rfind('/')) {
+                path.erase(slash);
+                auto dir = directoryCompanions.find(path);
+                if (dir != directoryCompanions.end())
+                    all.insert(dir->second.begin(), dir->second.end());
+                if (path.empty()) break;
+            }
         }
         return std::vector<UInt32>(all.begin(), all.end());
     }
@@ -858,6 +878,10 @@ static void sz_indexAppleDoubleSidecars(SZArchiveHandle *handle) {
     IInArchive *arc = handle->activeArchive();
 
     std::unordered_map<std::string, UInt32> indexByPath;
+    // Directories an entry path implies. An archive need not store a directory
+    // entry for every level -- plenty do not -- but `._Resources` still describes
+    // the `Resources/` those levels stand for, and extraction creates it.
+    std::set<std::string> impliedDirs;
     std::vector<std::string> paths(handle->numItems);
     std::vector<bool> sequestered(handle->numItems, false);
 
@@ -871,7 +895,15 @@ static void sz_indexAppleDoubleSidecars(SZArchiveHandle *handle) {
         // A mirror entry never wins the name: the real entry owns it.
         if (!fromMirror && !paths[i].empty())
             indexByPath[paths[i]] = i;
+
+        for (size_t slash = paths[i].rfind('/'); slash != std::string::npos;
+             slash = paths[i].rfind('/', slash - 1)) {
+            impliedDirs.insert(paths[i].substr(0, slash));
+            if (slash == 0) break;
+        }
     }
+
+    handle->pathByIndex = paths;
 
     for (UInt32 i = 0; i < handle->numItems; i++) {
         const std::string &path = paths[i];
@@ -892,13 +924,27 @@ static void sz_indexAppleDoubleSidecars(SZArchiveHandle *handle) {
         std::string described = path;
         described.erase(base, 2);
 
+        auto target = indexByPath.find(described);
+        if (target != indexByPath.end()) {
+            handle->hiddenSidecars.insert(i);
+            handle->companions[target->second].push_back(i);
+            continue;
+        }
+
+        // No entry of that name, but the path is a directory the entries imply.
+        // Extraction creates it and folds the sidecar into it, so listing the
+        // sidecar would again promise a file that never arrives. Nothing to hang
+        // it off for selection either, so it is keyed by the directory and picked
+        // up by anything extracted from inside it.
+        if (impliedDirs.count(described) != 0) {
+            handle->hiddenSidecars.insert(i);
+            handle->directoryCompanions[described].push_back(i);
+            continue;
+        }
+
         // Nothing here for it to describe: a file like any other, however it is
         // named. Left visible unless it came out of the mirror.
-        auto target = indexByPath.find(described);
-        if (target == indexByPath.end()) continue;
-
-        handle->hiddenSidecars.insert(i);
-        handle->companions[target->second].push_back(i);
+        continue;
     }
 }
 
@@ -1080,6 +1126,15 @@ int32_t sz_entry_count(SZArchiveRef archive) {
     } catch (...) {
         return -1;
     }
+}
+
+int32_t sz_sidecar_target(SZArchiveRef archive, uint32_t index) {
+    if (!archive) return -1;
+    auto *handle = static_cast<SZArchiveHandle *>(archive);
+    for (const auto &pair : handle->companions)
+        for (UInt32 sidecar : pair.second)
+            if (sidecar == index) return (int32_t)pair.first;
+    return -1;
 }
 
 bool sz_get_entry(SZArchiveRef archive, uint32_t index, SZEntry *entry_out) {

--- a/Modules/Sources/Swift7zip/SevenZipWriter.swift
+++ b/Modules/Sources/Swift7zip/SevenZipWriter.swift
@@ -127,6 +127,13 @@ extension SevenZipArchive {
             }
             for i in 0..<UInt32(entryCount) {
                 if removedIndices.contains(i) { continue }
+                // A sidecar is its file's extended attributes and resource fork,
+                // not a file of its own, and it is not in the listing for the user
+                // to remove alongside. Dropping the file drops them with it, or the
+                // archive keeps metadata describing something it no longer holds —
+                // which then shows up as a stray `._name` entry.
+                let sidecarTarget = sz_sidecar_target(archive.handle.ref, i)
+                if sidecarTarget >= 0 && removedIndices.contains(UInt32(sidecarTarget)) { continue }
                 if let newPath = movedIndices[i] {
                     result.append(.move(sourceIndex: i, newPath: newPath))
                 } else {

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -582,12 +582,16 @@ extension AllCoreTests {
 
         // codesign is the same judgement #189 was reported as — an app macOS called
         // damaged — made by the system rather than by this test. Only the archives
-        // that can carry a bundle intact are listed: `realworld/ditto_inline.zip`
-        // and `realworld/sevenzip.zip` both lose framework version symlinks, and
+        // that can carry a bundle intact are listed: `archivers/ditto_inline.zip`
+        // and `archivers/sevenzip.zip` both lose framework version symlinks, and
         // Archive Utility fails them the same way, so their bundles are broken
         // before extraction begins. Those two are covered by the engine comparison
         // instead.
-        @Test(arguments: ["realworld/finder_compress.zip", "realworld/infozip.zip"])
+        @Test(arguments: [
+            "archivers/finder_compress.zip",
+            "archivers/infozip.zip",
+            "archivers/keka.zip"
+        ])
         func realWorldArchivesExtractToAValidBundle(name: String) async throws {
             let parts = name.split(separator: "/")
             let folder = Bundle.module.url(forResource: String(parts[0]), withExtension: nil)!
@@ -624,13 +628,13 @@ extension AllCoreTests {
         @Test(arguments: [
             "zip/minimalApp.zip",
             "zip/appbundle.zip",
-            // The corpus proper: one bundle, archived by Finder's "Compress", by
-            // ditto without sequestering, by Info-ZIP and by 7-Zip's writer. Nobody
-            // shaped these around this implementation.
-            "realworld/finder_compress.zip",
-            "realworld/ditto_inline.zip",
-            "realworld/infozip.zip",
-            "realworld/sevenzip.zip"
+            // One bundle per archiver — Finder's "Compress", ditto without
+            // sequestering, Info-ZIP, Keka, 7-Zip. Nobody here shaped these.
+            "archivers/finder_compress.zip",
+            "archivers/ditto_inline.zip",
+            "archivers/infozip.zip",
+            "archivers/keka.zip",
+            "archivers/sevenzip.zip"
         ])
         func sevenZipAgreesWithXadOnRealArchives(name: String) async throws {
             let parts = name.split(separator: "/")

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -339,6 +339,66 @@ extension AllCoreTests {
             )
         }
 
+        // The general form of the guard above, and the one that does not depend on
+        // knowing which name is dangerous. An extraction owns what it writes and
+        // nothing else — but the destination is not always empty: "Extract here"
+        // writes into a folder of the user's own files, and "Extract to folder"
+        // reuses an existing folder on a second run. Post-processing passes are
+        // where this goes wrong, because they run over paths rather than over the
+        // stream they just wrote; the AppleDouble drain did exactly that.
+        //
+        // Deliberately not about name collisions: an entry that matches a file
+        // already there does replace it, the same as `ditto`. This is about the
+        // files an archive never mentions at all.
+        @Test func extractionLeavesFilesItDidNotCreateAlone() async throws {
+            let engine = Archive7ZipEngine()
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("appledouble.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            // Bystanders, none of them named by the archive, planted in the very
+            // directories the extraction writes into. The `._userfile.dat` pair is
+            // the sharp one: a complete AppleDouble pair the user already had, which
+            // an extractor working from names rather than from what it wrote would
+            // happily fold together and delete half of.
+            let bystanders: [(path: String, contents: String)] = [
+                ("payload/orphan.bin", "the file an archive sidecar names but never carries\n"),
+                ("payload/userfile.dat", "a file of the user's own\n"),
+                ("payload/._userfile.dat", "its sidecar, also the user's own\n"),
+                ("payload/Contents/Resources/keepme.png", "a bystander where the sidecars land\n")
+            ]
+            for bystander in bystanders {
+                let fileURL = tempDir.appendingPathComponent(bystander.path)
+                try fm.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try Data(bystander.contents.utf8).write(to: fileURL)
+            }
+
+            _ = try await engine.extract(
+                items: items,
+                from: url,
+                to: tempDir,
+                passwordResolver: { _ in nil }
+            )
+
+            for bystander in bystanders {
+                let fileURL = tempDir.appendingPathComponent(bystander.path)
+                #expect(
+                    (try? Data(contentsOf: fileURL)) == Data(bystander.contents.utf8),
+                    "\(bystander.path) was not written by this extraction and must come out untouched"
+                )
+                #expect(
+                    extendedAttribute("com.macpacker.test", at: fileURL) == nil,
+                    "\(bystander.path) must not receive metadata from the archive"
+                )
+            }
+        }
+
         @Test func extractEmptyItemsThrows() async throws {
             let engine = Archive7ZipEngine()
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -580,6 +580,34 @@ extension AllCoreTests {
             #expect(codesignVerdict(app) == 0, "extracted bundle failed codesign")
         }
 
+        // codesign is the same judgement #189 was reported as — an app macOS called
+        // damaged — made by the system rather than by this test. Only the archives
+        // that can carry a bundle intact are listed: `realworld/ditto_inline.zip`
+        // and `realworld/sevenzip.zip` both lose framework version symlinks, and
+        // Archive Utility fails them the same way, so their bundles are broken
+        // before extraction begins. Those two are covered by the engine comparison
+        // instead.
+        @Test(arguments: ["realworld/finder_compress.zip", "realworld/infozip.zip"])
+        func realWorldArchivesExtractToAValidBundle(name: String) async throws {
+            let parts = name.split(separator: "/")
+            let folder = Bundle.module.url(forResource: String(parts[0]), withExtension: nil)!
+            let url = folder.appendingPathComponent(String(parts[1]))
+
+            let engine = Archive7ZipEngine()
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            _ = try await engine.extract(items: Array(loadResult.items.values), from: url,
+                                         to: tempDir, passwordResolver: { _ in nil })
+
+            let app = tempDir.appendingPathComponent("MinimalApp.app")
+            try #require(fm.fileExists(atPath: app.path))
+            #expect(codesignVerdict(app) == 0, "\(name) extracted to a bundle codesign rejects")
+        }
+
         // The tests above assert what this implementation was built to do, which is
         // worth only so much — they were written by the same hand that wrote the
         // code. This one asks a different question: does the 7-Zip engine agree with
@@ -593,10 +621,21 @@ extension AllCoreTests {
         // directory entries at all, which no real tool produces — XADMaster gets
         // wrong. Fixtures like that are what this test exists to compensate for, so
         // it is restricted to archives real tools actually made.
-        @Test(arguments: ["minimalApp.zip", "appbundle.zip"])
+        @Test(arguments: [
+            "zip/minimalApp.zip",
+            "zip/appbundle.zip",
+            // The corpus proper: one bundle, archived by Finder's "Compress", by
+            // ditto without sequestering, by Info-ZIP and by 7-Zip's writer. Nobody
+            // shaped these around this implementation.
+            "realworld/finder_compress.zip",
+            "realworld/ditto_inline.zip",
+            "realworld/infozip.zip",
+            "realworld/sevenzip.zip"
+        ])
         func sevenZipAgreesWithXadOnRealArchives(name: String) async throws {
-            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
-            let url = zipFolder.appendingPathComponent(name)
+            let parts = name.split(separator: "/")
+            let folder = Bundle.module.url(forResource: String(parts[0]), withExtension: nil)!
+            let url = folder.appendingPathComponent(String(parts[1]))
             let fm = FileManager.default
 
             var snapshots: [String: [String: String]] = [:]

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -373,6 +373,12 @@ extension AllCoreTests {
                 ("payload/._userfile.dat", "its sidecar, also the user's own\n"),
                 ("payload/Contents/Resources/keepme.png", "a bystander where the sidecars land\n")
             ]
+            // Planting that last one also makes `payload/Contents/Resources/` a
+            // directory the user already had. The archive carries `._Resources`
+            // describing exactly that path, and writes `icon.png` inside it — but
+            // `CreateComplexDir` is mkdir -p and reports success on a directory that
+            // was already there, so writing into it must not be mistaken for making
+            // it.
             for bystander in bystanders {
                 let fileURL = tempDir.appendingPathComponent(bystander.path)
                 try fm.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -397,6 +403,17 @@ extension AllCoreTests {
                     "\(bystander.path) must not receive metadata from the archive"
                 )
             }
+
+            // The directory the bystander sits in was the user's, not ours.
+            let resources = tempDir.appendingPathComponent("payload/Contents/Resources")
+            #expect(
+                extendedAttribute("com.macpacker.dir", at: resources) == nil,
+                "a directory the extraction only wrote into must not collect metadata from ._Resources"
+            )
+            #expect(
+                fm.fileExists(atPath: tempDir.appendingPathComponent("payload/Contents/._Resources").path),
+                "._Resources has no directory of ours to fold into and must stay put"
+            )
         }
 
         @Test func extractEmptyItemsThrows() async throws {

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -236,6 +236,15 @@ extension AllCoreTests {
             try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
+            // "Extract here" writes straight into a folder of the user's own files,
+            // and "Extract to folder" reuses an existing folder on a second run — so
+            // the destination is not always empty. Plant a file the archive does not
+            // contain, whose name a sidecar in it happens to describe.
+            let fm = FileManager.default
+            let squatter = tempDir.appendingPathComponent("payload/orphan.bin")
+            try fm.createDirectory(at: squatter.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data("a file the user already had\n".utf8).write(to: squatter)
+
             _ = try await engine.extract(
                 items: items,
                 from: url,
@@ -244,7 +253,6 @@ extension AllCoreTests {
             )
 
             let payload = tempDir.appendingPathComponent("payload")
-            let fm = FileManager.default
 
             // 1. Both real sidecars are consumed, and both targets come out carrying
             //    what the sidecar held. The two differ only in storage order —
@@ -319,9 +327,15 @@ extension AllCoreTests {
                 fm.fileExists(atPath: payload.appendingPathComponent("._orphan.bin").path),
                 "._orphan.bin has no target to unpack into and must survive"
             )
+            // The planted file is not ours: the extraction never wrote it, so its
+            // contents and its metadata both have to come out exactly as they went in.
             #expect(
-                fm.fileExists(atPath: payload.appendingPathComponent("orphan.bin").path) == false,
-                "orphan.bin was never in the archive and must not be conjured from its sidecar"
+                (try? Data(contentsOf: squatter)) == Data("a file the user already had\n".utf8),
+                "a pre-existing orphan.bin must not be rewritten by the extraction"
+            )
+            #expect(
+                extendedAttribute("com.macpacker.test", at: squatter) == nil,
+                "._orphan.bin must not fold its metadata into a file the extraction did not create"
             )
         }
 

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -212,6 +212,119 @@ extension AllCoreTests {
             )
         }
 
+        // Regression for #189: when macOS cannot store a file's xattrs and resource
+        // fork in place — a FAT stick, an SMB share — it splits them into a sibling
+        // `._name` file in AppleDouble format. That sidecar is then an ordinary
+        // file, so any archiver walking the folder stores it; nothing about it is
+        // zip-specific. Written out as a file it adds an entry to the tree, which
+        // inside a signed `.app` breaks the code-signature seal — the reported
+        // archive extracted to a bundle macOS called damaged. The sidecar has to be
+        // unpacked into the entry it describes and removed.
+        //
+        // `._` is a convention, not a reservation, so the fixture also carries
+        // files that only look like sidecars and must survive untouched. See
+        // `zip/make_appledouble.sh` in MacPacker-TestArchives for the full matrix.
+        @Test func extractionUnpacksAppleDoubleSidecarsAndSparesDecoys() async throws {
+            let engine = Archive7ZipEngine()
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("appledouble.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            _ = try await engine.extract(
+                items: items,
+                from: url,
+                to: tempDir,
+                passwordResolver: { _ in nil }
+            )
+
+            let payload = tempDir.appendingPathComponent("payload")
+            let fm = FileManager.default
+
+            // 1. Both real sidecars are consumed, and both targets come out carrying
+            //    what the sidecar held. The two differ only in storage order —
+            //    `._icon.png` precedes its file, `._helper` follows it — because an
+            //    extractor that unpacks a sidecar the moment it reads it handles
+            //    only the second. Order means nothing in a zip, and `._x` sorts
+            //    before `x`, so the first form is what plain `zip -r` produces.
+            for target in ["Contents/Resources/icon.png", "Contents/MacOS/helper"] {
+                let fileURL = payload.appendingPathComponent(target)
+                let sidecarURL = fileURL
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("._" + fileURL.lastPathComponent)
+
+                #expect(
+                    fm.fileExists(atPath: sidecarURL.path) == false,
+                    "\(sidecarURL.lastPathComponent) should have been unpacked into \(target) and removed"
+                )
+                #expect(
+                    extendedAttribute("com.apple.ResourceFork", at: fileURL)
+                        == Data("RESOURCE-FORK-PAYLOAD".utf8),
+                    "\(target) should carry the resource fork from its sidecar"
+                )
+                #expect(
+                    extendedAttribute("com.macpacker.test", at: fileURL)
+                        == Data("appledouble-fixture".utf8),
+                    "\(target) should carry the xattr from its sidecar"
+                )
+            }
+
+            // 2. Unpacking metadata must not touch the data fork. The fixture stores
+            //    a 1x1 PNG; applying the sidecar with the wrong copyfile flags would
+            //    overwrite these bytes with the AppleDouble instead.
+            let iconData = try Data(contentsOf: payload.appendingPathComponent("Contents/Resources/icon.png"))
+            #expect(iconData.count == 70, "icon.png data fork should be untouched, got \(iconData.count) bytes")
+            #expect(iconData.starts(with: [0x89, 0x50, 0x4E, 0x47]), "icon.png should still be a PNG")
+
+            // 3. A file that merely starts with `._` is a normal file. This one is
+            //    plain text and its sibling exists, so only its content separates it
+            //    from the two above — deleting it on the name alone loses user data.
+            let decoy = payload.appendingPathComponent("._notadouble.txt")
+            #expect(fm.fileExists(atPath: decoy.path), "._notadouble.txt is not AppleDouble and must survive")
+            #expect(
+                (try? Data(contentsOf: decoy)) == Data("A real file that merely starts with dot-underscore.\n".utf8),
+                "._notadouble.txt should come out byte-identical"
+            )
+
+            // 4. Directories carry extended attributes too, and macOS emits
+            //    `._Resources` beside a bundle's `Resources/` as readily as it does
+            //    for a file. Inside a bundle such a sidecar breaks the seal the same
+            //    way, so it has to go the same way — and `Resources/` has to survive
+            //    as a directory, with its contents untouched.
+            let resources = payload.appendingPathComponent("Contents/Resources")
+            #expect(
+                fm.fileExists(atPath: payload.appendingPathComponent("Contents/._Resources").path) == false,
+                "._Resources describes the Resources directory and should have been unpacked into it"
+            )
+            var resourcesIsDirectory: ObjCBool = false
+            #expect(
+                fm.fileExists(atPath: resources.path, isDirectory: &resourcesIsDirectory)
+                    && resourcesIsDirectory.boolValue,
+                "Resources should still be a directory"
+            )
+            #expect(
+                extendedAttribute("com.macpacker.dir", at: resources) == Data("appledouble-fixture".utf8),
+                "Resources should carry the xattr from its sidecar"
+            )
+
+            // 5. A real AppleDouble with no sibling stays put. `copyfile` with
+            //    COPYFILE_UNPACK happily creates a missing destination, which would
+            //    invent `orphan.bin` — a file the archive never contained.
+            #expect(
+                fm.fileExists(atPath: payload.appendingPathComponent("._orphan.bin").path),
+                "._orphan.bin has no target to unpack into and must survive"
+            )
+            #expect(
+                fm.fileExists(atPath: payload.appendingPathComponent("orphan.bin").path) == false,
+                "orphan.bin was never in the archive and must not be conjured from its sidecar"
+            )
+        }
+
         @Test func extractEmptyItemsThrows() async throws {
             let engine = Archive7ZipEngine()
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
@@ -890,4 +1003,21 @@ extension AllCoreTests {
             }
         }
     }
+}
+
+/// Reads one extended attribute, or nil when the file does not carry it.
+/// `FileManager` exposes no API for these, and the AppleDouble regression above
+/// is entirely about whether they arrive — including `com.apple.ResourceFork`,
+/// which is how macOS stores a resource fork.
+private func extendedAttribute(_ name: String, at url: URL) -> Data? {
+    let size = getxattr(url.path, name, nil, 0, 0, 0)
+    guard size >= 0 else { return nil }
+    guard size > 0 else { return Data() }
+
+    var buffer = Data(count: size)
+    let read = buffer.withUnsafeMutableBytes {
+        getxattr(url.path, name, $0.baseAddress, size, 0, 0)
+    }
+    guard read == size else { return nil }
+    return buffer
 }

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -370,7 +370,6 @@ extension AllCoreTests {
             let bystanders: [(path: String, contents: String)] = [
                 ("payload/orphan.bin", "the file an archive sidecar names but never carries\n"),
                 ("payload/userfile.dat", "a file of the user's own\n"),
-                ("payload/._userfile.dat", "its sidecar, also the user's own\n"),
                 ("payload/Contents/Resources/keepme.png", "a bystander where the sidecars land\n")
             ]
             // Planting that last one also makes `payload/Contents/Resources/` a
@@ -384,6 +383,26 @@ extension AllCoreTests {
                 try fm.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
                 try Data(bystander.contents.utf8).write(to: fileURL)
             }
+
+            // `userfile.dat` gets a real sidecar of its own, packed by the same
+            // system call that unpacks one — plain bytes would not do, because a
+            // destination-walking implementation would reject them on content alone
+            // and this would pass without proving anything. Both halves are the
+            // user's, and the extraction has no business reading either: the drain
+            // works from the list of sidecars it wrote, never from what it finds on
+            // disk. Fold these together and the user loses `._userfile.dat`.
+            let userFile = tempDir.appendingPathComponent("payload/userfile.dat")
+            let userSidecar = tempDir.appendingPathComponent("payload/._userfile.dat")
+            setExtendedAttribute("com.macpacker.userown", Data("the user's own metadata".utf8), at: userFile)
+            #expect(
+                copyfile(userFile.path, userSidecar.path, nil,
+                         copyfile_flags_t(COPYFILE_PACK | COPYFILE_XATTR | COPYFILE_ACL)) == 0,
+                "could not pack the bystander sidecar"
+            )
+            let userSidecarBytes = try Data(contentsOf: userSidecar)
+            let userFileXattr = extendedAttribute("com.macpacker.userown", at: userFile)
+            #expect(userSidecarBytes.starts(with: [0x00, 0x05, 0x16, 0x07]), "bystander sidecar should be AppleDouble")
+            #expect(userFileXattr != nil)
 
             _ = try await engine.extract(
                 items: items,
@@ -403,6 +422,17 @@ extension AllCoreTests {
                     "\(bystander.path) must not receive metadata from the archive"
                 )
             }
+
+            // Neither half of the user's own AppleDouble pair may be read, rewritten
+            // or removed — not the sidecar, and not the metadata it describes.
+            #expect(
+                (try? Data(contentsOf: userSidecar)) == userSidecarBytes,
+                "a sidecar the extraction did not write must come out byte-identical"
+            )
+            #expect(
+                extendedAttribute("com.macpacker.userown", at: userFile) == userFileXattr,
+                "userfile.dat must keep the metadata it already had"
+            )
 
             // The directory the bystander sits in was the user's, not ours.
             let resources = tempDir.appendingPathComponent("payload/Contents/Resources")
@@ -1111,4 +1141,13 @@ private func extendedAttribute(_ name: String, at url: URL) -> Data? {
     }
     guard read == size else { return nil }
     return buffer
+}
+
+/// Sets one extended attribute. The counterpart to `extendedAttribute`, for
+/// seeding metadata a test then asserts survives untouched.
+private func setExtendedAttribute(_ name: String, _ value: Data, at url: URL) {
+    let result = value.withUnsafeBytes {
+        setxattr(url.path, name, $0.baseAddress, value.count, 0, 0)
+    }
+    precondition(result == 0, "setxattr \(name) failed on \(url.path)")
 }

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -384,6 +384,15 @@ extension AllCoreTests {
                 try Data(bystander.contents.utf8).write(to: fileURL)
             }
 
+            // Two entries the archive *does* carry, planted first so the extraction
+            // overwrites them: one the archive has a sidecar for, one it does not.
+            for name in ["payload/Contents/MacOS/helper", "payload/notadouble.txt"] {
+                let fileURL = tempDir.appendingPathComponent(name)
+                try fm.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try Data("the user's own copy\n".utf8).write(to: fileURL)
+                setExtendedAttribute("com.macpacker.usertag", Data("a tag the user put there".utf8), at: fileURL)
+            }
+
             // `userfile.dat` gets a real sidecar of its own, packed by the same
             // system call that unpacks one — plain bytes would not do, because a
             // destination-walking implementation would reject them on content alone
@@ -433,6 +442,21 @@ extension AllCoreTests {
                 extendedAttribute("com.macpacker.userown", at: userFile) == userFileXattr,
                 "userfile.dat must keep the metadata it already had"
             )
+
+            // An entry that matches a file already in the destination replaces it,
+            // the same as `ditto` does — but the write keeps that file's extended
+            // attributes, so Finder tags and comments survive an overwrite. Folding
+            // a sidecar in must not change that: whether your tags survive cannot
+            // depend on whether the archive happened to ship a `._` file for that
+            // one path. `notadouble.txt` is the control, an overwritten entry with
+            // no sidecar of its own.
+            for name in ["payload/Contents/MacOS/helper", "payload/notadouble.txt"] {
+                #expect(
+                    extendedAttribute("com.macpacker.usertag", at: tempDir.appendingPathComponent(name))
+                        == Data("a tag the user put there".utf8),
+                    "\(name) was overwritten, but its own metadata is not the archive's to discard"
+                )
+            }
 
             // The directory the bystander sits in was the user's, not ours.
             let resources = tempDir.appendingPathComponent("payload/Contents/Resources")

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -561,15 +561,18 @@ extension AllCoreTests {
                                          to: tempDir, passwordResolver: { _ in nil })
 
             // Nothing of the mirror survives — neither the sidecars nor the
-            // directories that only ever existed to hold them.
-            var leftovers: [String] = []
-            let walker = fm.enumerator(at: tempDir, includingPropertiesForKeys: nil)!
-            while let fileURL = walker.nextObject() as? URL {
-                if fileURL.path.contains("__MACOSX") || fileURL.lastPathComponent.hasPrefix("._") {
-                    leftovers.append(fileURL.lastPathComponent)
-                }
-            }
-            #expect(leftovers.isEmpty, "the __MACOSX mirror should be gone, found \(leftovers)")
+            // directories that only ever existed to hold them. The sidecars have to
+            // be looked for by name: FileManager's directory enumeration cannot see
+            // a `._` file at all, so scanning for them finds nothing whether they
+            // are there or not.
+            #expect(
+                appleDoubleLeftovers(in: tempDir).isEmpty,
+                "sidecars should be folded in, found \(appleDoubleLeftovers(in: tempDir))"
+            )
+            #expect(
+                fm.fileExists(atPath: tempDir.appendingPathComponent("__MACOSX").path) == false,
+                "the __MACOSX mirror holds nothing but sidecars and should be gone"
+            )
 
             // And the bundle it describes still verifies. This is the assertion that
             // matches what a user does with the archive: #189 was reported as an app
@@ -661,6 +664,43 @@ extension AllCoreTests {
                     "\(name) \(path): 7z produced \(sevenZip[path] ?? "<absent>"), xad produced \(xad[path] ?? "<absent>")"
                 )
             }
+        }
+
+        // The listing has to agree with the extraction, and both engines have to
+        // agree with each other. They did not: for an archive with inline sidecars
+        // the 7-Zip engine listed 43 entries and delivered 22, while XADMaster
+        // listed the 22 it delivers. Entries a user can see, select and delete —
+        // MacPacker edits zips — but that no extraction ever produces are worse
+        // than a cosmetic difference: deleting one silently discards the metadata
+        // of the file it belongs to.
+        @Test(arguments: [
+            "archivers/finder_compress.zip",
+            "archivers/ditto_inline.zip",
+            "archivers/infozip.zip",
+            "archivers/keka.zip",
+            "archivers/sevenzip.zip",
+            "zip/minimalApp.zip"
+        ])
+        func bothEnginesListTheSameEntries(name: String) async throws {
+            let parts = name.split(separator: "/")
+            let folder = Bundle.module.url(forResource: String(parts[0]), withExtension: nil)!
+            let url = folder.appendingPathComponent(String(parts[1]))
+
+            var listings: [String: [String]] = [:]
+            for (label, engine) in [("7z", Archive7ZipEngine() as ArchiveEngine),
+                                    ("xad", ArchiveXadEngine() as ArchiveEngine)] {
+                let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+                listings[label] = loadResult.items.values.map(\.name).sorted()
+            }
+
+            #expect(
+                listings["7z"]!.filter { $0.hasPrefix("._") }.isEmpty,
+                "sidecars are metadata, not entries, and should not be listed"
+            )
+            #expect(
+                listings["7z"]!.count == listings["xad"]!.count,
+                "\(name): 7z lists \(listings["7z"]!.count) entries, xad lists \(listings["xad"]!.count)"
+            )
         }
 
         @Test func extractEmptyItemsThrows() async throws {
@@ -1431,5 +1471,38 @@ private func extractionSnapshot(_ root: URL) -> [String: String] {
 
         snapshot[fileURL.path.replacingOccurrences(of: rootPath, with: "")] = facts.joined(separator: " ")
     }
+
+    // Directory enumeration cannot see a `._` file, so a sidecar left behind by
+    // one engine and not the other would go unnoticed — exactly the divergence
+    // this comparison exists for. Ask for them by name instead.
+    for path in snapshot.keys {
+        let fileURL = URL(fileURLWithPath: rootPath + path)
+        let sidecar = fileURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("._" + fileURL.lastPathComponent)
+        var info = stat()
+        if lstat(sidecar.path, &info) == 0 {
+            snapshot[sidecar.path.replacingOccurrences(of: rootPath, with: "")] =
+                "sidecar:\((try? Data(contentsOf: sidecar))?.count ?? -1)"
+        }
+    }
     return snapshot
+}
+
+/// AppleDouble sidecars still sitting next to the entries they describe. Found by
+/// name because `FileManager` cannot enumerate them: on macOS a `._` file is
+/// invisible to `contentsOfDirectory` and to directory enumerators, though
+/// `fileExists` and `lstat` see it perfectly well. A test that scans for them
+/// finds nothing whether or not they are there.
+private func appleDoubleLeftovers(in root: URL) -> [String] {
+    let fm = FileManager.default
+    var found: [String] = []
+    guard let walker = fm.enumerator(at: root, includingPropertiesForKeys: nil) else { return found }
+    while let fileURL = walker.nextObject() as? URL {
+        let sidecar = fileURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("._" + fileURL.lastPathComponent)
+        if fm.fileExists(atPath: sidecar.path) { found.append(sidecar.lastPathComponent) }
+    }
+    return found.sorted()
 }

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -320,7 +320,26 @@ extension AllCoreTests {
                 "Resources should carry the xattr from its sidecar"
             )
 
-            // 5. A real AppleDouble with no sibling stays put. `copyfile` with
+            // 5. Finder's "Compress" (`ditto --sequesterRsrc`) does not put sidecars
+            //    beside their files at all — it mirrors the tree under `__MACOSX/`.
+            //    That is the common shape, so folding only the inline form would do
+            //    nothing for most macOS-made zips. The attribute below appears
+            //    nowhere else in the archive, so it can only be here if the sidecar
+            //    was folded onto the real file rather than onto the mirror path —
+            //    which is also created by this extraction, and so is not
+            //    distinguishable by ownership alone.
+            #expect(
+                extendedAttribute("com.macpacker.sequestered",
+                                  at: payload.appendingPathComponent("Contents/Info.plist"))
+                    == Data("appledouble-fixture".utf8),
+                "a sidecar under __MACOSX/ describes the real file, not the mirror"
+            )
+            #expect(
+                fm.fileExists(atPath: tempDir.appendingPathComponent("__MACOSX").path) == false,
+                "the __MACOSX mirror holds nothing but sidecars and should not survive"
+            )
+
+            // 6. A real AppleDouble with no sibling stays put. `copyfile` with
             //    COPYFILE_UNPACK happily creates a missing destination, which would
             //    invent `orphan.bin` — a file the archive never contained.
             #expect(
@@ -519,6 +538,86 @@ extension AllCoreTests {
                 extendedAttribute("com.apple.quarantine", at: helper) == verdict,
                 "an archive must not be able to clear Gatekeeper's quarantine"
             )
+        }
+
+        // Finder's "Compress" is `ditto -c -k --sequesterRsrc`, which does not put
+        // sidecars beside their files — it puts them in a `__MACOSX/` mirror of the
+        // whole tree. That is the common shape, not the exotic one, so an
+        // implementation that only folds in the inline form does nothing at all for
+        // most macOS-made zips. `zip/minimalApp.zip` is a real ad-hoc-signed bundle
+        // compressed exactly that way: 21 sidecars, every one of them sequestered.
+        @Test func extractionFoldsInTheSequesteredMacOSXTree() async throws {
+            let engine = Archive7ZipEngine()
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("minimalApp.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            _ = try await engine.extract(items: Array(loadResult.items.values), from: url,
+                                         to: tempDir, passwordResolver: { _ in nil })
+
+            // Nothing of the mirror survives — neither the sidecars nor the
+            // directories that only ever existed to hold them.
+            var leftovers: [String] = []
+            let walker = fm.enumerator(at: tempDir, includingPropertiesForKeys: nil)!
+            while let fileURL = walker.nextObject() as? URL {
+                if fileURL.path.contains("__MACOSX") || fileURL.lastPathComponent.hasPrefix("._") {
+                    leftovers.append(fileURL.lastPathComponent)
+                }
+            }
+            #expect(leftovers.isEmpty, "the __MACOSX mirror should be gone, found \(leftovers)")
+
+            // And the bundle it describes still verifies. This is the assertion that
+            // matches what a user does with the archive: #189 was reported as an app
+            // macOS called damaged, and codesign is the same judgement, made by the
+            // system rather than by this test.
+            let app = tempDir.appendingPathComponent("MinimalApp.app")
+            try #require(fm.fileExists(atPath: app.path))
+            #expect(codesignVerdict(app) == 0, "extracted bundle failed codesign")
+        }
+
+        // The tests above assert what this implementation was built to do, which is
+        // worth only so much — they were written by the same hand that wrote the
+        // code. This one asks a different question: does the 7-Zip engine agree with
+        // XADMaster, which people have relied on for well over a decade? Both
+        // engines are already in this process, so the comparison is free, and it
+        // covers ground no hand-written assertion reaches — permissions, symlink
+        // targets, extended attributes, every path in the tree.
+        //
+        // `appledouble.zip` is deliberately not in this list. It is a synthetic
+        // fixture built to exercise edge cases, and one of them — an archive with no
+        // directory entries at all, which no real tool produces — XADMaster gets
+        // wrong. Fixtures like that are what this test exists to compensate for, so
+        // it is restricted to archives real tools actually made.
+        @Test(arguments: ["minimalApp.zip", "appbundle.zip"])
+        func sevenZipAgreesWithXadOnRealArchives(name: String) async throws {
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent(name)
+            let fm = FileManager.default
+
+            var snapshots: [String: [String: String]] = [:]
+            for (label, engine) in [("7z", Archive7ZipEngine() as ArchiveEngine),
+                                    ("xad", ArchiveXadEngine() as ArchiveEngine)] {
+                let dir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+                try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+                defer { try? fm.removeItem(at: dir) }
+                let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+                _ = try await engine.extract(items: Array(loadResult.items.values), from: url,
+                                             to: dir, passwordResolver: { _ in nil })
+                snapshots[label] = extractionSnapshot(dir)
+            }
+
+            let sevenZip = snapshots["7z"]!, xad = snapshots["xad"]!
+            for path in Set(sevenZip.keys).union(xad.keys).sorted() {
+                #expect(
+                    sevenZip[path] == xad[path],
+                    "\(name) \(path): 7z produced \(sevenZip[path] ?? "<absent>"), xad produced \(xad[path] ?? "<absent>")"
+                )
+            }
         }
 
         @Test func extractEmptyItemsThrows() async throws {
@@ -1225,4 +1324,69 @@ private func setExtendedAttribute(_ name: String, _ value: Data, at url: URL) {
         setxattr(url.path, name, $0.baseAddress, value.count, 0, 0)
     }
     precondition(result == 0, "setxattr \(name) failed on \(url.path)")
+}
+
+/// Runs codesign over a bundle and returns its exit status. The system's own
+/// judgement on whether an extraction produced something usable, which is what
+/// #189 was reported as -- an app macOS called damaged.
+private func codesignVerdict(_ bundle: URL) -> Int32 {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+    process.arguments = ["-v", "--deep", "--strict", bundle.path]
+    process.standardError = Pipe()
+    process.standardOutput = Pipe()
+    do { try process.run() } catch { return -1 }
+    process.waitUntilExit()
+    return process.terminationStatus
+}
+
+/// Everything about an extracted tree that two engines ought to agree on, keyed
+/// by path: what each entry is, its permissions, and which extended attributes
+/// it carries. Attribute *values* are left out deliberately -- the names are
+/// what a divergence shows up in, and some values carry timestamps.
+///
+/// The volatile ones are skipped: the system stamps `provenance` and
+/// `quarantine` on whatever a process writes, and `lastuseddate#PS` changes when
+/// a file is read, so all three say more about the test run than the engine.
+private func extractionSnapshot(_ root: URL) -> [String: String] {
+    let volatile: Set<String> = [
+        "com.apple.provenance", "com.apple.quarantine",
+        "com.apple.lastuseddate#PS", "com.apple.macl"
+    ]
+    let fm = FileManager.default
+    let rootPath = root.resolvingSymlinksInPath().path
+    var snapshot: [String: String] = [:]
+
+    guard let walker = fm.enumerator(at: root, includingPropertiesForKeys: nil) else { return snapshot }
+    while let fileURL = walker.nextObject() as? URL {
+        var facts: [String] = []
+
+        var info = stat()
+        if lstat(fileURL.path, &info) == 0 {
+            switch info.st_mode & S_IFMT {
+            case S_IFLNK:
+                facts.append("link -> " + ((try? fm.destinationOfSymbolicLink(atPath: fileURL.path)) ?? "?"))
+            case S_IFDIR:
+                facts.append("dir")
+            default:
+                facts.append("file:\((try? Data(contentsOf: fileURL))?.count ?? -1)")
+            }
+            facts.append(String(format: "mode=%o", info.st_mode & 0o777))
+        }
+
+        let size = listxattr(fileURL.path, nil, 0, XATTR_NOFOLLOW)
+        if size > 0 {
+            var buffer = [CChar](repeating: 0, count: size)
+            if listxattr(fileURL.path, &buffer, size, XATTR_NOFOLLOW) == size {
+                let names = buffer.split(separator: 0)
+                    .map { String(cString: Array($0) + [0]) }
+                    .filter { !volatile.contains($0) }
+                    .sorted()
+                if !names.isEmpty { facts.append("xattr=" + names.joined(separator: ",")) }
+            }
+        }
+
+        snapshot[fileURL.path.replacingOccurrences(of: rootPath, with: "")] = facts.joined(separator: " ")
+    }
+    return snapshot
 }

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -446,6 +446,57 @@ extension AllCoreTests {
             )
         }
 
+        // Gatekeeper's verdict on a downloaded file lives in com.apple.quarantine,
+        // and copyfile's COPYFILE_UNPACK replaces a target's extended attributes
+        // rather than merging into them. So an archive shipping `Evil.app` beside a
+        // `._Evil.app` that carries no quarantine would have this extraction lift
+        // the quarantine off the bundle — the archive deciding, through metadata
+        // alone, that its own contents are trusted. Quarantine is the system's call,
+        // never the archive's.
+        //
+        // Extracting twice into one destination is what makes this observable: the
+        // second pass reopens the existing file with O_TRUNC, which keeps the inode
+        // and the attributes on it, so a quarantine set between the passes is still
+        // there when the sidecar is unpacked over it.
+        @Test func extractionDoesNotLetAnArchiveClearQuarantine() async throws {
+            let engine = Archive7ZipEngine()
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("appledouble.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            for _ in 0..<1 {
+                _ = try await engine.extract(items: items, from: url, to: tempDir,
+                                             passwordResolver: { _ in nil })
+            }
+
+            // Stand in for what the system does to anything MacPacker writes.
+            let helper = tempDir.appendingPathComponent("payload/Contents/MacOS/helper")
+            try #require(fm.fileExists(atPath: helper.path))
+            let verdict = Data("0083;68a1b2c3;Safari;E7A1-CAFE".utf8)
+            setExtendedAttribute("com.apple.quarantine", verdict, at: helper)
+
+            _ = try await engine.extract(items: items, from: url, to: tempDir,
+                                         passwordResolver: { _ in nil })
+
+            // The sidecar was unpacked again over the same file — proving the pass
+            // ran — but it has no say over the quarantine that was already there.
+            #expect(
+                extendedAttribute("com.macpacker.test", at: helper) == Data("appledouble-fixture".utf8),
+                "the sidecar should still have been unpacked on the second pass"
+            )
+            #expect(
+                extendedAttribute("com.apple.quarantine", at: helper) == verdict,
+                "an archive must not be able to clear Gatekeeper's quarantine"
+            )
+        }
+
         @Test func extractEmptyItemsThrows() async throws {
             let engine = Archive7ZipEngine()
             let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import Swift7zip
 @testable import Core
 
 // MARK: - 1. Archive7ZipEngine Tests
@@ -700,6 +701,52 @@ extension AllCoreTests {
             #expect(
                 listings["7z"]!.count == listings["xad"]!.count,
                 "\(name): 7z lists \(listings["7z"]!.count) entries, xad lists \(listings["xad"]!.count)"
+            )
+        }
+
+        // A sidecar is its file's metadata, and it is no longer in the listing for
+        // a user to remove alongside the file. So removing the file has to remove
+        // it too — otherwise editing an archive leaves metadata describing
+        // something the archive no longer holds, which then reappears in the
+        // listing as a stray `._name` entry, in the place the user just cleared.
+        @Test func deletingAFileDeletesItsSidecar() async throws {
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let source = zipFolder.appendingPathComponent("appledouble.zip")
+
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            let archive = try SevenZipArchive(url: source)
+            let icon = try #require(try archive.entries.first { $0.path.hasSuffix("Resources/icon.png") })
+
+            let edited = tempDir.appendingPathComponent("edited.zip")
+            try SevenZipArchive.writeArchive(
+                source: source,
+                destination: edited,
+                items: [.remove(sourceIndex: icon.index)],
+                options: .init(format: .zip)
+            )
+
+            // Read the result with a tool that has no opinion about sidecars.
+            let listing = Process()
+            listing.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+            listing.arguments = ["-Z1", edited.path]
+            let pipe = Pipe()
+            listing.standardOutput = pipe
+            try listing.run()
+            let raw = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+                .split(separator: "\n").map(String.init)
+            listing.waitUntilExit()
+
+            #expect(
+                raw.contains { $0.hasSuffix("/icon.png") } == false,
+                "icon.png was removed and should be gone"
+            )
+            #expect(
+                raw.contains { $0.hasSuffix("/._icon.png") } == false,
+                "._icon.png described icon.png and should have gone with it, found \(raw)"
             )
         }
 


### PR DESCRIPTION
Resolves #189

## The bug

The reported archive extracts to a `.app` that macOS calls damaged. Confirmed on the file from the issue — the 7-Zip engine leaves one extra file behind, and that is enough:

```
$ codesign -v --deep --strict --verbose=2 GoodSyncInstaller-vsub.app
GoodSyncInstaller-vsub.app: a sealed resource is missing or invalid
file added: .../Contents/Resources/._wd-logo120.png
```

Archive Utility and the XAD engine both produce a bundle that verifies; the only difference in the whole extracted tree is that one file.

`._wd-logo120.png` is an **AppleDouble sidecar**. When macOS cannot keep a file's extended attributes and resource fork in place — a FAT stick, an SMB share — it splits them out into a sibling `._name` file:

```
$ cp -R src /Volumes/SOMEFAT/
cp: could not copy extended attributes ...
$ ls -a /Volumes/SOMEFAT/src
._file.txt   file.txt
```

From that point the sidecar is an ordinary file on disk, so any archiver walking the folder stores it. **Nothing about this is zip-specific** — the same folder archived as tar, 7z and zip carries the sidecar in all three, and all three were verified against the fix. Written back out as a plain file it adds an entry to the extracted tree, and inside a signed bundle that breaks the code-signature seal.

## The fix

`Modules/Sources/CSevenZip/sevenzip_bridge.cpp`, +78 lines. No change to the vendored 7-Zip submodule.

`SetOperationResult` records extracted entries whose name starts with `._`. They cannot be resolved as they arrive, because a sidecar may be stored *before* the entry it describes — `._x` sorts before `x`, so that is the order an archiver walking a tree tends to produce. `finishExtract`, already the shared tail of all three `sz_extract_*` paths, drains the list once everything is on disk. This is the same choke point that #121 used for symlinks and the exec bit.

`copyfile(3)` with `COPYFILE_UNPACK` does the decoding, so there is no AppleDouble parser in this diff.

## Why it does not eat real files

`._` is a naming convention, not a reservation — a file may legitimately be named that way and hold anything, and deleting on the name alone loses user data. `copyfile` rejects a source that is not AppleDouble, which makes it the discriminator as well as the decoder: such a file fails the unpack and stays put. Two further guards keep the destructive half honest:

- The entry a sidecar describes must **already exist**, as a regular file or a directory. With a missing destination `copyfile` *creates* it rather than failing, conjuring a file the archive never contained.
- The sidecar is unlinked **only** once `copyfile` reports success.

Symlinks are excluded as targets: `copyfile` follows them and would write through to whatever they point at.

Failures are silent by design. Anything not unpacked is left exactly where extraction wrote it, so the worst case is the previous behaviour rather than a failed extraction.

## Reference behaviour

Archive Utility is the reference, and it is content-aware, not name-based — in one archive holding both, it consumed a genuine sidecar and kept a plain-text decoy byte-identical.

It is also **order-dependent**: it unpacks a sidecar the moment it reads it, so a sidecar stored before its target is left on disk. Entry order carries no meaning in a zip, so this fix resolves sidecars after the entries are written and gets both orders right. That is deliberately more than Archive Utility delivers.

## Tests

`extractionUnpacksAppleDoubleSidecarsAndSparesDecoys` in `Modules/Tests/CoreTests/EngineTests.swift`, alongside the #121 symlink test, in the standard `swift test --package-path Modules` suite. Fixture is `zip/appledouble.zip` (MacPacker-TestArchives#2, #3), one archive covering every branch:

| entry | expected |
| --- | --- |
| `Contents/Resources/._icon.png` (sidecar stored **before** target) | gone; resource fork + xattr on `icon.png` |
| `Contents/MacOS/._helper` (sidecar stored **after** target) | gone; resource fork + xattr on `helper` |
| `Contents/._Resources` (sidecar for a **directory**) | gone; `Resources/` still a directory, carrying its xattr |
| `._notadouble.txt` (plain text, sibling exists) | survives byte-identical |
| `._orphan.bin` (real AppleDouble, no sibling) | survives, and no `orphan.bin` is conjured |

It also asserts the data fork is untouched — 70 bytes, PNG magic — which catches the wrong `copyfile` flags overwriting file contents with the AppleDouble.

Verified failing before the fix (6 issues) and passing after. Each guard was checked to have teeth individually: reverting the directory guard alone fails exactly the `._Resources` assertion.

Full suite: **389/389**.

The archive from the issue was also driven through the fixed engine directly, with a throwaway test not included here — a 63 MB download is not a fixture:

```
codesign(0): .../GoodSyncInstaller-vsub.app: valid on disk
```

## Performance

The per-entry check measures 38.5 ns — one string copy, an `rfind`, a two-byte compare. That is 47 µs across this archive's 1217 entries and 3.9 ms across 100k, against a per-entry cost that already includes a file create, decompression, write and close. The drain does nothing when no sidecars were seen. Collecting during extraction rather than walking the destination afterwards is what keeps it proportional to what was actually written.

## Deliberately out of scope

Both cosmetic rather than seal-breaking, and each a behaviour change deserving its own issue:

- `__MACOSX/` trees are still extracted verbatim. They land beside a bundle, not inside it, so no signature breaks.
- `._` entries still appear in the file list. The bridge already hides 7-Zip alternate streams; AppleDouble sidecars are ordinary entries.

## Changelog

`0.21.0`, type `fix`: **Extracted apps reported as damaged**, all 15 languages in the file. Translations beyond English are unreviewed placeholders — POEditor overwrites every value including `en`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed extraction of macOS metadata, including extended attributes, resource forks, and ACLs.
  * Preserved existing quarantine metadata during repeated extraction and handled metadata sidecars safely.
  * Ensured metadata is applied correctly regardless of sidecar order and for directories.
  * Preserved unrelated, orphaned, or pre-existing files instead of modifying them incorrectly.
  * Fixed extracted apps being incorrectly reported as damaged.
  * Added the 0.21.0 changelog entry with updated translations, including corrected Korean wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->