### PR TITLE
fix: ask the host to launch MacPacker from the preview (#220)

### DIFF
--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
@@ -60,7 +60,7 @@ public final class ArchivePreviewViewController: NSViewController {
     /// Quick Look panel keeps key focus, so a password field in this view never
     /// receives a keystroke. Clicks do arrive, so a button works.
     private lazy var lockedNotice: NSStackView = {
-        let open = NSButton(
+        let open = PreviewButton(
             title: String(localized: "Open in MacPacker", bundle: .module, comment: "Button in the Quick Look preview that opens a password protected archive in the MacPacker app"),
             target: self,
             action: #selector(openInMacPacker))
@@ -266,8 +266,15 @@ public final class ArchivePreviewViewController: NSViewController {
         guard let appURL = components.url else { return }
 
         PreviewLog.general.info("Handing the archive to MacPacker", context: ["file": url.lastPathComponent])
-        if !NSWorkspace.shared.open(appURL) {
-            PreviewLog.general.error("MacPacker did not open", context: ["scheme": scheme])
+        if NSWorkspace.shared.open(appURL) { return }
+
+        // Some hosts refuse an extension's NSWorkspace launch; the extension
+        // context asks the host to open it on our behalf.
+        PreviewLog.general.notice("NSWorkspace refused the hand-off, asking the host")
+        extensionContext?.open(appURL) { opened in
+            if !opened {
+                PreviewLog.general.error("MacPacker did not open", context: ["scheme": scheme])
+            }
         }
     }
 

--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
@@ -281,12 +281,18 @@ public final class ArchivePreviewViewController: NSViewController {
         PreviewLog.general.info("Handing the archive to MacPacker", context: ["file": url.lastPathComponent])
         if NSWorkspace.shared.open(appURL) { return }
 
-        // Some hosts refuse an extension's NSWorkspace launch; the extension
-        // context asks the host to open it on our behalf.
-        // The extension's sandbox denies LaunchServices (`deny(1) lsopen`), so
-        // this is the expected path: ask the host to open it for us.
+        // Expected path in the extension: its sandbox denies LaunchServices
+        // (`deny(1) lsopen`), so the host is asked to open the url instead.
+        // There is no host in the in-app harness, where NSWorkspace works.
+        guard let extensionContext else {
+            PreviewLog.general.error("MacPacker did not open and there is no host to ask",
+                                     context: ["scheme": scheme])
+            showHandOffUnavailable()
+            return
+        }
+
         PreviewLog.general.notice("NSWorkspace refused the hand-off, asking the host")
-        extensionContext?.open(appURL) { [weak self] opened in
+        extensionContext.open(appURL) { [weak self] opened in
             guard !opened else { return }
             PreviewLog.general.error("MacPacker did not open", context: ["scheme": scheme])
             Task { @MainActor in self?.showHandOffUnavailable() }

--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
@@ -59,13 +59,15 @@ public final class ArchivePreviewViewController: NSViewController {
     /// A locked archive is handed to MacPacker rather than unlocked here: the
     /// Quick Look panel keeps key focus, so a password field in this view never
     /// receives a keystroke. Clicks do arrive, so a button works.
-    private lazy var lockedNotice: NSStackView = {
-        let open = PreviewButton(
+    private lazy var openInAppButton: PreviewButton = {
+        PreviewButton(
             title: String(localized: "Open in MacPacker", bundle: .module, comment: "Button in the Quick Look preview that opens a password protected archive in the MacPacker app"),
             target: self,
             action: #selector(openInMacPacker))
+    }()
 
-        let stack = NSStackView(views: [lockedLabel, open])
+    private lazy var lockedNotice: NSStackView = {
+        let stack = NSStackView(views: [lockedLabel, openInAppButton])
         stack.orientation = .vertical
         stack.alignment = .centerX
         stack.spacing = 8
@@ -225,9 +227,20 @@ public final class ArchivePreviewViewController: NSViewController {
             bundle: .module,
             comment: "Shown in the Quick Look preview when an archive needs a password to be read")
         showsLockedNotice = true
+        openInAppButton.isHidden = false
         lockedNotice.isHidden = false
         messageLabel.isHidden = true
         contentViewController.view.isHidden = true
+    }
+
+    /// Neither route could start the app, so stop offering a button that does
+    /// nothing and say what to do instead.
+    private func showHandOffUnavailable() {
+        openInAppButton.isHidden = true
+        lockedLabel.stringValue = String(
+            localized: "Open this archive in MacPacker to enter the password.",
+            bundle: .module,
+            comment: "Shown in the Quick Look preview when a password protected archive cannot be handed to the app")
     }
 
     private func hideLockedNotice() {
@@ -270,11 +283,13 @@ public final class ArchivePreviewViewController: NSViewController {
 
         // Some hosts refuse an extension's NSWorkspace launch; the extension
         // context asks the host to open it on our behalf.
+        // The extension's sandbox denies LaunchServices (`deny(1) lsopen`), so
+        // this is the expected path: ask the host to open it for us.
         PreviewLog.general.notice("NSWorkspace refused the hand-off, asking the host")
-        extensionContext?.open(appURL) { opened in
-            if !opened {
-                PreviewLog.general.error("MacPacker did not open", context: ["scheme": scheme])
-            }
+        extensionContext?.open(appURL) { [weak self] opened in
+            guard !opened else { return }
+            PreviewLog.general.error("MacPacker did not open", context: ["scheme": scheme])
+            Task { @MainActor in self?.showHandOffUnavailable() }
         }
     }
 

--- a/Modules/Sources/ArchivePreviewUI/ButtonBarViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ButtonBarViewController.swift
@@ -28,7 +28,7 @@ final class ButtonBarViewController: NSViewController {
         stack.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stack)
 
-        let extractSelectedButton = NSButton()
+        let extractSelectedButton = PreviewButton()
         extractSelectedButton.image = NSImage(systemSymbolName: "square.and.arrow.down", accessibilityDescription: nil)!
         extractSelectedButton.title = String(localized: "Extract selected", bundle: .module, comment: "Button in the tooblar that allows the user to extract the selected files.")
         extractSelectedButton.imagePosition = .imageLeading
@@ -38,7 +38,7 @@ final class ButtonBarViewController: NSViewController {
         extractSelectedButton.target = self
         extractSelectedButton.action = #selector(extractSelected)
         
-        let extractAllButton = NSButton()
+        let extractAllButton = PreviewButton()
         extractAllButton.image = NSImage(systemSymbolName: "square.and.arrow.down", accessibilityDescription: nil)!
         extractAllButton.title = String(localized: "Extract archive", bundle: .module, comment: "Button in the toolbar that allows the user to extract the full archive to a target directory.")
         extractAllButton.imagePosition = .imageLeading

--- a/Modules/Sources/ArchivePreviewUI/Localizable.xcstrings
+++ b/Modules/Sources/ArchivePreviewUI/Localizable.xcstrings
@@ -120,6 +120,9 @@
     "Open in MacPacker" : {
       "comment" : "Button in the Quick Look preview that opens a password protected archive in the MacPacker app"
     },
+    "Open this archive in MacPacker to enter the password." : {
+      "comment" : "Shown in the Quick Look preview when a password protected archive cannot be handed to the app"
+    },
     "Packed Size" : {
       "comment" : "Column that shows the packed size of the archive files",
       "localizations" : {

--- a/Modules/Sources/ArchivePreviewUI/PreviewButton.swift
+++ b/Modules/Sources/ArchivePreviewUI/PreviewButton.swift
@@ -1,0 +1,17 @@
+//
+//  PreviewButton.swift
+//  ArchivePreviewUI
+//
+
+import AppKit
+
+/// A button that acts on the first click.
+///
+/// The preview runs in Finder's Quick Look panel, whose window is not key. A
+/// plain `NSButton` swallows the first click to activate the window, so the
+/// button appears dead — and a second click lands on the panel, which reads a
+/// double click as "open this file in its default app" (Archive Utility, for a
+/// zip). Accepting the first mouse keeps the click here.
+final class PreviewButton: NSButton {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}


### PR DESCRIPTION
The **Open in MacPacker** button in v1.0.0-beta.2 does nothing. The click fires — the extension logs `Handing the archive to MacPacker` — but the launch is refused by the kernel:

```
Sandbox: QuickLookExtension(93585) deny(1) lsopen
```

A Quick Look extension may not use LaunchServices at all, unlike the Finder extension, whose profile allows the same hand-off.

- `extensionContext.open(_:)` now runs when `NSWorkspace` is refused, so the launch is performed by the host rather than from our sandbox
- if that is refused too, the button retires itself and the notice reads "Open this archive in MacPacker to enter the password", instead of leaving a button that looks broken
- buttons in the preview accept the first mouse. Evidence says clicks already arrive — both of the tested clicks fired — so this is defensive rather than a proven fix: the panel's window is not key, and `NSButton` swallows a first click by default. Say the word and I drop it

Whether the host implements `extensionContext.open` on macOS is unknown to me; the beta answers it. Either outcome now reads clearly in the log: `NSWorkspace refused the hand-off, asking the host`, then the app opens or `MacPacker did not open` with the reworded notice on screen.

If the host refuses as well, no extension can start the app, and the sequel worth having is MacPacker remembering an archive's password in the app group so the preview never needs the app.

Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Look buttons now respond to the first click, including in Finder’s non-key preview panel.
  * Password-protected archives can fall back to opening in MacPacker when automatic handoff is unavailable.
  * If the archive cannot be opened automatically, the preview displays instructions to open it in MacPacker.

* **Localization**
  * Added preview text explaining how to open password-protected archives in MacPacker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->