### PR TITLE
fix: replace files in an archive fails (#199)

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -62,7 +62,7 @@
           {
             "type": "fix",
             "title": {
-              "en": "Replace files in an archive fails",
+              "en": "Replacing files in an archive fails",
               "zh-Hans": "替换压缩包中的文件失败",
               "fr": "Le remplacement de fichiers dans une archive échoue",
               "de": "Ersetzen von Dateien in einem Archiv schlägt fehl",

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -60,6 +60,29 @@
             ]
           },
           {
+            "type": "fix",
+            "title": {
+              "en": "Replace files in an archive fails",
+              "zh-Hans": "替换压缩包中的文件失败",
+              "fr": "Le remplacement de fichiers dans une archive échoue",
+              "de": "Ersetzen von Dateien in einem Archiv schlägt fehl",
+              "it": "La sostituzione di file in un archivio non riesce",
+              "ja": "アーカイブ内のファイルの置き換えに失敗する",
+              "fa": "جایگزینی فایل‌ها در یک آرشیو ناموفق است",
+              "pl": "Zastępowanie plików w archiwum nie działa",
+              "pt-BR": "Substituir arquivos em um arquivo compactado falha",
+              "ru": "Замена файлов в архиве не работает",
+              "uk": "Заміна файлів в архіві не працює",
+              "es-MX": "Reemplazar archivos en un archivo comprimido falla",
+              "ko": "아카이브 내 파일 교체가 실패함",
+              "nl": "Bestanden vervangen in een archief mislukt",
+              "tr": "Arşivdeki dosyaları değiştirme başarısız oluyor"
+            },
+            "issues": [
+              "199"
+            ]
+          },
+          {
             "type": "core",
             "title": {
               "en": "Update 7-Zip to v26.03",

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -535,7 +535,19 @@ extension ArchiveState {
         loadChildren()
     }
 
+    /// The item currently sitting under `name` in `parent` — a real archive
+    /// entry or a pending addition — if there is one.
+    private func child(named name: String, under parent: ArchiveItem) -> ArchiveItem? {
+        parent.children?.lazy.compactMap { self.entries[$0] }.first { $0.name == name }
+    }
+
     private func addFile(url: URL, archivePath: String, under parent: ArchiveItem) {
+        // Adding over a name the archive already holds replaces it. Without
+        // dropping the old entry the archive keeps both, so the file the user
+        // meant to replace is still in there next to its replacement.
+        if let existing = child(named: url.lastPathComponent, under: parent) {
+            discard(items: [existing])
+        }
         diff.append(.addFile(archivePath: archivePath, diskPath: url))
         let item = ArchiveItem(url: url, archivePath: archivePath)
         item.parent = parent.id
@@ -560,11 +572,21 @@ extension ArchiveState {
             return
         }
 
-        diff.append(.addDirectory(archivePath: archivePath))
-        let item = ArchiveItem(url: url, archivePath: archivePath)
-        item.parent = parent.id
-        parent.addChild(item.id)
-        entries[item.id] = item
+        // A folder that is already there is merged into, not added a second
+        // time: only the files that collide inside it are replaced, the rest
+        // of what it holds stays. Anything else drops the whole folder.
+        let existing = child(named: url.lastPathComponent, under: parent)
+        let item: ArchiveItem
+        if let existing, existing.isFolder {
+            item = existing
+        } else {
+            if let existing { discard(items: [existing]) }
+            diff.append(.addDirectory(archivePath: archivePath))
+            item = ArchiveItem(url: url, archivePath: archivePath)
+            item.parent = parent.id
+            parent.addChild(item.id)
+            entries[item.id] = item
+        }
 
         for child in children.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
             if child.isDirectory {
@@ -585,6 +607,25 @@ extension ArchiveState {
             return
         }
 
+        let dropped = discard(items: items)
+
+        log.notice("Marked items for removal", context: [
+            "items": "\(items.count)",
+            "archiveEntries": "\(dropped.archiveEntries)",
+            "pendingAdds": "\(dropped.pendingAdds)"
+        ])
+
+        selectedItems = []
+        isReloadNeeded = true
+        loadChildren()
+    }
+
+    /// Takes the given items (and everything below them) out of the tree and
+    /// records that in the diff: entries that exist in the archive on disk
+    /// become removals, pending (unsaved) additions are dropped from the diff
+    /// again. Used both by delete and by an add that replaces an existing item.
+    @discardableResult
+    private func discard(items: [ArchiveItem]) -> (archiveEntries: Int, pendingAdds: Int) {
         var removedIndices: Set<UInt32> = []
         var droppedAddPaths: Set<String> = []
         for item in items {
@@ -608,15 +649,10 @@ extension ArchiveState {
         // entries that exist in the archive on disk are removed on save
         diff.append(contentsOf: removedIndices.sorted().map { .remove(sourceIndex: $0) })
 
-        log.notice("Marked items for removal", context: [
-            "items": "\(items.count)",
-            "archiveEntries": "\(removedIndices.count)",
-            "pendingAdds": "\(droppedAddPaths.count)"
-        ])
+        // a discarded item must not stay selected — it is gone from `entries`
+        selectedItems = selectedItems.filter { entries[$0.id] != nil }
 
-        selectedItems = []
-        isReloadNeeded = true
-        loadChildren()
+        return (removedIndices.count, droppedAddPaths.count)
     }
 
     /// Depth-first: collects the source indices (real archive entries) and

--- a/Modules/Tests/CoreTests/ZipWriteTests.swift
+++ b/Modules/Tests/CoreTests/ZipWriteTests.swift
@@ -57,10 +57,31 @@ private func makeSystemZipFixture(in dir: URL) throws -> URL {
     return zip
 }
 
+/// Entry paths as listed by the independent system tool (`unzip -Z1`), in
+/// file order and with duplicates kept — a `Set` would hide exactly the
+/// duplicate that an add over an existing name used to leave behind.
+private func systemZipEntries(_ zip: URL) throws -> [String] {
+    let out = try run("/usr/bin/unzip", ["-Z1", zip.path])
+    return out.split(separator: "\n").map(String.init)
+}
+
 /// Entry paths as listed by the independent system tool (`unzip -Z1`).
 private func systemZipList(_ zip: URL) throws -> Set<String> {
-    let out = try run("/usr/bin/unzip", ["-Z1", zip.path])
-    return Set(out.split(separator: "\n").map(String.init))
+    Set(try systemZipEntries(zip))
+}
+
+/// A jar fixture — a zip by another name, with the manifest a real one carries:
+/// META-INF/MANIFEST.MF, com/example/data.txt, readme.txt
+private func makeJarFixture(in dir: URL) throws -> URL {
+    let src = dir.appendingPathComponent("jarsrc")
+    try FileManager.default.createDirectory(at: src.appendingPathComponent("META-INF"), withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: src.appendingPathComponent("com/example"), withIntermediateDirectories: true)
+    try "Manifest-Version: 1.0\n".write(to: src.appendingPathComponent("META-INF/MANIFEST.MF"), atomically: true, encoding: .utf8)
+    try "data".write(to: src.appendingPathComponent("com/example/data.txt"), atomically: true, encoding: .utf8)
+    try "old".write(to: src.appendingPathComponent("readme.txt"), atomically: true, encoding: .utf8)
+    let jar = dir.appendingPathComponent("fixture.jar")
+    try run("/usr/bin/zip", ["-r", jar.path, "META-INF", "com", "readme.txt"], cwd: src)
+    return jar
 }
 
 // MARK: - Writer-level tests (SevenZipArchive.writeArchive)
@@ -421,6 +442,84 @@ extension AllCoreTests {
             let pending = try #require(item("extra.txt", in: state))
             state.remove(items: [pending])
             #expect(!state.hasPendingChanges)
+        }
+
+        /// Adding a file the archive already holds under that name replaces it.
+        /// Issue #199: the old entry was kept, so the jar came out with two
+        /// entries for one path and the replacement did not take.
+        @Test func addingOverAnExistingFileReplacesIt() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let jar = try makeJarFixture(in: dir)
+
+            // the replacement, same name, elsewhere on disk
+            let newDir = dir.appendingPathComponent("new")
+            try FileManager.default.createDirectory(at: newDir, withIntermediateDirectories: true)
+            let replacement = newDir.appendingPathComponent("readme.txt")
+            try "new".write(to: replacement, atomically: true, encoding: .utf8)
+
+            let state = makeState()
+            state.open(url: jar)
+            try await state.openTask?.value
+            #expect(state.canBeEdited)
+
+            state.add(url: replacement)
+            let saveTask = try #require(state.save())
+            await saveTask.value
+            #expect(state.error == nil)
+
+            let listed = try systemZipEntries(jar)
+            #expect(listed.filter { $0 == "readme.txt" }.count == 1,
+                    "duplicate entry after replace: \(listed)")
+            #expect(listed.contains("com/example/data.txt"))
+            #expect(listed.contains("META-INF/MANIFEST.MF"))
+            try run("/usr/bin/unzip", ["-t", jar.path])
+
+            // the entry that survived is the new one
+            let out = dir.appendingPathComponent("out")
+            try run("/usr/bin/unzip", [jar.path, "-d", out.path])
+            #expect(try String(contentsOf: out.appendingPathComponent("readme.txt"), encoding: .utf8) == "new")
+
+            // and the archive shows one row for it, not two
+            #expect(state.entries.values.filter { $0.name == "readme.txt" }.count == 1)
+        }
+
+        /// Adding a folder that is already in the archive merges into it:
+        /// colliding files are replaced, the rest of the folder survives.
+        @Test func addingOverAnExistingFolderMergesIntoIt() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let zip = try makeSystemZipFixture(in: dir)   // folder/one.txt, folder/two.txt
+
+            // a folder of the same name on disk: one.txt replaced, three.txt new
+            let newFolder = dir.appendingPathComponent("new/folder")
+            try FileManager.default.createDirectory(at: newFolder, withIntermediateDirectories: true)
+            try "one v2".write(to: newFolder.appendingPathComponent("one.txt"), atomically: true, encoding: .utf8)
+            try "three".write(to: newFolder.appendingPathComponent("three.txt"), atomically: true, encoding: .utf8)
+
+            let state = makeState()
+            state.open(url: zip)
+            try await state.openTask?.value
+
+            state.add(url: newFolder)
+            let saveTask = try #require(state.save())
+            await saveTask.value
+            #expect(state.error == nil)
+
+            let listed = try systemZipEntries(zip)
+            #expect(listed.filter { $0 == "folder/one.txt" }.count == 1,
+                    "duplicate entry after replace: \(listed)")
+            #expect(listed.filter { $0 == "folder/" || $0 == "folder" }.count == 1,
+                    "duplicate folder entry: \(listed)")
+            #expect(listed.contains("folder/two.txt"))   // untouched sibling survives
+            #expect(listed.contains("folder/three.txt")) // new file arrived
+            #expect(listed.contains("root.txt"))
+            try run("/usr/bin/unzip", ["-t", zip.path])
+
+            let out = dir.appendingPathComponent("out")
+            try run("/usr/bin/unzip", [zip.path, "-d", out.path])
+            #expect(try String(contentsOf: out.appendingPathComponent("folder/one.txt"), encoding: .utf8) == "one v2")
+            #expect(try String(contentsOf: out.appendingPathComponent("folder/two.txt"), encoding: .utf8) == "two")
         }
     }
 }


### PR DESCRIPTION
Replacing a file inside an archive left the old one in there.

Adding a file under a name the archive already holds appended a second entry instead of replacing the first: the writer keeps every source entry unless the diff removes it, and `add` never removed anything. The saved archive then carried two entries for one path — old bytes plus new — so the replacement did not take, `unzip` stopped on the duplicate name, and MacPacker showed the file twice after the post-save reload.

Reproduced on a jar (a zip by another name, which is what the report was about), but nothing here is jar-specific — any editable archive was affected.

## Fix

- `addFile` discards whatever currently occupies that name before recording the addition.
- `addFolder` merges into a folder that is already there: only the colliding files inside it get replaced, the rest of its contents stay. A folder landing on a *file* replaces it outright.
- The removal bookkeeping that delete already had moved into `discard(items:)`, now shared by delete and by a replacing add.

## Tests

Two failing-first tests in `Modules/Tests/CoreTests/ZipWriteTests.swift`:

- `addingOverAnExistingFileReplacesIt` — the reported flow on a `.jar` fixture: one entry survives, it holds the new content, the archive still passes `unzip -t`.
- `addingOverAnExistingFolderMergesIntoIt` — folder drop replaces the colliding file, keeps the untouched sibling, adds the new file, and writes no second directory entry.

`unzip -Z1` output is now compared as a list, not a `Set` — a `Set` hid exactly the duplicate this fixes.

`swift test --package-path Modules`: 415 tests, all passing.

Closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where replacing a file in an archive could leave duplicate entries.
  - Adding files with an existing name now correctly replaces the previous file.
  - Adding content to an existing folder now merges the contents while replacing conflicting files.
  - Removing archive items now preserves the selection of unaffected items.

- **Documentation**
  - Added a changelog entry for the archive replacement fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->