### PR TITLE
core: update 7-Zip to 26.03 (#201)

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -58,6 +58,29 @@
             "issues": [
               "165"
             ]
+          },
+          {
+            "type": "core",
+            "title": {
+              "en": "Update 7-Zip to v26.03",
+              "zh-Hans": "更新 7-Zip 至 v26.03",
+              "fr": "Mise à jour de 7-Zip vers la version 26.03",
+              "de": "7-Zip auf Version 26.03 aktualisiert",
+              "it": "Aggiornamento di 7-Zip alla versione 26.03",
+              "ja": "7-Zip を v26.03 に更新",
+              "fa": "به‌روزرسانی 7-Zip به نسخه 26.03",
+              "pl": "Aktualizacja 7-Zip do wersji 26.03",
+              "pt-BR": "Atualização do 7-Zip para a versão 26.03",
+              "ru": "Обновление 7-Zip до версии 26.03",
+              "uk": "Оновлення 7-Zip до версії 26.03",
+              "es-MX": "Actualización de 7-Zip a la versión 26.03",
+              "ko": "7-Zip을 v26.03으로 업데이트",
+              "nl": "7-Zip bijgewerkt naar v26.03",
+              "tr": "7-Zip v26.03'e güncellendi"
+            },
+            "issues": [
+              "201"
+            ]
           }
         ]
       },

--- a/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
+++ b/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
@@ -119,7 +119,7 @@ bool sz_is_tree(SZArchiveRef archive);
 
 // --- Utilities ---
 
-/// Version of the vendored 7-Zip sources, e.g. "26.02".
+/// Version of the vendored 7-Zip sources, e.g. "26.03".
 /// Statically allocated -- do not free.
 const char* sz_version(void);
 

--- a/Modules/Sources/Swift7zip/SevenZipArchive.swift
+++ b/Modules/Sources/Swift7zip/SevenZipArchive.swift
@@ -50,7 +50,7 @@ public class SevenZipArchive {
 
     // MARK: - Inspection
 
-    /// Version of the embedded 7-Zip library, e.g. `26.02`.
+    /// Version of the embedded 7-Zip library, e.g. `26.03`.
     ///
     /// Read from the vendored sources at compile time, so it follows the
     /// `Sources/CSevenZip/vendor/7zip` submodule automatically.


### PR DESCRIPTION
Bumps the vendored `Modules/Sources/CSevenZip/vendor/7zip` submodule from
`26.02` to the `26.03` tag.

Upstream 26.03 (2026-09-03):
- Improved support for Joliet ISO images and Compound archives
- Bug and vulnerability fixes (CVE-2026-58052 is Windows Mark-of-the-Web, not
  applicable on macOS)

No source files were added or removed upstream between the two tags, so the
curated file list in `Modules/Package.swift` and `SOURCES.md` needs no change —
verified all 320 listed paths still resolve. The two `e.g. 26.02` doc comments
were refreshed.

`EngineVersionTests` reads `MY_VERSION_NUMBERS` straight from the vendored
header, so the version shown in "Info on Engines" follows the bump on its own.

## Verification
- `swift test --package-path Modules` — 413 tests in 119 suites pass
- `xcodebuild -scheme MacPacker build` — BUILD SUCCEEDED, no new UI strings

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the bundled 7-Zip engine to version 26.03.

- **Documentation**
  - Updated displayed version examples and release information to reflect 7-Zip 26.03.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->