### PR TITLE
fix: remember window size and position

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -37,6 +37,28 @@
         "version": "0.21.0",
         "items": [
           {
+            "type": "fix",
+            "title": {
+              "en": "Remember window size and position",
+              "zh-Hans": "记住窗口大小和位置",
+              "fr": "Mémorisation de la taille et position de la fenêtre",
+              "de": "Fenstergröße und -position merken",
+              "it": "Memorizza dimensioni e posizione della finestra",
+              "ja": "ウインドウのサイズと位置を記憶",
+              "fa": "به خاطر سپردن اندازه و موقعیت پنجره",
+              "pl": "Zapamiętywanie rozmiaru i położenia okna",
+              "pt-BR": "Lembrar tamanho e posição da janela",
+              "ru": "Сохранение размера и положения окна",
+              "uk": "Збереження розміру та положення вікна",
+              "es-MX": "Recordar tamaño y posición de la ventana",
+              "ko": "창 크기 및 위치 기억",
+              "nl": "Venstergrootte en -positie onthouden",
+              "tr": "Pencere boyutunu ve konumunu hatırla"
+            },
+            "issues": [
+            ]
+          },
+          {
             "type": "feat",
             "title": {
                 "en": "cbz, cbr support",

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -56,6 +56,7 @@
               "tr": "Pencere boyutunu ve konumunu hatırla"
             },
             "issues": [
+              "165"
             ]
           }
         ]

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -34,7 +34,7 @@
     },
     "versions": [
       {
-        "version": "0.21.0",
+        "version": "0.22.0",
         "items": [
           {
             "type": "fix",
@@ -57,7 +57,12 @@
             },
             "issues": [
             ]
-          },
+          }
+        ]
+      },
+      {
+        "version": "0.21.0",
+        "items": [
           {
             "type": "feat",
             "title": {

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
@@ -25,13 +25,21 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
         appState: AppState,
         dropCompressor: DropCompressor,
         openQuickCompressWindow: @escaping @MainActor () -> Void,
-        openArchiveInNewWindow: @escaping @MainActor (URL) -> Void
+        openArchiveInNewWindow: @escaping @MainActor (URL) -> Void,
+        cascadeFrom: NSWindow? = nil
     ) {
         self.archiveState = archiveState
 
         let window = ArchiveWindow()
         window.isRestorable = false
-        window.center()
+        window.setFrameAutosaveName("ArchiveWindow")
+        let onScreen = NSScreen.screens.contains { $0.visibleFrame.intersects(window.frame) }
+        if !onScreen || window.frame.origin == .zero {
+            window.center()
+        } else if let cascadeFrom {
+            let nextPoint = cascadeFrom.cascadeTopLeft(from: NSPoint(x: cascadeFrom.frame.minX, y: cascadeFrom.frame.maxY))
+            window.setFrameTopLeftPoint(nextPoint)
+        }
         super.init(window: window)
 
         window.delegate = self

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
@@ -34,7 +34,7 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
         window.isRestorable = false
         let didRestoreFrame = window.setFrameAutosaveName("ArchiveWindow")
         if let cascadeFrom {
-            let nextPoint = cascadeFrom.cascadeTopLeft(from: NSPoint(x: cascadeFrom.frame.minX, y: cascadeFrom.frame.maxY))
+            let nextPoint = window.cascadeTopLeft(from: NSPoint(x: cascadeFrom.frame.minX, y: cascadeFrom.frame.maxY))
             window.setFrameTopLeftPoint(nextPoint)
         } else if didRestoreFrame {
             let onScreen = NSScreen.screens.contains { screen in

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
@@ -32,18 +32,22 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
 
         let window = ArchiveWindow()
         window.isRestorable = false
-        window.setFrameAutosaveName("ArchiveWindow")
-        let onScreen = NSScreen.screens.contains { screen in
-            let intersection = screen.visibleFrame.intersection(window.frame)
-            let minWidth = min(window.frame.width * 0.5, 300)
-            let minHeight = min(window.frame.height * 0.5, 200)
-            return !intersection.isNull && intersection.width >= minWidth && intersection.height >= minHeight
-        }
-        if !onScreen || window.frame.origin == .zero {
-            window.center()
-        } else if let cascadeFrom {
+        let didRestoreFrame = window.setFrameAutosaveName("ArchiveWindow")
+        if let cascadeFrom {
             let nextPoint = cascadeFrom.cascadeTopLeft(from: NSPoint(x: cascadeFrom.frame.minX, y: cascadeFrom.frame.maxY))
             window.setFrameTopLeftPoint(nextPoint)
+        } else if didRestoreFrame {
+            let onScreen = NSScreen.screens.contains { screen in
+                let intersection = screen.visibleFrame.intersection(window.frame)
+                let minWidth = min(window.frame.width * 0.5, 300)
+                let minHeight = min(window.frame.height * 0.5, 200)
+                return !intersection.isNull && intersection.width >= minWidth && intersection.height >= minHeight
+            }
+            if !onScreen || window.frame.origin == .zero {
+                window.center()
+            }
+        } else {
+            window.center()
         }
         super.init(window: window)
 

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
@@ -9,6 +9,9 @@ import AppKit
 import Combine
 import Core
 import SwiftUI
+import tb
+
+private let log = tb.Logger(subsystem: "app.MacPacker", category: "lifecycle")
 
 class ArchiveWindowController: NSWindowController, NSWindowDelegate {
     let archiveState: ArchiveState
@@ -32,22 +35,21 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
 
         let window = ArchiveWindow()
         window.isRestorable = false
-        let didRestoreFrame = window.setFrameAutosaveName("ArchiveWindow")
         if let cascadeFrom {
-            let nextPoint = window.cascadeTopLeft(from: NSPoint(x: cascadeFrom.frame.minX, y: cascadeFrom.frame.maxY))
-            window.setFrameTopLeftPoint(nextPoint)
-        } else if didRestoreFrame {
-            let onScreen = NSScreen.screens.contains { screen in
-                let intersection = screen.visibleFrame.intersection(window.frame)
-                let minWidth = min(window.frame.width * 0.5, 300)
-                let minHeight = min(window.frame.height * 0.5, 200)
-                return !intersection.isNull && intersection.width >= minWidth && intersection.height >= minHeight
-            }
-            if !onScreen || window.frame.origin == .zero {
-                window.center()
-            }
-        } else {
+            // macOS convention: inherit the size of the window in use, step
+            // down-right. `.zero` asks for the next point without moving anything,
+            // so the existing window stays put.
+            window.setFrame(cascadeFrom.frame, display: false)
+            window.setFrameTopLeftPoint(window.cascadeTopLeft(from: .zero))
+            log.info("window placed cascaded frame=\(NSStringFromRect(window.frame))")
+        } else if !window.setFrameUsingName(Self.frameName)
+                    || !WindowFramePlacement.isUsable(window.frame, on: NSScreen.screens.map(\.visibleFrame)) {
+            // nothing remembered, or remembered on a display that is gone —
+            // an off-screen window looks like one that never opened
             window.center()
+            log.info("window placed centered frame=\(NSStringFromRect(window.frame))")
+        } else {
+            log.info("window placed restored frame=\(NSStringFromRect(window.frame))")
         }
         super.init(window: window)
 
@@ -83,6 +85,21 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
     /// reliably does; the call is idempotent and cheap.
     func windowDidUpdate(_ notification: Notification) {
         (notification.object as? NSWindow)?.publishAccessibilityIdentifiers()
+    }
+
+    /// A single shared entry, not one per window: rewritten by whichever window the
+    /// user last moved or resized, and read only when no window is open. A new window
+    /// alongside others copies the main window instead. `setFrameAutosaveName` cannot
+    /// do this — one live window owns the name, every later one silently gets none.
+    private static let frameName = "ArchiveWindow"
+
+    func windowDidResize(_ notification: Notification) { rememberFrame(notification) }
+    func windowDidMove(_ notification: Notification) { rememberFrame(notification) }
+
+    private func rememberFrame(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        window.saveFrame(usingName: Self.frameName)
+        log.info("window frame remembered \(NSStringFromRect(window.frame))")
     }
 
     /// Closing a window with unsaved edits asks to save first, like a document

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindow.swift
@@ -33,7 +33,12 @@ class ArchiveWindowController: NSWindowController, NSWindowDelegate {
         let window = ArchiveWindow()
         window.isRestorable = false
         window.setFrameAutosaveName("ArchiveWindow")
-        let onScreen = NSScreen.screens.contains { $0.visibleFrame.intersects(window.frame) }
+        let onScreen = NSScreen.screens.contains { screen in
+            let intersection = screen.visibleFrame.intersection(window.frame)
+            let minWidth = min(window.frame.width * 0.5, 300)
+            let minHeight = min(window.frame.height * 0.5, 200)
+            return !intersection.isNull && intersection.width >= minWidth && intersection.height >= minHeight
+        }
         if !onScreen || window.frame.origin == .zero {
             window.center()
         } else if let cascadeFrom {

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindowManager.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindowManager.swift
@@ -69,7 +69,7 @@ class ArchiveWindowManager {
             openArchiveInNewWindow: { [weak self] url in
                 self?.openDroppedInNewWindow(url)
             },
-            cascadeFrom: windowControllers.last?.window
+            cascadeFrom: modelWindow
         )
         windowControllers.append(archiveWindowController)
         archiveWindowController.willCloseHandler = { [weak self] in
@@ -77,6 +77,14 @@ class ArchiveWindowManager {
         }
         archiveWindowController.showWindow(nil)
         return archiveState
+    }
+
+    /// The window a new one models itself on. Falls back to the newest when no
+    /// window is main (Finder's "Add to Archive…" keeps focus). Nil when none are
+    /// open — the new window then uses the remembered frame.
+    private var modelWindow: NSWindow? {
+        windowControllers.first { $0.window?.isMainWindow == true }?.window
+            ?? windowControllers.last?.window
     }
 
     /// During launch two things might happen. Either the app is launched with a url (e.g. via the Open With... menu

--- a/MacPacker/Features/ArchiveWindow/ArchiveWindowManager.swift
+++ b/MacPacker/Features/ArchiveWindow/ArchiveWindowManager.swift
@@ -68,7 +68,8 @@ class ArchiveWindowManager {
             openQuickCompressWindow: openQuickCompressWindow,
             openArchiveInNewWindow: { [weak self] url in
                 self?.openDroppedInNewWindow(url)
-            }
+            },
+            cascadeFrom: windowControllers.last?.window
         )
         windowControllers.append(archiveWindowController)
         archiveWindowController.willCloseHandler = { [weak self] in

--- a/Modules/Sources/Core/WindowFramePlacement.swift
+++ b/Modules/Sources/Core/WindowFramePlacement.swift
@@ -1,0 +1,28 @@
+//
+//  WindowFramePlacement.swift
+//  Modules
+//
+//  Created by Stephan Arenswald on 31.08.26.
+//
+
+import Foundation
+
+/// Geometry for restoring a remembered window frame. Pure math so it is testable
+/// without a screen; the app passes its `NSScreen.visibleFrame`s in.
+public enum WindowFramePlacement {
+
+    /// Whether a remembered frame is still worth restoring. A frame saved on a
+    /// display that is gone lands off-screen, which looks like a window that never
+    /// opened, and a sliver is no better than none. Require half the window visible,
+    /// or 300×200 for a large one, whichever is smaller.
+    public static func isUsable(_ frame: CGRect, on visibleFrames: [CGRect]) -> Bool {
+        guard !frame.isEmpty else { return false }
+        let minWidth = min(frame.width * 0.5, 300)
+        let minHeight = min(frame.height * 0.5, 200)
+        return visibleFrames.contains { visible in
+            // a disjoint intersection is CGRect.null: zero size, fails both checks
+            let overlap = visible.intersection(frame)
+            return overlap.width >= minWidth && overlap.height >= minHeight
+        }
+    }
+}

--- a/Modules/Tests/CoreTests/WindowFramePlacementTests.swift
+++ b/Modules/Tests/CoreTests/WindowFramePlacementTests.swift
@@ -1,0 +1,71 @@
+//
+//  WindowFramePlacementTests.swift
+//  Modules
+//
+//  Created by Stephan Arenswald on 31.08.26.
+//
+
+import Testing
+import Foundation
+@testable import Core
+
+extension AllCoreTests {
+
+    struct WindowFramePlacementTests {
+
+        /// A single 1920×1080 display with the menu bar taken off the top.
+        private let laptop = CGRect(x: 0, y: 0, width: 1920, height: 1055)
+        /// A second display sitting to the right of it.
+        private let external = CGRect(x: 1920, y: 0, width: 2560, height: 1415)
+
+        @Test func frameFullyOnScreenIsUsable() {
+            let frame = CGRect(x: 200, y: 200, width: 800, height: 500)
+            #expect(WindowFramePlacement.isUsable(frame, on: [laptop]))
+        }
+
+        @Test func frameOnADisconnectedDisplayIsNotUsable() {
+            // saved on the external display, which is now unplugged
+            let frame = CGRect(x: 2400, y: 300, width: 800, height: 500)
+            #expect(!WindowFramePlacement.isUsable(frame, on: [laptop]))
+        }
+
+        @Test func frameOnASecondDisplayIsUsable() {
+            let frame = CGRect(x: 2400, y: 300, width: 800, height: 500)
+            #expect(WindowFramePlacement.isUsable(frame, on: [laptop, external]))
+        }
+
+        /// The regression that made the plain `intersects` check wrong: a few
+        /// pixels of the window poke onto the screen and everything else is off.
+        @Test func sliverOfOverlapIsNotUsable() {
+            let frame = CGRect(x: 1910, y: 300, width: 800, height: 500)
+            #expect(!WindowFramePlacement.isUsable(frame, on: [laptop]))
+        }
+
+        /// A big window only has to show 300×200 — half of it would be a
+        /// stricter bar than the user needs to grab it.
+        @Test func largeWindowNeedsOnlyTheCappedMinimum() {
+            let frame = CGRect(x: 1600, y: 800, width: 2000, height: 1200)
+            let overlap = laptop.intersection(frame)
+            #expect(overlap.width == 320 && overlap.height == 255)
+            #expect(WindowFramePlacement.isUsable(frame, on: [laptop]))
+        }
+
+        /// A small window is measured against half of itself, not against 300×200.
+        @Test func smallWindowIsMeasuredAgainstHalfOfItself() {
+            let frame = CGRect(x: 1800, y: 300, width: 200, height: 150)
+            #expect(WindowFramePlacement.isUsable(frame, on: [laptop]))
+
+            let mostlyOff = CGRect(x: 1880, y: 300, width: 200, height: 150)
+            #expect(!WindowFramePlacement.isUsable(mostlyOff, on: [laptop]))
+        }
+
+        @Test func emptyFrameIsNotUsable() {
+            #expect(!WindowFramePlacement.isUsable(.zero, on: [laptop]))
+        }
+
+        @Test func noScreensAtAllIsNotUsable() {
+            let frame = CGRect(x: 200, y: 200, width: 800, height: 500)
+            #expect(!WindowFramePlacement.isUsable(frame, on: []))
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Restores and persists the main archive window's size and screen position across launches and window sessions.
Closes: https://github.com/sarensw/MacPacker/issues/165

### Problem
Previously, `ArchiveWindowController` unconditionally centered the window with a default size of 800×500 and did not configure a frame autosave name. As a result, any user adjustments to window dimensions or position were lost whenever a window was closed or the app was restarted.

### Changes
- **Window Frame Autosave:** Configured `window.setFrameAutosaveName("ArchiveWindow")` in `ArchiveWindowController.init` to automatically persist and restore window frame metrics via `UserDefaults`.
- **Multi-display & Bounds Validation:** Added an on-screen validation check against `NSScreen.screens` to ensure off-screen frames (e.g., from disconnected external displays) or initial zero origins fall back to centering on screen.
- **Window Cascading:** Added support for cascading subsequent archive windows (`cascadeFrom: windowControllers.last?.window`) using `cascadeTopLeft(from:)` while retaining the saved width and height.
- **Changelog:** Added changelog entry under version `0.22.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archive windows now remember their size and position between uses.
  * New archive windows open in a convenient cascading arrangement when appropriate.

* **Bug Fixes**
  * Saved windows are restored only when they sufficiently overlap a visible screen area.
  * Windows are centered automatically when their saved position is unavailable or off-screen.
  * Window placement remains reliable across display and workspace changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->