### PR TITLE
ci: bump workflows-macos to v0.5.3 and pin every runner

### DIFF
--- a/.github/workflows/distribute-beta.yml
+++ b/.github/workflows/distribute-beta.yml
@@ -1,4 +1,4 @@
-# ── Per-app beta shell (workflows-macos v0.4.6, product-file model) ───────────
+# ── Per-app beta shell (workflows-macos v0.5.2, product-file model) ───────────
 # Fires on push to main. The orchestrator discovers Config/products/*.json and
 # cuts a beta for each product whose OWN file changed and whose version is still
 # unreleased (primary MacPacker → bare v<ver>-beta.N). Channel toggles and the
@@ -18,7 +18,12 @@ permissions:
 
 jobs:
   beta:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.4.6
+    # Forks get a copy of this shell and `push: branches: [main]` fires on every
+    # fork sync, running the pipeline as far as signing before it dies red on
+    # secrets a fork never receives. A skipped `uses:` job never resolves the
+    # reusable workflow at all — no secret mapping, no jobs, no runner minutes.
+    if: github.repository == 'sarensw/MacPacker'
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.5.2
     secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
@@ -43,6 +48,14 @@ jobs:
       JIRA_API_TOKEN:                 ${{ secrets.JIRA_API_TOKEN }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
+      # From v0.5.2 every runs-on-* defaults to ["self-hosted","macOS"], and this
+      # repo has no self-hosted runner — unpinned jobs would queue forever, and a
+      # queued job never turns red. Pin explicitly.
+      runs-on-build-direct: '"macos-26"'
+      runs-on-build-store:  '"macos-26"'
+      runs-on-test:         '"macos-26"'
+      runs-on-publish:      '"macos-26"'
+
       artifact-retention-days: 90   # CI artifacts kept 90 days
       # The store leg MUST archive "Release Store" — the orchestrator default is
       # "Release", which would build the wrong flavor.

--- a/.github/workflows/distribute-beta.yml
+++ b/.github/workflows/distribute-beta.yml
@@ -1,4 +1,4 @@
-# ── Per-app beta shell (workflows-macos v0.5.2, product-file model) ───────────
+# ── Per-app beta shell (workflows-macos v0.5.3, product-file model) ───────────
 # Fires on push to main. The orchestrator discovers Config/products/*.json and
 # cuts a beta for each product whose OWN file changed and whose version is still
 # unreleased (primary MacPacker → bare v<ver>-beta.N). Channel toggles and the
@@ -23,7 +23,7 @@ jobs:
     # secrets a fork never receives. A skipped `uses:` job never resolves the
     # reusable workflow at all — no secret mapping, no jobs, no runner minutes.
     if: github.repository == 'sarensw/MacPacker'
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.5.2
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.5.3
     secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
@@ -48,9 +48,10 @@ jobs:
       JIRA_API_TOKEN:                 ${{ secrets.JIRA_API_TOKEN }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
-      # From v0.5.2 every runs-on-* defaults to ["self-hosted","macOS"], and this
-      # repo has no self-hosted runner — unpinned jobs would queue forever, and a
-      # queued job never turns red. Pin explicitly.
+      # Every runs-on-* defaults to ["self-hosted","macOS"], and this repo has no
+      # self-hosted runner — an unpinned job queues forever, and a queued job
+      # never turns red. Pin every one of them.
+      runs-on-prepare:      '"macos-26"'
       runs-on-build-direct: '"macos-26"'
       runs-on-build-store:  '"macos-26"'
       runs-on-test:         '"macos-26"'

--- a/.github/workflows/distribute-beta.yml
+++ b/.github/workflows/distribute-beta.yml
@@ -18,10 +18,7 @@ permissions:
 
 jobs:
   beta:
-    # Forks get a copy of this shell and `push: branches: [main]` fires on every
-    # fork sync, running the pipeline as far as signing before it dies red on
-    # secrets a fork never receives. A skipped `uses:` job never resolves the
-    # reusable workflow at all — no secret mapping, no jobs, no runner minutes.
+    # Make sure the beta job only runs in our own repo, not any fork repo.
     if: github.repository == 'sarensw/MacPacker'
     uses: LeanBytes/workflows-macos/.github/workflows/distribute-beta.yml@v0.5.3
     secrets:
@@ -48,9 +45,7 @@ jobs:
       JIRA_API_TOKEN:                 ${{ secrets.JIRA_API_TOKEN }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
-      # Every runs-on-* defaults to ["self-hosted","macOS"], and this repo has no
-      # self-hosted runner — an unpinned job queues forever, and a queued job
-      # never turns red. Pin every one of them.
+      # All jobs shall run on GitHub infrastructure, not LeanBytes infrastructure
       runs-on-prepare:      '"macos-26"'
       runs-on-build-direct: '"macos-26"'
       runs-on-build-store:  '"macos-26"'

--- a/.github/workflows/distribute-pr.yml
+++ b/.github/workflows/distribute-pr.yml
@@ -20,9 +20,7 @@ jobs:
   pr:
     uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.5.3
     with:
-      # Every runs-on-* defaults to ["self-hosted","macOS"], and this repo has no
-      # self-hosted runner — an unpinned job queues forever, and a queued job
-      # never turns red. Pin every one of them.
+      # All jobs shall run on GitHub infrastructure, not LeanBytes infrastructure
       runs-on-discover: '"macos-26"'
       runs-on-build:    '"macos-26"'
       runs-on-test:     '"macos-26"'

--- a/.github/workflows/distribute-pr.yml
+++ b/.github/workflows/distribute-pr.yml
@@ -1,4 +1,4 @@
-# ── Per-app PR shell (workflows-macos v0.5.2, product-file model) ─────────────
+# ── Per-app PR shell (workflows-macos v0.5.3, product-file model) ─────────────
 # Trigger-only: the orchestrator discovers every Config/products/<id>.json and
 # compiles each product (unsigned, fork-PR safe), then runs the Swift package
 # tests. Identity + channels live in the product files, not here.
@@ -18,13 +18,14 @@ permissions:
 
 jobs:
   pr:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.5.2
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.5.3
     with:
-      # From v0.5.2 every runs-on-* defaults to ["self-hosted","macOS"], and this
-      # repo has no self-hosted runner — unpinned jobs would queue forever, and a
-      # queued job never turns red. Pin explicitly.
-      runs-on-build: '"macos-26"'
-      runs-on-test:  '"macos-26"'
+      # Every runs-on-* defaults to ["self-hosted","macOS"], and this repo has no
+      # self-hosted runner — an unpinned job queues forever, and a queued job
+      # never turns red. Pin every one of them.
+      runs-on-discover: '"macos-26"'
+      runs-on-build:    '"macos-26"'
+      runs-on-test:     '"macos-26"'
 
       artifact-retention-days: 90   # CI artifacts kept 90 days
       # ── Test configuration ──

--- a/.github/workflows/distribute-pr.yml
+++ b/.github/workflows/distribute-pr.yml
@@ -1,4 +1,4 @@
-# ── Per-app PR shell (workflows-macos v0.4.6, product-file model) ─────────────
+# ── Per-app PR shell (workflows-macos v0.5.2, product-file model) ─────────────
 # Trigger-only: the orchestrator discovers every Config/products/<id>.json and
 # compiles each product (unsigned, fork-PR safe), then runs the Swift package
 # tests. Identity + channels live in the product files, not here.
@@ -18,8 +18,14 @@ permissions:
 
 jobs:
   pr:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.4.6
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-pr.yml@v0.5.2
     with:
+      # From v0.5.2 every runs-on-* defaults to ["self-hosted","macOS"], and this
+      # repo has no self-hosted runner — unpinned jobs would queue forever, and a
+      # queued job never turns red. Pin explicitly.
+      runs-on-build: '"macos-26"'
+      runs-on-test:  '"macos-26"'
+
       artifact-retention-days: 90   # CI artifacts kept 90 days
       # ── Test configuration ──
       run-tests: true

--- a/.github/workflows/distribute-release.yml
+++ b/.github/workflows/distribute-release.yml
@@ -1,4 +1,4 @@
-# ── Per-app release shell (workflows-macos v0.4.6, product-file model) ────────
+# ── Per-app release shell (workflows-macos v0.5.2, product-file model) ────────
 # Fires on a version tag. The orchestrator parses the tag → the target product,
 # validates the version against that product's inline changelog, then builds and
 # publishes just it. The GH Release is created last (fail-safe ordering).
@@ -24,7 +24,12 @@ permissions:
 
 jobs:
   release:
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.4.6
+    # Forks get a copy of this shell, and a fork that pulls in our tags fires it
+    # on its own — the pipeline runs as far as signing, then dies red on secrets
+    # a fork never receives. A skipped `uses:` job never resolves the reusable
+    # workflow at all — no secret mapping, no jobs, no runner minutes.
+    if: github.repository == 'sarensw/MacPacker'
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.5.2
     secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
@@ -47,6 +52,13 @@ jobs:
       SPARKLE_ED_PRIVATE_KEY:         ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
+      # From v0.5.2 every runs-on-* defaults to ["self-hosted","macOS"], and this
+      # repo has no self-hosted runner — unpinned jobs would queue forever, and a
+      # queued job never turns red. Pin explicitly.
+      runs-on-build-direct: '"macos-26"'
+      runs-on-build-store:  '"macos-26"'
+      runs-on-publish:      '"macos-26"'
+
       artifact-retention-days: 90   # CI artifacts kept 90 days
       # The store leg MUST archive "Release Store" — the orchestrator default is
       # "Release", which would build the wrong flavor.

--- a/.github/workflows/distribute-release.yml
+++ b/.github/workflows/distribute-release.yml
@@ -1,4 +1,4 @@
-# ── Per-app release shell (workflows-macos v0.5.2, product-file model) ────────
+# ── Per-app release shell (workflows-macos v0.5.3, product-file model) ────────
 # Fires on a version tag. The orchestrator parses the tag → the target product,
 # validates the version against that product's inline changelog, then builds and
 # publishes just it. The GH Release is created last (fail-safe ordering).
@@ -29,7 +29,7 @@ jobs:
     # a fork never receives. A skipped `uses:` job never resolves the reusable
     # workflow at all — no secret mapping, no jobs, no runner minutes.
     if: github.repository == 'sarensw/MacPacker'
-    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.5.2
+    uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.5.3
     secrets:
       DEVELOPER_ID_P12_BASE64:        ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
       DEVELOPER_ID_PASSWORD:          ${{ secrets.DEVELOPER_ID_PASSWORD }}
@@ -52,9 +52,10 @@ jobs:
       SPARKLE_ED_PRIVATE_KEY:         ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
-      # From v0.5.2 every runs-on-* defaults to ["self-hosted","macOS"], and this
-      # repo has no self-hosted runner — unpinned jobs would queue forever, and a
-      # queued job never turns red. Pin explicitly.
+      # Every runs-on-* defaults to ["self-hosted","macOS"], and this repo has no
+      # self-hosted runner — an unpinned job queues forever, and a queued job
+      # never turns red. Pin every one of them.
+      runs-on-prepare:      '"macos-26"'
       runs-on-build-direct: '"macos-26"'
       runs-on-build-store:  '"macos-26"'
       runs-on-publish:      '"macos-26"'

--- a/.github/workflows/distribute-release.yml
+++ b/.github/workflows/distribute-release.yml
@@ -24,10 +24,7 @@ permissions:
 
 jobs:
   release:
-    # Forks get a copy of this shell, and a fork that pulls in our tags fires it
-    # on its own — the pipeline runs as far as signing, then dies red on secrets
-    # a fork never receives. A skipped `uses:` job never resolves the reusable
-    # workflow at all — no secret mapping, no jobs, no runner minutes.
+    # Make sure the release job only runs in our own repo, not any fork repo.
     if: github.repository == 'sarensw/MacPacker'
     uses: LeanBytes/workflows-macos/.github/workflows/distribute-release.yml@v0.5.3
     secrets:
@@ -52,9 +49,7 @@ jobs:
       SPARKLE_ED_PRIVATE_KEY:         ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
       SHARED_WORKFLOWS_TOKEN:         ${{ secrets.SHARED_WORKFLOWS_TOKEN }}
     with:
-      # Every runs-on-* defaults to ["self-hosted","macOS"], and this repo has no
-      # self-hosted runner — an unpinned job queues forever, and a queued job
-      # never turns red. Pin every one of them.
+      # All jobs shall run on GitHub infrastructure, not LeanBytes infrastructure
       runs-on-prepare:      '"macos-26"'
       runs-on-build-direct: '"macos-26"'
       runs-on-build-store:  '"macos-26"'


### PR DESCRIPTION
Bumps all three shells from `@v0.4.6` to `@v0.5.3` and pins **every** job in all three pipelines to `macos-26`.

## Why the bump and the pinning are one change

`v0.5.x` brings `altool` rejections that actually fail instead of reporting success while shipping nothing, a per-channel build runner split, a `codesign` that no longer hangs when a fresh `build.keychain` auto-locks after 300s idle, a cancelled build job that no longer publishes a half-built beta, and `RUNS_ON_*` repo Variable overrides.

But from `v0.4.7` on, every `runs-on-*` input defaults to `["self-hosted","macOS"]`:

```
$ gh api repos/sarensw/MacPacker/actions/runners --jq .total_count
0
```

MacPacker is a personal repo, so the LeanBytes org runner is not reachable from it. Bumping without pinning would leave every job queued forever — and a queued job never goes red, so it fails silently.

Note the rename: `runs-on-build` was split into `runs-on-build-direct` + `runs-on-build-store` in beta and release.

## Stopping forks from running the beta and release shells

Forks carry a copy of these shells. `distribute-beta.yml` fires on `push: branches: [main]`, so every fork sync runs their copy of the beta pipeline, which gets as far as signing and fails red on secrets a fork never receives. One fork has done this nine times since 2026-08-09, ending each run at `Set up signing` / `Verify .p12 envelope` with 0 tags and 0 releases to show for it. Nothing leaks and nothing of ours is touched — it is pure noise on their Actions minutes, and it makes the project look broken to someone trying to contribute.

```yaml
jobs:
  beta:
    if: github.repository == 'sarensw/MacPacker'
```

A skipped `uses:` job never resolves the reusable workflow, so no secret mapping is evaluated, no jobs are dispatched, and zero runner minutes are spent. The run turns grey `skipped` instead of red `failure`.

Two things it deliberately does not do: the run row still appears in the fork's Actions tab (the push matched `on:`, so GitHub creates the run regardless), and it does not reach existing forks until they sync `main`.

`distribute-pr.yml` and `guard-version.yml` need no guard — both are `pull_request`-triggered, so in a fork they only fire for PRs opened *into* that fork.

## Verification

Checked against what `v0.5.3` actually ships, not assumed:

- Walked the job-level `runs-on` of **every** workflow file in the tag. No literal runner remains anywhere except `selftest.yml` on `ubuntu-latest`, which is upstream's sanctioned exception. Every job these three pipelines reach is covered by a pin here.
- Every input and secret the shells pass is declared; no required secret is missing. The ~21 mapped secrets, `configuration-app-store: Release Store`, `run-tests`, `test-runner`, `swift-package-path` and `artifact-retention-days` carry over untouched.
- All `runs-on` values are consumed as `${{ vars.RUNS_ON_* || fromJSON(inputs.runs-on) }}`, so the JSON-encoded `'"macos-26"'` form is correct — confirmed by parsing each value back through `json.loads`.
- `actionlint` clean on all four workflow files.

**CI on this branch is green, which is the live test of the bump:**

```
pr / discover    | success | ["macos-26"]
pr / verify      | success | ["macos-26"]
pr / test / gate | success | ["macos-26"]
pr / test / test | success | ["macos-26"]
```

No product-file changes — the v0.4.0 model is already in place, and the release tag filter is already correct. No changelog entry: this is CI infrastructure, nothing user-visible.

Closes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated beta, pull request, and release distribution workflows to use the latest workflow tooling.
  - Standardized build, test, preparation, and publishing jobs on macOS 26 runners.
  - Preserved repository safeguards for release distribution, preventing unsupported fork executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->