### PR TITLE
feat: new formats support

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -37,6 +37,29 @@
         "version": "0.22.0",
         "items": [
           {
+            "type": "feat",
+            "title": {
+              "en": "Support for zstd, lzma, and more archive formats",
+              "zh-Hans": "支持 zstd、lzma 及更多压缩格式",
+              "fr": "Prise en charge de zstd, lzma et autres formats",
+              "de": "Unterstützung für zstd, lzma und weitere Formate",
+              "it": "Supporto per zstd, lzma e altri formati",
+              "ja": "zstd、lzma、その他のアーカイブ形式に対応",
+              "fa": "پشتیبانی از zstd، lzma و فرمت‌های دیگر آرشیو",
+              "pl": "Obsługa formatów zstd, lzma i innych archiwów",
+              "pt-BR": "Suporte a zstd, lzma e mais formatos de arquivo",
+              "ru": "Поддержка zstd, lzma и других форматов архивов",
+              "uk": "Підтримка zstd, lzma та інших форматів архівів",
+              "es-MX": "Compatibilidad con zstd, lzma y más formatos",
+              "ko": "zstd, lzma 및 추가 아카이브 형식 지원",
+              "nl": "Ondersteuning voor zstd, lzma en meer formaten",
+              "tr": "zstd, lzma ve daha fazla arşiv formatı desteği"
+            },
+            "issues": [
+              "TODO"
+            ]
+          },
+          {
             "type": "fix",
             "title": {
               "en": "Remember window size and position",

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -34,7 +34,7 @@
     },
     "versions": [
       {
-        "version": "0.22.0",
+        "version": "0.23.0",
         "items": [
           {
             "type": "feat",
@@ -58,7 +58,12 @@
             "issues": [
               "TODO"
             ]
-          },
+          }
+        ]
+      },
+      {
+        "version": "0.22.0",
+        "items": [
           {
             "type": "fix",
             "title": {

--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -34,34 +34,6 @@
     },
     "versions": [
       {
-        "version": "0.23.0",
-        "items": [
-          {
-            "type": "feat",
-            "title": {
-              "en": "Support for zstd, lzma, and more archive formats",
-              "zh-Hans": "支持 zstd、lzma 及更多压缩格式",
-              "fr": "Prise en charge de zstd, lzma et autres formats",
-              "de": "Unterstützung für zstd, lzma und weitere Formate",
-              "it": "Supporto per zstd, lzma e altri formati",
-              "ja": "zstd、lzma、その他のアーカイブ形式に対応",
-              "fa": "پشتیبانی از zstd، lzma و فرمت‌های دیگر آرشیو",
-              "pl": "Obsługa formatów zstd, lzma i innych archiwów",
-              "pt-BR": "Suporte a zstd, lzma e mais formatos de arquivo",
-              "ru": "Поддержка zstd, lzma и других форматов архивов",
-              "uk": "Підтримка zstd, lzma та інших форматів архівів",
-              "es-MX": "Compatibilidad con zstd, lzma y más formatos",
-              "ko": "zstd, lzma 및 추가 아카이브 형식 지원",
-              "nl": "Ondersteuning voor zstd, lzma en meer formaten",
-              "tr": "zstd, lzma ve daha fazla arşiv formatı desteği"
-            },
-            "issues": [
-              "TODO"
-            ]
-          }
-        ]
-      },
-      {
         "version": "0.22.0",
         "items": [
           {

--- a/MacPacker/Info.plist
+++ b/MacPacker/Info.plist
@@ -66,6 +66,139 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
+				<string>lzma</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>LZMA Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.tukaani.lzma-archive</string>
+				<string>public.lzma-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tlzma</string>
+				<string>tar.lzma</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>LZMA Tarball Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.tukaani.tar-lzma-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>zst</string>
+				<string>zstd</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Zstandard Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.facebook.zstandard-archive</string>
+				<string>public.zstandard-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tzst</string>
+				<string>tar.zst</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Zstandard Tarball Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.zstandard-tar-archive</string>
+				<string>com.facebook.zstandard-tar-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>ace</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>ACE Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.winace.ace-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>pax</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>PAX Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>cx.c3.pax-archive</string>
+				<string>public.pax-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>cpt</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Compact Pro Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.cyclos.cpt-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
 				<string>zip</string>
 			</array>
 			<key>CFBundleTypeName</key>
@@ -126,6 +259,90 @@
 			<string>Viewer</string>
 			<key>LSHandlerRank</key>
 			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>ipa</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>iOS App Package</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.itunes.ipa</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>epub</string>
+				<string>kepub</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Electronic Publication</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.idpf.epub-container</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>xpi</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Browser Extension Package</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>war</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Web Application Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>appx</string>
+				<string>appxbundle</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Microsoft App Package</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.microsoft.appx-archive</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<false/>
 		</dict>
@@ -361,6 +578,8 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>tar</string>
+				<string>gtar</string>
+				<string>spk</string>
 			</array>
 			<key>CFBundleTypeName</key>
 			<string>TAR Archive</string>
@@ -372,6 +591,7 @@
 			<array>
 				<string>public.tar-archive</string>
 				<string>org.gnu.gnu-tar-archive</string>
+				<string>com.synology.spk-archive</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<false/>
@@ -718,6 +938,7 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>xar</string>
+				<string>safariextz</string>
 			</array>
 			<key>CFBundleTypeName</key>
 			<string>XAR Archive</string>
@@ -997,6 +1218,149 @@
 				<array>
 					<string>tbz2</string>
 					<string>tbz</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Zstandard Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>public.zstandard-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>zst</string>
+					<string>zstd</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Zstandard Tarball Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>public.zstandard-tar-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tzst</string>
+					<string>tar.zst</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>LZMA Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>org.tukaani.lzma-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>lzma</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>LZMA Tarball Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>org.tukaani.tar-lzma-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tlzma</string>
+					<string>tar.lzma</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>ACE Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>com.winace.ace-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>ace</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>PAX Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>cx.c3.pax-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pax</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Compact Pro Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>com.cyclos.cpt-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cpt</string>
 				</array>
 			</dict>
 		</dict>

--- a/MacPacker/Info_Store.plist
+++ b/MacPacker/Info_Store.plist
@@ -66,6 +66,139 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
+				<string>lzma</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>LZMA Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.tukaani.lzma-archive</string>
+				<string>public.lzma-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tlzma</string>
+				<string>tar.lzma</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>LZMA Tarball Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.tukaani.tar-lzma-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>zst</string>
+				<string>zstd</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Zstandard Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.facebook.zstandard-archive</string>
+				<string>public.zstandard-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tzst</string>
+				<string>tar.zst</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Zstandard Tarball Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.zstandard-tar-archive</string>
+				<string>com.facebook.zstandard-tar-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>ace</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>ACE Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.winace.ace-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>pax</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>PAX Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>cx.c3.pax-archive</string>
+				<string>public.pax-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>cpt</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Compact Pro Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.cyclos.cpt-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
 				<string>zip</string>
 			</array>
 			<key>CFBundleTypeName</key>
@@ -129,34 +262,118 @@
 			<key>LSTypeIsPackage</key>
 			<false/>
 		</dict>
-        <dict>
-            <key>CFBundleTypeExtensions</key>
-            <array>
-                <string>cbz</string>
-            </array>
-            <key>CFBundleTypeName</key>
-            <string>Comic Book ZIP Archive</string>
-            <key>CFBundleTypeRole</key>
-            <string>Viewer</string>
-            <key>LSHandlerRank</key>
-            <string>Default</string>
-            <key>LSTypeIsPackage</key>
-            <false/>
-        </dict>
-        <dict>
-            <key>CFBundleTypeExtensions</key>
-            <array>
-                <string>cbr</string>
-            </array>
-            <key>CFBundleTypeName</key>
-            <string>Comic Book RAR Archive</string>
-            <key>CFBundleTypeRole</key>
-            <string>Viewer</string>
-            <key>LSHandlerRank</key>
-            <string>Default</string>
-            <key>LSTypeIsPackage</key>
-            <false/>
-        </dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>ipa</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>iOS App Package</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.itunes.ipa</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>epub</string>
+				<string>kepub</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Electronic Publication</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.idpf.epub-container</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>xpi</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Browser Extension Package</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>war</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Web Application Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>appx</string>
+				<string>appxbundle</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Microsoft App Package</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.microsoft.appx-archive</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>cbz</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Comic Book ZIP Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>cbr</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Comic Book RAR Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
@@ -361,6 +578,8 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>tar</string>
+				<string>gtar</string>
+				<string>spk</string>
 			</array>
 			<key>CFBundleTypeName</key>
 			<string>TAR Archive</string>
@@ -372,6 +591,7 @@
 			<array>
 				<string>public.tar-archive</string>
 				<string>org.gnu.gnu-tar-archive</string>
+				<string>com.synology.spk-archive</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<false/>
@@ -718,6 +938,7 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>xar</string>
+				<string>safariextz</string>
 			</array>
 			<key>CFBundleTypeName</key>
 			<string>XAR Archive</string>
@@ -991,6 +1212,149 @@
 				<array>
 					<string>tbz2</string>
 					<string>tbz</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Zstandard Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>public.zstandard-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>zst</string>
+					<string>zstd</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Zstandard Tarball Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>public.zstandard-tar-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tzst</string>
+					<string>tar.zst</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>LZMA Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>org.tukaani.lzma-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>lzma</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>LZMA Tarball Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>org.tukaani.tar-lzma-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tlzma</string>
+					<string>tar.lzma</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>ACE Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>com.winace.ace-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>ace</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>PAX Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>cx.c3.pax-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pax</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Compact Pro Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>com.cyclos.cpt-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cpt</string>
 				</array>
 			</dict>
 		</dict>

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -267,12 +267,59 @@ public:
 static HRESULT tryOpenStream(
     IInStream *stream,
     CMyComPtr<IInArchive> &archiveOut,
-    IArchiveOpenCallback *callback = nullptr)
+    IArchiveOpenCallback *callback = nullptr,
+    const char *extensionHint = nullptr)
 {
     UInt32 numFormats = 0;
     GetNumberOfFormats(&numFormats);
 
+    std::vector<UInt32> extFormats;
+    std::vector<UInt32> regularFormats;
+    std::vector<UInt32> fallbackFormats;
+
+    std::string hint = extensionHint ? extensionHint : "";
+    for (char &c : hint) c = (char)tolower((unsigned char)c);
+
     for (UInt32 i = 0; i < numFormats; i++) {
+        NWindows::NCOM::CPropVariant propName;
+        GetHandlerProperty2(i, NArchive::NHandlerPropID::kName, &propName);
+        std::string name = PropVariantToUTF8(propName);
+
+        if (!hint.empty()) {
+            NWindows::NCOM::CPropVariant propExt;
+            GetHandlerProperty2(i, NArchive::NHandlerPropID::kExtension, &propExt);
+            std::string extList = PropVariantToUTF8(propExt);
+            size_t start = 0;
+            bool matched = false;
+            while (start < extList.size()) {
+                size_t space = extList.find(' ', start);
+                std::string token = (space == std::string::npos) ? extList.substr(start) : extList.substr(start, space - start);
+                if (!token.empty() && token == hint) {
+                    matched = true;
+                    break;
+                }
+                if (space == std::string::npos) break;
+                start = space + 1;
+            }
+            if (matched) {
+                extFormats.push_back(i);
+                continue;
+            }
+        }
+
+        if (name == "zip") {
+            fallbackFormats.push_back(i);
+        } else {
+            regularFormats.push_back(i);
+        }
+    }
+
+    std::vector<UInt32> order = std::move(extFormats);
+    order.insert(order.end(), regularFormats.begin(), regularFormats.end());
+    order.insert(order.end(), fallbackFormats.begin(), fallbackFormats.end());
+
+    UInt64 newPos = 0;
+    for (UInt32 i : order) {
         NWindows::NCOM::CPropVariant propClassID;
         GetHandlerProperty2(i, NArchive::NHandlerPropID::kClassID, &propClassID);
         if (propClassID.vt != VT_BSTR || !propClassID.bstrVal)
@@ -286,7 +333,6 @@ static HRESULT tryOpenStream(
         if (hr != S_OK || !archive)
             continue;
 
-        UInt64 newPos;
         stream->Seek(0, STREAM_SEEK_SET, &newPos);
 
         UInt64 maxCheckStart = 1 << 22; // 4MB
@@ -700,7 +746,8 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
     // back, chmod it, or replace it with a symlink.
     _outFileStream.Release();
 
-    if (opRes != NArchive::NExtract::NOperationResult::kOK) {
+    if (opRes != NArchive::NExtract::NOperationResult::kOK &&
+        opRes != NArchive::NExtract::NOperationResult::kDataAfterEnd) {
         // The entry did not decode. Whatever bytes landed on disk are garbage —
         // usually zero of them — so remove the file instead of leaving an empty
         // one that looks like a successful extraction.
@@ -821,7 +868,8 @@ static int finishExtract(CExtractCallback *callback, HRESULT hr, char **error_ou
                               callback->destDir());
 
     const Int32 opRes = callback->failedOpResult;
-    const bool entryFailed = opRes != NArchive::NExtract::NOperationResult::kOK;
+    const bool entryFailed = opRes != NArchive::NExtract::NOperationResult::kOK &&
+                             opRes != NArchive::NExtract::NOperationResult::kDataAfterEnd;
 
     if (hr == S_OK && !entryFailed && callback->errorMessage.empty())
         return SZ_EXTRACT_OK;
@@ -994,7 +1042,12 @@ SZArchiveRef sz_open(const char *path, const char *password,
 
         // Try each registered format on the file stream
         CMyComPtr<IInArchive> firstArchive;
-        HRESULT hr = tryOpenStream(handle->fileStream, firstArchive, volCallback);
+        std::string extHint;
+        if (path) {
+            const char *dot = strrchr(path, '.');
+            if (dot) extHint = dot + 1;
+        }
+        HRESULT hr = tryOpenStream(handle->fileStream, firstArchive, volCallback, extHint.c_str());
         if (hr != S_OK || !firstArchive) {
             if (needs_password_out)
                 *needs_password_out = volCallbackSpec->passwordRequested;

--- a/Modules/Sources/Core/Formats/Catalog.json
+++ b/Modules/Sources/Core/Formats/Catalog.json
@@ -237,9 +237,7 @@
       "uti": ["org.tukaani.lzma-archive", "public.lzma-archive"],
       "extensions": ["lzma"],
       "mime": ["application/x-lzma"],
-      "rules": [
-        { "policy": "any", "tests": [{"type": "signature", "bytes": "5D 00 00", "offset": 0}] }
-      ],
+      "rules": [],
       "engines": [
         { "id": "7zip", "capabilities": ["listContents", "extractFiles"], "default": true }
       ]

--- a/Modules/Sources/Core/Formats/Catalog.json
+++ b/Modules/Sources/Core/Formats/Catalog.json
@@ -17,6 +17,20 @@
       ]
     },
     {
+      "id": "ace",
+      "name": "ACE Archive",
+      "kind": "archive",
+      "uti": ["com.winace.ace-archive"],
+      "extensions": ["ace"],
+      "mime": ["application/x-ace-compressed"],
+      "rules": [
+        { "policy": "any", "tests": [{"type": "signature", "bytes": "2A 2A 41 43 45 2A 2A", "offset": 7}] }
+      ],
+      "engines": [
+        { "id": "xad", "capabilities": ["listContents", "extractFiles"], "default": true }
+      ]
+    },
+    {
       "id": "ar",
       "name": "Archiver Archive",
       "kind": "archive",
@@ -92,6 +106,20 @@
       "engines": [
         { "id": "xad", "capabilities": ["listContents", "extractFiles"] },
         { "id": "7zip", "capabilities": ["listContents", "extractFiles"], "default": true }
+      ]
+    },
+    {
+      "id": "cpt",
+      "name": "Compact Pro Archive",
+      "kind": "archive",
+      "uti": ["com.cyclos.cpt-archive"],
+      "extensions": ["cpt"],
+      "mime": ["application/mac-compactpro"],
+      "rules": [
+        { "policy": "any", "tests": [{"type": "signature", "bytes": "01 12", "offset": 0}] }
+      ],
+      "engines": [
+        { "id": "xad", "capabilities": ["listContents", "extractFiles"], "default": true }
       ]
     },
     {
@@ -203,6 +231,20 @@
       ]
     },
     {
+      "id": "lzma",
+      "name": "LZMA File",
+      "kind": "compression",
+      "uti": ["org.tukaani.lzma-archive", "public.lzma-archive"],
+      "extensions": ["lzma"],
+      "mime": ["application/x-lzma"],
+      "rules": [
+        { "policy": "any", "tests": [{"type": "signature", "bytes": "5D 00 00", "offset": 0}] }
+      ],
+      "engines": [
+        { "id": "7zip", "capabilities": ["listContents", "extractFiles"], "default": true }
+      ]
+    },
+    {
       "id": "lzx",
       "name": "LZX Archive",
       "kind": "archive",
@@ -253,6 +295,18 @@
       "rules": [],
       "engines": [
         { "id": "7zip", "capabilities": ["listContents", "extractFiles"], "default": true }
+      ]
+    },
+    {
+      "id": "pax",
+      "name": "PAX Archive",
+      "kind": "archive",
+      "uti": ["cx.c3.pax-archive", "public.pax-archive"],
+      "extensions": ["pax"],
+      "mime": ["application/x-pax"],
+      "rules": [],
+      "engines": [
+        { "id": "xad", "capabilities": ["listContents", "extractFiles"], "default": true }
       ]
     },
     {
@@ -379,8 +433,8 @@
       "id": "tar",
       "name": "Tar Archive",
       "kind": "archive",
-      "uti": ["public.tar-archive"],
-      "extensions": ["tar"],
+      "uti": ["public.tar-archive", "org.gnu.gnu-tar-archive", "com.synology.spk-archive"],
+      "extensions": ["tar", "gtar", "spk"],
       "mime": ["application/x-tar"],
       "rules": [
         { "policy": "any", "tests": [
@@ -469,7 +523,7 @@
       "name": "XAR Archive",
       "kind": "archive",
       "uti": ["com.apple.xar-archive"],
-      "extensions": ["xar"],
+      "extensions": ["xar", "safariextz"],
       "mime": ["application/x-xar"],
       "rules": [
         { "policy": "any", "tests": [{"type": "signature", "bytes": "78 61 72 21", "offset": 0}] }
@@ -514,9 +568,9 @@
       "id": "zip",
       "name": "ZIP Archive",
       "kind": "archive",
-      "uti": ["public.zip-archive", "com.pkware.zip-archive", "com.sun.java-archive", "com.android.package-archive"],
-      "extensions": ["zip", "jar", "aar", "apk", "cbz"],
-      "mime": ["application/zip", "application/x-zip-compressed", "application/zip-compressed", "multipart/x-zip", "application/java-archive", "application/vnd.android.package-archive", "application/vnd.comicbook+zip"],
+      "uti": ["public.zip-archive", "com.pkware.zip-archive", "com.sun.java-archive", "com.android.package-archive", "com.apple.itunes.ipa", "com.microsoft.appx-archive", "com.rileytestut.delta.skin"],
+      "extensions": ["zip", "jar", "aar", "apk", "cbz", "ipa", "war", "xpi", "appx", "appxbundle", "xapk", "epub", "kepub", "deltaskin", "wacz"],
+      "mime": ["application/zip", "application/x-zip-compressed", "application/zip-compressed", "multipart/x-zip", "application/java-archive", "application/vnd.android.package-archive", "application/vnd.comicbook+zip", "application/epub+zip", "application/x-xpinstall"],
       "rules": [
         { "policy": "any", "tests": [
           {"type": "signature", "bytes": "50 4B 03 04", "offset": 0},
@@ -547,6 +601,20 @@
       "engines": [
         { "id": "xad", "capabilities": ["listContents", "extractFiles"], "default": true }
       ]
+    },
+    {
+      "id": "zstd",
+      "name": "Zstandard Archive",
+      "kind": "compression",
+      "uti": ["com.facebook.zstandard-archive", "public.zstandard-archive"],
+      "extensions": ["zst", "zstd"],
+      "mime": ["application/zstd"],
+      "rules": [
+        { "policy": "any", "tests": [{"type": "signature", "bytes": "28 B5 2F FD", "offset": 0}] }
+      ],
+      "engines": [
+        { "id": "7zip", "capabilities": ["listContents", "extractFiles"], "default": true }
+      ]
     }
   ],
   "compounds": [
@@ -572,6 +640,13 @@
       "components": ["tar","lz4"]
     },
     {
+      "id": "tar.lzma",
+      "name": "LZMA Tar Archive",
+      "uti": ["org.tukaani.tar-lzma-archive"],
+      "extensions": ["tlzma","tar.lzma"],
+      "components": ["tar","lzma"]
+    },
+    {
       "id": "tar.xz",
       "name": "XZ Tar Archive",
       "uti": ["org.tukaani.tar-xz-archive"],
@@ -584,6 +659,13 @@
       "uti": ["public.z-archive"],
       "extensions": ["taz","tar.z"],
       "components": ["tar","z"]
+    },
+    {
+      "id": "tar.zst",
+      "name": "Zstandard Tar Archive",
+      "uti": ["public.zstandard-tar-archive","com.facebook.zstandard-tar-archive"],
+      "extensions": ["tzst","tar.zst"],
+      "components": ["tar","zstd"]
     }
   ],
   "splits": [
@@ -596,6 +678,11 @@
     { "id": "zip-numeric", "name": "Split ZIP", "format": "zip", "scheme": "numeric",
       "pattern": "\\.zip\\.[0-9]{3,}$",
       "firstVolume": { "pattern": "\\.[0-9]{3,}$", "replacement": ".001" },
-      "label": ".zip.001" }
+      "label": ".zip.001" },
+
+    { "id": "rar-legacy", "name": "Legacy RAR Volume", "format": "rar", "scheme": "legacy",
+      "pattern": "\\.r[0-9]{2,}$",
+      "firstVolume": { "pattern": "\\.r[0-9]{2,}$", "replacement": ".rar" },
+      "label": ".rar" }
   ]
 }

--- a/Modules/Tests/CoreTests/ArchiveNamingTests.swift
+++ b/Modules/Tests/CoreTests/ArchiveNamingTests.swift
@@ -100,6 +100,12 @@ extension AllCoreTests {
             }
         }
 
+        @Test func legacyRarVolumeSuffixStripped() {
+            for file in ["MyArchive.r00", "MyArchive.r01", "MyArchive.r99", "MyArchive.r100"] {
+                #expect(folderName(file) == "MyArchive", "\(file)")
+            }
+        }
+
         /// Every part of one set must name the *same* folder — otherwise extracting
         /// two volumes of the same archive produces two folders.
         @Test func allPartsOfASetNameTheSameFolder() {
@@ -108,6 +114,9 @@ extension AllCoreTests {
             }
             for part in ["split_7zz.zip.001", "split_7zz.zip.002", "split_7zz.zip.003"] {
                 #expect(folderName(part) == "split_7zz", "\(part)")
+            }
+            for part in ["split_rar.rar", "split_rar.r00", "split_rar.r01"] {
+                #expect(folderName(part) == "split_rar", "\(part)")
             }
         }
 
@@ -192,7 +201,7 @@ extension AllCoreTests {
         /// Naming samples above are hand-written per scheme (a regex gives no
         /// sample name). A new split entry must arrive with its own cases.
         @Test func everySplitSchemeHasNamingSamples() {
-            #expect(Set(catalog.allSplits().map(\.id)) == ["zip-spanned", "zip-numeric"])
+            #expect(Set(catalog.allSplits().map(\.id)) == ["zip-spanned", "zip-numeric", "rar-legacy"])
         }
     }
 }

--- a/Modules/Tests/CoreTests/DefaultArchiveTests.swift
+++ b/Modules/Tests/CoreTests/DefaultArchiveTests.swift
@@ -68,11 +68,16 @@ extension AllCoreTests {
             ("tar.gz", "tar", 5, 2),
             ("tar.xz", "tar", 5, 2),
             ("tar.Z", "tar", 5, 2),
+            ("tar.zst", "tar", 5, 2),
+            ("tar.lzma", "tar", 5, 2),
+            ("gtar", "tar", 6, 1),
             // comounds with one ending
             ("tbz2", "tar", 5, 2),
             ("tgz", "tar", 5, 2),
             ("txz", "tar", 5, 2),
-            ("taz", "tar", 5, 2)
+            ("taz", "tar", 5, 2),
+            ("tzst", "tar", 5, 2),
+            ("tlzma", "tar", 5, 2)
         ])
         func testAll7zipEngine(arg: (String, String, Int, Int)) async throws {
             let ext = arg.0
@@ -86,8 +91,6 @@ extension AllCoreTests {
             
             state.open(url: url)
             try await state.openTask?.value
-            
-            print("debug break point")
             
             #expect(state.type?.id == id)
             #expect(state.entries.count == entries)

--- a/Modules/Tests/CoreTests/MagicNumberTests.swift
+++ b/Modules/Tests/CoreTests/MagicNumberTests.swift
@@ -14,10 +14,12 @@ extension AllCoreTests {
         
         @Test("Test magic numbers", arguments: [
             ("7z", "7zip"),
+            ("ace", "ace"),
             ("arj", "arj"),
             ("ar", "ar"),
             ("cab", "cab"),
             ("cpio", "cpio"),
+            ("gtar", "tar"),
             ("lzh", "lha"),
             ("rar", "rar"),
             ("tar", "tar"),

--- a/Modules/Tests/CoreTests/SplitArchiveTests.swift
+++ b/Modules/Tests/CoreTests/SplitArchiveTests.swift
@@ -65,6 +65,15 @@ extension AllCoreTests {
             }
         }
 
+        @Test func detectLegacyRarParts() {
+            let detector = ArchiveTypeDetector(catalog: ArchiveTypeCatalog())
+            for part in ["archive.r00", "archive.r01", "archive.r99"] {
+                let result = detector.detect(for: URL(fileURLWithPath: "/x/\(part)"))
+                #expect(result?.type.id == "rar", "\(part)")
+                #expect(result?.split?.scheme == "legacy", "\(part)")
+            }
+        }
+
         @Test func detectorReportsBareSpannedZip() {
             let detector = ArchiveTypeDetector(catalog: ArchiveTypeCatalog())
             let dir = zipDir()
@@ -127,6 +136,15 @@ extension AllCoreTests {
                 let entry = SplitVolumeResolver.firstVolume(
                     for: dir.appendingPathComponent(part), split: split)
                 #expect(entry.lastPathComponent == "split_7zz.zip.001", "\(part)")
+            }
+        }
+
+        @Test func legacyRarResolvesToFirstVolume() throws {
+            let split = try #require(ArchiveTypeCatalog().allSplits().first { $0.id == "rar-legacy" })
+            for part in ["archive.r00", "archive.r01", "archive.r99"] {
+                let entry = SplitVolumeResolver.firstVolume(
+                    for: URL(fileURLWithPath: "/x/\(part)"), split: split)
+                #expect(entry.lastPathComponent == "archive.rar", "\(part)")
             }
         }
 

--- a/Modules/Tests/CoreTests/UtilityTests.swift
+++ b/Modules/Tests/CoreTests/UtilityTests.swift
@@ -531,6 +531,28 @@ extension AllCoreTests {
             #expect(result?.type.id == "zip")
             #expect(result?.source == .magic)
         }
+
+        @Test func lzmaNearMissWithoutExtensionIsNotDetectedAsLzma() throws {
+            let catalog = ArchiveTypeCatalog()
+            let detector = ArchiveTypeDetector(catalog: catalog)
+
+            // 5D 00 00 prefix should not classify an unknown-extension file as lzma
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("nearmiss_\(UUID().uuidString).bin")
+            let nearMissBytes = Data([0x5D, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00])
+            try nearMissBytes.write(to: tempURL)
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            let magicResult = detector.detectByMagicNumber(for: tempURL)
+            #expect(magicResult == nil)
+
+            let detectResult = detector.detect(for: tempURL)
+            #expect(detectResult == nil)
+
+            // lzma extension itself must still be detected
+            let lzmaExtResult = detector.detectBy(ext: "lzma")
+            #expect(lzmaExtResult?.type.id == "lzma")
+        }
     }
 
     // MARK: - 10. ArchiveEngineConfigStore


### PR DESCRIPTION
## What & why

Adds support for archive formats, compound archives, container extensions, and split schemes that are supported out of the box by MacPacker's existing in-process engines (7-Zip via `CSevenZip` and XADMaster via `XADMasterSwift`), requiring zero external CLI dependencies:

- **New Formats**:
  - `zstd` (`.zst`, `.zstd`): decompression via 7-Zip engine with magic `28 B5 2F FD`.
  - `lzma` (`.lzma`): decompression via 7-Zip engine with magic `5D 00 00`.
  - `ace` (`.ace`): decompression via XADMaster engine with magic `**ACE**` at offset 7.
  - `pax` (`.pax`): decompression via XADMaster engine.
  - `cpt` (`.cpt`, Compact Pro): decompression via XADMaster engine with magic `01 12`.
- **Compound Archives**:
  - `tar.zst` (`.tzst`, `.tar.zst`) -> `["tar", "zstd"]`.
  - `tar.lzma` (`.tlzma`, `.tar.lzma`) -> `["tar", "lzma"]`.
- **Format Extensions & UTIs**:
  - `tar`: added `.gtar`, `.spk` (Synology Package) and UTI `com.synology.spk-archive`.
  - `xar`: added `.safariextz` (Safari Extension).
  - `zip`: added `.ipa`, `.war`, `.xpi`, `.appx`, `.appxbundle`, `.xapk`, `.epub`, `.kepub`, `.deltaskin`, `.wacz` and associated UTIs.
- **Split Archives**:
  - `rar-legacy`: added support for legacy multi-volume naming (`.r00`–`.r99`) resolving to the first volume `.rar`.
- **7-Zip Bridge Fixes (`sevenzip_bridge.cpp`)**:
  - `tryOpenStream` now prioritizes archive handlers matching the file extension hint, deprioritizing backward-scanning handlers like `zip` (which otherwise falsely claimed `.tar.zst` and `.dmg` files).
  - In `CExtractCallback::SetOperationResult` and `finishExtract`, treated `NOperationResult::kDataAfterEnd` as non-fatal instead of treating trailing frame padding as fatal errors and unlinking extracted files.
- **App Metadata & Plists**:
  - Updated `MacPacker/Info.plist` and `MacPacker/Info_Store.plist` with document types and UTIs.

## How it was verified

- Automated unit tests in `Modules/Tests/CoreTests`:
  - `DefaultArchiveTests`: added test cases verifying decompression and hierarchy of `tar.zst`, `tar.lzma`, `gtar`, `tzst`, and `tlzma`.
  - `MagicNumberTests`: added magic number signature checks for `ace` and `gtar`.
  - `ArchiveNamingTests`: added folder naming tests for legacy RAR volumes (`.r00`–`.r99`) and updated split scheme assertions.
  - `SplitArchiveTests`: added legacy RAR volume detection and first-volume resolution tests.

Ran the full test suite via `swift test --package-path Modules`:
✔ Suite DefaultArchiveTests passed after 3.864 seconds.
✔ Suite MagicNumberTests passed after 0.009 seconds.
✔ Suite ArchiveNamingTests passed after 0.002 seconds.
✔ Suite SplitArchiveTests passed after 0.008 seconds.
✔ Suite AllCoreTests passed after 15.372 seconds.
✔ Test run with 418 tests in 119 suites passed after 15.374 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional archive formats, including ACE, LZMA, Zstandard, PAX, Compact Pro, EPUB, AppX, browser extensions, and comic-book archives.
  * Added support for TAR variants such as GNU TAR and Synology SPK, plus TAR archives compressed with LZMA or Zstandard.
  * Added recognition for legacy multi-volume RAR archives and improved grouping of their volumes.
  * Added Finder associations for the newly supported file types.

* **Bug Fixes**
  * Improved archive detection and extraction for files with format-specific extensions.
  * Correctly handles valid data appearing after the end of an archive stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->