### PR TITLE
fix: hand a locked archive to MacPacker from the preview (#218)

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -85,24 +85,25 @@
           {
             "type": "feat",
             "title": {
-                "en": "Quick Look asks for the archive password",
-                "zh-Hans": "Quick Look 会询问压缩包密码",
-                "fr": "Quick Look demande le mot de passe de l’archive",
-                "de": "Quick Look fragt nach dem Archivpasswort",
-                "it": "Quick Look chiede la password dell’archivio",
-                "ja": "Quick Look がアーカイブのパスワードを尋ねるように",
-                "fa": "Quick Look رمز آرشیو را می‌پرسد",
-                "pl": "Quick Look pyta o hasło archiwum",
-                "pt-BR": "Quick Look pede a senha do arquivo",
-                "ru": "Quick Look запрашивает пароль архива",
-                "uk": "Quick Look запитує пароль архіву",
-                "es-MX": "Quick Look pide la contraseña del archivo",
-                "ko": "Quick Look이 압축 파일 암호를 요청합니다",
-                "nl": "Quick Look vraagt om het wachtwoord van het archief",
-                "tr": "Quick Look arşiv parolasını sorar"
+                "en": "Quick Look opens locked archives in MacPacker",
+                "zh-Hans": "Quick Look 在 MacPacker 中打开加密压缩包",
+                "fr": "Quick Look ouvre les archives protégées dans MacPacker",
+                "de": "Quick Look öffnet geschützte Archive in MacPacker",
+                "it": "Quick Look apre gli archivi protetti in MacPacker",
+                "ja": "Quick Look がパスワード付きアーカイブを MacPacker で開く",
+                "fa": "Quick Look آرشیوهای قفل‌شده را در MacPacker باز می‌کند",
+                "pl": "Quick Look otwiera zabezpieczone archiwa w MacPacker",
+                "pt-BR": "O Quick Look abre arquivos protegidos no MacPacker",
+                "ru": "Quick Look открывает защищённые архивы в MacPacker",
+                "uk": "Quick Look відкриває захищені архіви в MacPacker",
+                "es-MX": "Quick Look abre archivos protegidos en MacPacker",
+                "ko": "Quick Look이 암호로 보호된 압축 파일을 MacPacker에서 엽니다",
+                "nl": "Quick Look opent beveiligde archieven in MacPacker",
+                "tr": "Quick Look korumalı arşivleri MacPacker’da açar"
             },
             "issues": [
-                "149"
+                "149",
+                "218"
             ]
           }
         ]

--- a/MacPackerUITests/MacPackerUITests.swift
+++ b/MacPackerUITests/MacPackerUITests.swift
@@ -488,13 +488,14 @@ final class MacPackerUITests: XCTestCase {
     }
 
     /// Reading a nested archive means unpacking it first, so an encrypted outer
-    /// archive asks for its password — inline, since an extension has no window
-    /// of its own to put a sheet on. Entering it continues the same open.
+    /// archive needs its password — which the preview cannot take. Finder's Quick
+    /// Look panel keeps key focus, so a text field there never sees a keystroke;
+    /// the preview says so and offers to hand the archive to MacPacker instead.
     ///
     /// The zip *listing* needs no password (only 7z `-mhe`/rar `-hp` headers do,
-    /// and neither tool is guaranteed on a CI runner), which is exactly why the
-    /// prompt is triggered here by opening the nested archive.
-    func testQuickLookPreviewAsksForThePasswordOfAnEncryptedArchive() throws {
+    /// and neither tool is guaranteed on a CI runner), which is why the notice is
+    /// triggered here by opening the nested archive.
+    func testQuickLookPreviewOffersToOpenALockedArchiveInMacPacker() throws {
         let dir = try makeWorkDir("ql-password")
         defer { try? FileManager.default.removeItem(at: dir) }
         try "inner".write(to: dir.appendingPathComponent("inner.txt"), atomically: true, encoding: .utf8)
@@ -506,15 +507,13 @@ final class MacPackerUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["inner.zip"].waitForExistence(timeout: 15), "preview did not load")
 
         expandRow(app, "inner.zip")
-        let field = app.secureTextFields.firstMatch
-        XCTAssertTrue(field.waitForExistence(timeout: 20), "no password prompt for the encrypted archive")
 
-        field.click()
-        app.typeText("password")
-        app.buttons["Unlock"].firstMatch.click()
-
-        XCTAssertTrue(app.staticTexts["inner.txt"].waitForExistence(timeout: 20),
-                      "the nested archive did not open after the password was entered")
+        XCTAssertTrue(app.staticTexts["This archive is password protected."].waitForExistence(timeout: 20),
+                      "no locked-archive notice for the encrypted archive")
+        XCTAssertTrue(app.buttons["Open in MacPacker"].firstMatch.exists,
+                      "the notice does not offer the hand-off to MacPacker")
+        XCTAssertEqual(app.secureTextFields.count, 0,
+                       "a password field cannot be typed into inside the Quick Look panel")
         app.terminate()
     }
 }

--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
@@ -245,12 +245,23 @@ public final class ArchivePreviewViewController: NSViewController {
             return
         }
 
+        // Encoded here and again by URLComponents, because the app decodes twice:
+        // once out of the query item, once with removingPercentEncoding. A path
+        // holding a literal % would otherwise arrive as nonsense — or as nil,
+        // which reads as "no files" and opens nothing. Same as FinderSync does.
+        guard let files = url.path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let target = url.deletingLastPathComponent().path
+                  .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            PreviewLog.general.error("Could not encode the archive path for the hand-off")
+            return
+        }
+
         var components = URLComponents()
         components.scheme = scheme
         components.host = "open"
         components.queryItems = [
-            URLQueryItem(name: "files", value: url.path),
-            URLQueryItem(name: "target", value: url.deletingLastPathComponent().path)
+            URLQueryItem(name: "files", value: files),
+            URLQueryItem(name: "target", value: target)
         ]
         guard let appURL = components.url else { return }
 

--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
@@ -23,18 +23,19 @@ public final class ArchivePreviewViewController: NSViewController {
     private var scopedURL: URL?
 
     /// Resumed once the host has something worth showing: the loaded archive, a
-    /// failure message, or the password prompt. QuickLook only puts the view on
-    /// screen after `preparePreviewOfFile` returns, so waiting for the whole load
-    /// would leave the user staring at nothing while we wait for their password.
+    /// failure message, or the locked-archive notice. QuickLook only puts the
+    /// view on screen after `preparePreviewOfFile` returns.
     private var readyContinuation: CheckedContinuation<Void, Never>?
-    private var passwordContinuation: CheckedContinuation<String?, Never>?
     /// Bumped by every load. The harness loads a second archive into the same
     /// controller, so a load can be superseded while it is still running: its
     /// callbacks must not touch the UI the newer load owns, and must not resume
     /// the newer load's continuations.
     private var loadGeneration = 0
-    /// What to go back to once a password has been entered.
-    private var showedContentBeforePrompt = false
+    /// The archive being previewed, for handing it over to MacPacker.
+    private var previewedURL: URL?
+    /// Set once the locked-archive notice is up, so the finished load does not
+    /// replace it with the engine's "could not read this" message.
+    private var showsLockedNotice = false
 
     private lazy var messageLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")
@@ -47,7 +48,7 @@ public final class ArchivePreviewViewController: NSViewController {
         return label
     }()
 
-    private lazy var passwordLabel: NSTextField = {
+    private lazy var lockedLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")
         label.alignment = .center
         label.maximumNumberOfLines = 0
@@ -55,24 +56,16 @@ public final class ArchivePreviewViewController: NSViewController {
         return label
     }()
 
-    private lazy var passwordField: NSSecureTextField = {
-        let field = NSSecureTextField()
-        field.target = self
-        field.action = #selector(submitPassword)
-        field.translatesAutoresizingMaskIntoConstraints = false
-        return field
-    }()
-
-    /// Inline rather than a sheet: an appex has no window of its own to attach a
-    /// sheet to, and the QuickLook panel is not ours to put one on.
-    private lazy var passwordPrompt: NSStackView = {
-        let unlock = NSButton(
-            title: String(localized: "Unlock", bundle: .module, comment: "Button that submits the password for an encrypted archive in the Quick Look preview"),
+    /// A locked archive is handed to MacPacker rather than unlocked here: the
+    /// Quick Look panel keeps key focus, so a password field in this view never
+    /// receives a keystroke. Clicks do arrive, so a button works.
+    private lazy var lockedNotice: NSStackView = {
+        let open = NSButton(
+            title: String(localized: "Open in MacPacker", bundle: .module, comment: "Button in the Quick Look preview that opens a password protected archive in the MacPacker app"),
             target: self,
-            action: #selector(submitPassword))
-        unlock.keyEquivalent = "\r"
+            action: #selector(openInMacPacker))
 
-        let stack = NSStackView(views: [passwordLabel, passwordField, unlock])
+        let stack = NSStackView(views: [lockedLabel, open])
         stack.orientation = .vertical
         stack.alignment = .centerX
         stack.spacing = 8
@@ -102,7 +95,7 @@ public final class ArchivePreviewViewController: NSViewController {
         content.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(content)
         container.addSubview(messageLabel)
-        container.addSubview(passwordPrompt)
+        container.addSubview(lockedNotice)
 
         NSLayoutConstraint.activate([
             content.topAnchor.constraint(equalTo: container.topAnchor),
@@ -115,11 +108,10 @@ public final class ArchivePreviewViewController: NSViewController {
             messageLabel.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 16),
             messageLabel.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
 
-            passwordPrompt.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            passwordPrompt.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            passwordPrompt.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 16),
-            passwordPrompt.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
-            passwordField.widthAnchor.constraint(equalToConstant: 220)
+            lockedNotice.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            lockedNotice.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            lockedNotice.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 16),
+            lockedNotice.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16)
         ])
 
         view = container
@@ -145,10 +137,10 @@ public final class ArchivePreviewViewController: NSViewController {
 
         // Let go of whatever the previous load was waiting on before replacing
         // it: an unresumed continuation hangs its caller forever.
-        passwordContinuation?.resume(returning: nil)
-        passwordContinuation = nil
         readyContinuation?.resume()
         readyContinuation = nil
+        hideLockedNotice()
+        previewedURL = url
 
         loadGeneration += 1
         let generation = loadGeneration
@@ -174,7 +166,12 @@ public final class ArchivePreviewViewController: NSViewController {
     /// taken over in the meantime.
     private func finishLoad(generation: Int) {
         guard generation == loadGeneration, let state else { return }
-        hidePasswordPrompt()
+        // A locked archive ends as a failed load; its notice says more than the
+        // engine's error would, so leave it standing.
+        guard !showsLockedNotice else {
+            signalReady()
+            return
+        }
 
         let entryCount = state.entries.count
         let rootChildren = state.root?.children?.count ?? -1
@@ -200,64 +197,67 @@ public final class ArchivePreviewViewController: NSViewController {
         signalReady()
     }
 
-    // MARK: - Password
+    // MARK: - Locked archives
 
-    /// Asks the user for the archive's password, inline in the preview.
+    /// Reports that the archive needs a password, and offers to open it in
+    /// MacPacker — this preview cannot take one.
     ///
-    /// A superseded load gets no prompt and no password: answering nil ends it
-    /// as cancelled instead of leaving its engine waiting on a prompt that the
-    /// newer load's UI has replaced.
+    /// Finder's Quick Look panel keeps key focus, so a text field here never
+    /// receives a keystroke; clicks do arrive, which is why a button works. The
+    /// engine is answered `nil` right away rather than left waiting for an entry
+    /// that can never come.
     private func requestPassword(_ request: ArchivePasswordRequest, generation: Int) async -> String? {
         guard generation == loadGeneration else { return nil }
-        PreviewLog.general.info("Password requested", context: [
+        PreviewLog.general.info("Archive is locked, offering the hand-off", context: [
             "file": request.url.lastPathComponent,
             "attempt": "\(request.attempt)"
         ])
-        showPasswordPrompt(retry: request.attempt > 1)
-        // The prompt is only usable once the host shows the view, and it only
+        showLockedNotice()
+        // The notice is only on screen once the host shows the view, and it only
         // does that after `preparePreviewOfFile` returns.
         signalReady()
-
-        return await withCheckedContinuation { continuation in
-            // two prompts at once would strand the first one forever
-            passwordContinuation?.resume(returning: nil)
-            passwordContinuation = continuation
-        }
+        return nil
     }
 
-    private func showPasswordPrompt(retry: Bool) {
-        // A password is asked for twice: for the archive itself (nothing on
-        // screen yet) and for a nested one (the tree is showing, and goes back
-        // up once the password is in).
-        showedContentBeforePrompt = !contentViewController.view.isHidden
-        passwordLabel.stringValue = retry
-            ? String(localized: "Wrong password. Try again.", bundle: .module, comment: "Shown in the Quick Look preview when the entered archive password did not work")
-            : String(localized: "This archive is password protected.", bundle: .module, comment: "Shown in the Quick Look preview when an archive needs a password to be read")
-        passwordField.stringValue = ""
-        passwordPrompt.isHidden = false
+    private func showLockedNotice() {
+        lockedLabel.stringValue = String(
+            localized: "This archive is password protected.",
+            bundle: .module,
+            comment: "Shown in the Quick Look preview when an archive needs a password to be read")
+        showsLockedNotice = true
+        lockedNotice.isHidden = false
         messageLabel.isHidden = true
         contentViewController.view.isHidden = true
-        view.window?.makeFirstResponder(passwordField)
     }
 
-    private func hidePasswordPrompt() {
-        passwordPrompt.isHidden = true
-        passwordField.stringValue = ""
+    private func hideLockedNotice() {
+        showsLockedNotice = false
+        lockedNotice.isHidden = true
     }
 
-    /// An empty password is a "no thanks" — the engine reports the archive as
-    /// locked instead of retrying forever.
-    @objc private func submitPassword() {
-        guard let continuation = passwordContinuation else { return }
-        passwordContinuation = nil
-        let password = passwordField.stringValue
-        hidePasswordPrompt()
-        if showedContentBeforePrompt {
-            hideMessage()   // back to the tree; the nested row keeps spinning
-        } else {
-            showMessage(String(localized: "Opening…", bundle: .module, comment: "Shown in the Quick Look preview while the archive is being read"))
+    /// Hands the archive to MacPacker through the app's url scheme, the same way
+    /// the Finder extension does, so the password can be entered there.
+    @objc private func openInMacPacker() {
+        guard let url = previewedURL,
+              let scheme = Bundle.main.object(forInfoDictionaryKey: "MacPackerURLScheme") as? String,
+              !scheme.isEmpty else {
+            PreviewLog.general.error("Cannot hand over: no url scheme in the extension's Info.plist")
+            return
         }
-        continuation.resume(returning: password.isEmpty ? nil : password)
+
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = "open"
+        components.queryItems = [
+            URLQueryItem(name: "files", value: url.path),
+            URLQueryItem(name: "target", value: url.deletingLastPathComponent().path)
+        ]
+        guard let appURL = components.url else { return }
+
+        PreviewLog.general.info("Handing the archive to MacPacker", context: ["file": url.lastPathComponent])
+        if !NSWorkspace.shared.open(appURL) {
+            PreviewLog.general.error("MacPacker did not open", context: ["scheme": scheme])
+        }
     }
 
     // MARK: - Helpers

--- a/Modules/Sources/ArchivePreviewUI/Localizable.xcstrings
+++ b/Modules/Sources/ArchivePreviewUI/Localizable.xcstrings
@@ -117,8 +117,8 @@
         }
       }
     },
-    "Opening…" : {
-      "comment" : "Shown in the Quick Look preview while the archive is being read"
+    "Open in MacPacker" : {
+      "comment" : "Button in the Quick Look preview that opens a password protected archive in the MacPacker app"
     },
     "Packed Size" : {
       "comment" : "Column that shows the packed size of the archive files",
@@ -180,12 +180,6 @@
     },
     "This archive is password protected." : {
       "comment" : "Shown in the Quick Look preview when an archive needs a password to be read"
-    },
-    "Unlock" : {
-      "comment" : "Button that submits the password for an encrypted archive in the Quick Look preview"
-    },
-    "Wrong password. Try again." : {
-      "comment" : "Shown in the Quick Look preview when the entered archive password did not work"
     }
   },
   "version" : "1.1"

--- a/QuickLookExtension/Info.plist
+++ b/QuickLookExtension/Info.plist
@@ -8,6 +8,8 @@
     <string>0.0</string>
     <key>MPAppGroupIdentifier</key>
     <string>$(APP_GROUP_ID)</string>
+    <key>MacPackerURLScheme</key>
+    <string>$(APP_URL_SCHEME)</string>
     <key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
The inline password field that shipped in v1.0.0-beta.1 cannot be filled in. Finder's Quick Look panel keeps key focus, so keystrokes land in its type-select and never reach the extension — the view is a remote view the panel never makes first responder, which also makes the `makeFirstResponder` call a no-op. No text field can work in that host, however it is built.

Mouse events *do* arrive (the Extract buttons and their open panel work), so the preview now states the archive is locked and offers **Open in MacPacker**, handing the file over through the app's url scheme exactly as the Finder extension does. The password is entered in the app, where typing works.

Also:

- the engine is answered `nil` immediately instead of waiting for an entry that can never come
- the finished load no longer paints its "couldn't read this archive" message over the notice
- `Unlock`, `Wrong password. Try again.` and `Opening…` are gone from the catalog; `Open in MacPacker` replaces them
- the appex Info.plist gains `MacPackerURLScheme`, like the Finder extension's

## Verification

- `testQuickLookPreviewOffersToOpenALockedArchiveInMacPacker` replaces the old typing test: opening a nested archive inside an encrypted zip shows the notice and the button, and asserts no secure text field exists
- `testQuickLookPreviewOpensNestedArchive` still passes
- 419 unit tests pass

Not yet verified in the real Quick Look panel — `qlmanage` routes to the installed build, so the hand-off click needs a beta on a machine where this build is the registered extension.

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quick Look previews for locked archives now display a password-protection notice with an **Open in MacPacker** button.
  - Selecting the button opens the archive directly in MacPacker for unlocking.
  - Locked archive previews no longer request passwords directly in Quick Look.

- **Documentation**
  - Updated the version 1.0.0 changelog to reflect the revised locked-archive preview behavior and related issue references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->