### PR TITLE
feat: back button in the toolbar

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -83,6 +83,29 @@
             ]
           },
           {
+            "type": "feat",
+            "title": {
+              "en": "Back button replaces optional parent row",
+              "zh-Hans": "返回按钮取代可选的“..”行",
+              "fr": "Le bouton Retour remplace la ligne « .. » optionnelle",
+              "de": "Zurück-Button ersetzt optionale „..“-Zeile",
+              "it": "Il pulsante Indietro sostituisce la riga «..» opzionale",
+              "ja": "「戻る」ボタンが任意の「..」行を置き換え",
+              "fa": "دکمه بازگشت جایگزین ردیف اختیاری «..» شد",
+              "pl": "Przycisk Wstecz zastępuje opcjonalny wiersz „..”",
+              "pt-BR": "Botão Voltar substitui a linha “..” opcional",
+              "ru": "Кнопка «Назад» заменяет необязательную строку «..»",
+              "uk": "Кнопка «Назад» замінює необов’язковий рядок «..»",
+              "es-MX": "El botón Atrás sustituye la fila «..» opcional",
+              "ko": "뒤로 버튼이 선택 사항인 “..” 행을 대체",
+              "nl": "Terug-knop vervangt de optionele “..”-rij",
+              "tr": "Geri düğmesi isteğe bağlı “..” satırının yerini alır"
+            },
+            "issues": [
+              "153"
+            ]
+          },
+          {
             "type": "fix",
             "title": {
               "en": "Extracted apps reported as damaged",

--- a/MacPacker/Features/ArchiveContentViewer/ArchiveContentToolbarView.swift
+++ b/MacPacker/Features/ArchiveContentViewer/ArchiveContentToolbarView.swift
@@ -59,6 +59,20 @@ struct ArchiveContentToolbarView: ToolbarContent {
     }
 
     var body: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            Button {
+                archiveState.openParent()
+            } label: {
+                Label {
+                    Text("Back", comment: "Button in the toolbar that leaves the current folder of the archive and shows the folder containing it.")
+                } icon: {
+                    Image(systemName: "chevron.backward")
+                }
+            }
+            .help(Text("Enclosing folder", comment: "Tooltip of the toolbar's back button: it shows the folder that contains the one being browsed."))
+            .disabled(!archiveState.canGoUp)
+        }
+
         ToolbarItemGroup(placement: .primaryAction) {
             Button {
                 addFilesViaOpenPanel()

--- a/MacPacker/Features/ArchiveContentViewer/ArchiveView.swift
+++ b/MacPacker/Features/ArchiveContentViewer/ArchiveView.swift
@@ -31,6 +31,7 @@ struct ArchiveView: View {
     @AppStorage(Keys.showColumnUncompressedSize) var showUncompressedSize: Bool = true
     @AppStorage(Keys.showColumnModificationDate) var showModificationDate: Bool = true
     @AppStorage(Keys.showColumnPosixPermissions) var showPermissions: Bool = false
+    @AppStorage(Keys.showParentRow) var showParentRow: Bool = false
 
     @State private var selection: IndexSet?
     /// nil while no file is over the window; otherwise the zone the pointer is in.
@@ -93,6 +94,9 @@ struct ArchiveView: View {
                 dropZones(active: activeZone)
             }
         }
+        // The row count changes with the setting, and the table only reloads on
+        // this flag — the toggle is in another window, so nothing else nudges it.
+        .onChange(of: showParentRow) { _, _ in state.isReloadNeeded = true }
         .onAppear {
             if state.openWithUrls.count > 0 {
                 state.openDropped(url: state.openWithUrls[0])

--- a/MacPacker/Features/Settings/GeneralSettingsView.swift
+++ b/MacPacker/Features/Settings/GeneralSettingsView.swift
@@ -15,6 +15,7 @@ struct GeneralSettingsView: View {
     @AppStorage(Keys.showColumnUncompressedSize) var showUncompressedSize: Bool = true
     @AppStorage(Keys.showColumnModificationDate) var showModificationDate: Bool = true
     @AppStorage(Keys.showColumnPosixPermissions) var showPermissions: Bool = false
+    @AppStorage(Keys.showParentRow) var showParentRow: Bool = false
     @AppStorage(Keys.quitOnLastWindowClosed) var quitOnLastWindowClosed: Bool = false
     @AppStorage(Keys.showMenuBarItem) var showMenuBarItem: Bool = false
 
@@ -42,7 +43,18 @@ struct GeneralSettingsView: View {
                 .toggleStyle(.checkbox)
                 .frame(width: 240, alignment: .leading)
             }
-            
+
+            HStack(alignment: .top) {
+                Text("Show .. parent row:", comment: "Setting that shows or hides the \"..\" row at the top of the archive window that leads back to the containing folder")
+                    .frame(width: 200, alignment: .trailing)
+
+                HStack {
+                    Toggle(isOn: $showParentRow) {}
+                }
+                .padding(.leading, 8)
+                .frame(width: 240, alignment: .leading)
+            }
+
             Divider()
             
             HStack(alignment: .top) {
@@ -75,12 +87,8 @@ struct GeneralSettingsView: View {
                 Text("Show in the menu bar:", comment: "Setting that adds a MacPacker icon to the menu bar, which opens the Quick Compress window")
                     .frame(width: 200, alignment: .trailing)
 
-                VStack(alignment: .leading) {
+                HStack {
                     Toggle(isOn: $showMenuBarItem) {}
-                    Text("Opens the Quick Compress window from anywhere.",
-                         comment: "Explains what the menu bar icon does. The Quick Compress window is the small floating window that compresses whatever is dropped on it.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
                 }
                 .padding(.leading, 8)
                 .frame(width: 240, alignment: .leading)

--- a/MacPacker/Localizable.xcstrings
+++ b/MacPacker/Localizable.xcstrings
@@ -1675,6 +1675,9 @@
         }
       }
     },
+    "Back" : {
+      "comment" : "Button in the toolbar that leaves the current folder of the archive and shows the folder containing it."
+    },
     "Bottom" : {
       "comment" : "Breadcrumb position at the bottom of the archive window",
       "localizations" : {
@@ -3440,6 +3443,9 @@
           }
         }
       }
+    },
+    "Enclosing folder" : {
+      "comment" : "Tooltip of the toolbar's back button: it shows the folder that contains the one being browsed."
     },
     "Engine" : {
       "comment" : "The header for the \"Engine\" column in the format settings view.",
@@ -6684,9 +6690,6 @@
         }
       }
     },
-    "Opens the Quick Compress window from anywhere." : {
-      "comment" : "Explains what the menu bar icon does. The Quick Compress window is the small floating window that compresses whatever is dropped on it."
-    },
     "Options" : {
       "comment" : "Shows or hides the compression settings of the Quick Compress window."
     },
@@ -8047,6 +8050,9 @@
           }
         }
       }
+    },
+    "Show .. parent row:" : {
+      "comment" : "Setting that shows or hides the \"..\" row at the top of the archive window that leads back to the containing folder"
     },
     "Show application support folder" : {
       "comment" : "Help text shown in a tooltip when hovering the \"Open cache directory\" button",

--- a/Modules/Sources/Core/AppStorageKeys.swift
+++ b/Modules/Sources/Core/AppStorageKeys.swift
@@ -13,6 +13,7 @@ public enum Keys {
     public static let quitOnLastWindowClosed = "quitOnLastWindowClosed"
     
     // table settings
+    public static let showParentRow = "showParentRow"
     public static let showColumnCompressedSize = "showColumnCompressedSize"
     public static let showColumnUncompressedSize = "showColumnUncompressedSize"
     public static let showColumnModificationDate = "showColumnModificationDate"

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -296,12 +296,19 @@ extension ArchiveState {
 
     public var isSearching: Bool { !searchText.isEmpty }
 
-    /// Whether the table shows the ".." row at the top: browsing below the
-    /// root shows it, search results never do (they come from all levels at
-    /// once, so there is no single parent to go up to).
-    public var showsParentRow: Bool {
-        guard let selectedItem, !isSearching else { return false }
+    /// Whether there is an enclosing folder to go up to.
+    public var canGoUp: Bool {
+        guard let selectedItem else { return false }
         return selectedItem.type != .root
+    }
+
+    /// Whether the table shows the ".." row at the top: off unless the user
+    /// switches it on, and never in search results (they come from all levels
+    /// at once, so there is no single parent to go up to). The toolbar's back
+    /// button and ⌘↑ go up either way.
+    public var showsParentRow: Bool {
+        guard !isSearching, canGoUp else { return false }
+        return UserDefaults.standard.bool(forKey: Keys.showParentRow)
     }
 
     /// Updates the live search. Every change re-filters the entries; clearing

--- a/Modules/Tests/CoreTests/ArchiveStateTests.swift
+++ b/Modules/Tests/CoreTests/ArchiveStateTests.swift
@@ -253,6 +253,33 @@ extension AllCoreTests {
             state.openParent()
             #expect(state.selectedItem === state.root)
         }
+
+        @Test func parentRowFollowsTheSetting() async throws {
+            let state = ArchiveState(catalog: ArchiveTypeCatalog(), engineSelector: ArchiveEngineSelector7zip())
+            let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let url = folderURL.appendingPathComponent("defaultArchive.zip")
+
+            state.open(url: url)
+            try await state.openTask?.value
+
+            // At the root there is nothing above, whatever the setting says.
+            #expect(state.canGoUp == false)
+            #expect(state.showsParentRow == false)
+
+            let dirChild = state.root!.children!
+                .compactMap { state.entries[$0] }
+                .first(where: { $0.type == .directory })!
+            try await state.openAsync(item: dirChild)
+
+            // Off by default: the toolbar button and ⌘↑ are the way up.
+            #expect(state.canGoUp)
+            #expect(state.showsParentRow == false)
+
+            UserDefaults.standard.set(true, forKey: Keys.showParentRow)
+            defer { UserDefaults.standard.removeObject(forKey: Keys.showParentRow) }
+
+            #expect(state.showsParentRow)
+        }
     }
 
     // MARK: - open(item:) for directory
@@ -484,8 +511,12 @@ extension AllCoreTests {
 
             state.loadChildren()
 
-            // With parent row, index 0 is the parent; index 1 maps to childItems[0]
+            // With parent row, index 0 is the parent; index 1 maps to childItems[0].
+            // The row is off by default, so this test asks for it. No await until
+            // it is cleared again — the flag is global, the main actor is not.
+            UserDefaults.standard.set(true, forKey: Keys.showParentRow)
             state.changeSelection(selection: IndexSet(integer: 1))
+            UserDefaults.standard.removeObject(forKey: Keys.showParentRow)
 
             #expect(state.selectedItems.count == 1)
             #expect(state.selectedItems[0] === state.childItems![0])
@@ -544,9 +575,11 @@ extension AllCoreTests {
 
             try await state.openAsync(item: dirChild)
 
-            // Non-root: indices shift by +1
+            // Non-root with the parent row switched on: indices shift by +1
             let input = IndexSet([0, 1])
+            UserDefaults.standard.set(true, forKey: Keys.showParentRow)
             let result = state.selectionOffset(selection: input)
+            UserDefaults.standard.removeObject(forKey: Keys.showParentRow)
             #expect(result == IndexSet([1, 2]))
         }
     }


### PR DESCRIPTION
Drilling into a folder left only the `..` row and the breadcrumb as a way back out. This adds the leading chevron every macOS window has.

- **Toolbar back button** — `ToolbarItem(placement: .navigation)`, `chevron.backward`, always visible and greyed out at the root rather than disappearing. Calls the existing `openParent()`, same as ⌘↑.
- **`..` row is now a setting** — General ▸ *Show .. parent row*, **off by default**; the toolbar button replaces it. Flipping it reloads open windows live.
- `ArchiveState.canGoUp` is the single source for both the button's enabled state and `showsParentRow`.

Verified by running the app: chevron enabled inside a folder, greyed at the root, and the `..` row appears/disappears with the setting without a relaunch. `swift test --package-path Modules` → 405 pass, incl. the new `parentRowFollowsTheSetting`; two existing parent-row tests now switch the pref on around the call they need it for.

Skipped: a real back/forward history stack — worth adding if breadcrumb jumps ever need retracing.

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a back button for navigating from archive contents to the enclosing folder.
  * Added a setting to show or hide the optional “..” parent-directory row.
  * The back button is disabled when navigation to a parent folder is unavailable.
  * Added localized labels and tooltips for the new navigation and setting options.

* **Bug Fixes**
  * Parent-directory rows are now hidden at the archive root and during searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->