### PR TITLE
feat: preview cbz and cbr in Quick Look (#187)

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -39,6 +39,29 @@
           {
             "type": "feat",
             "title": {
+                "en": "Quick Look preview for cbz and cbr",
+                "zh-Hans": "cbz 和 cbr 的 Quick Look 预览",
+                "fr": "Aperçu Quick Look pour cbz et cbr",
+                "de": "Quick Look-Vorschau für cbz und cbr",
+                "it": "Anteprima Quick Look per cbz e cbr",
+                "ja": "cbz と cbr の Quick Look プレビュー",
+                "fa": "پیش‌نمایش Quick Look برای cbz و cbr",
+                "pl": "Podgląd Quick Look dla cbz i cbr",
+                "pt-BR": "Visualização do Quick Look para cbz e cbr",
+                "ru": "Просмотр cbz и cbr в Quick Look",
+                "uk": "Перегляд cbz і cbr у Quick Look",
+                "es-MX": "Vista previa de Quick Look para cbz y cbr",
+                "ko": "cbz 및 cbr의 Quick Look 미리보기",
+                "nl": "Quick Look-voorbeeld voor cbz en cbr",
+                "tr": "cbz ve cbr için Quick Look önizlemesi"
+            },
+            "issues": [
+                "187"
+            ]
+          },
+          {
+            "type": "feat",
+            "title": {
                 "en": "Quick Look follows your engine settings",
                 "zh-Hans": "Quick Look 遵循引擎设置",
                 "fr": "Quick Look suit les réglages de moteur",

--- a/MacPacker/Info.plist
+++ b/MacPacker/Info.plist
@@ -134,6 +134,10 @@
 			<array>
 				<string>cbz</string>
 			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>cx.c3.cbz-archive</string>
+			</array>
 			<key>CFBundleTypeName</key>
 			<string>Comic Book ZIP Archive</string>
 			<key>CFBundleTypeRole</key>
@@ -147,6 +151,10 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>cbr</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>cx.c3.cbr-archive</string>
 			</array>
 			<key>CFBundleTypeName</key>
 			<string>Comic Book RAR Archive</string>
@@ -920,6 +928,48 @@
 	</array>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.zip-archive</string>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Comic Book ZIP Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>cx.c3.cbz-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cbz</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.rarlab.rar-archive</string>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Comic Book RAR Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>cx.c3.cbr-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cbr</string>
+				</array>
+			</dict>
+		</dict>
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>

--- a/MacPacker/Info_Store.plist
+++ b/MacPacker/Info_Store.plist
@@ -134,6 +134,10 @@
             <array>
                 <string>cbz</string>
             </array>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>cx.c3.cbz-archive</string>
+            </array>
             <key>CFBundleTypeName</key>
             <string>Comic Book ZIP Archive</string>
             <key>CFBundleTypeRole</key>
@@ -147,6 +151,10 @@
             <key>CFBundleTypeExtensions</key>
             <array>
                 <string>cbr</string>
+            </array>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>cx.c3.cbr-archive</string>
             </array>
             <key>CFBundleTypeName</key>
             <string>Comic Book RAR Archive</string>
@@ -914,6 +922,48 @@
 	</array>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.zip-archive</string>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Comic Book ZIP Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>cx.c3.cbz-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cbz</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.rarlab.rar-archive</string>
+				<string>public.archive</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Comic Book RAR Archive</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>cx.c3.cbr-archive</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cbr</string>
+				</array>
+			</dict>
+		</dict>
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>

--- a/QuickLookExtension/Info.plist
+++ b/QuickLookExtension/Info.plist
@@ -19,6 +19,8 @@
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>cx.c3.lzx-archive</string>
+                <string>cx.c3.cbr-archive</string>
+                <string>cx.c3.cbz-archive</string>
                 <string>com.apple.self-extracting-archive</string>
                 <string>com.apple.xar-archive</string>
 				<string>com.microsoft.cab</string>


### PR DESCRIPTION
A `.cbz` shows the generic icon in Quick Look instead of its contents.

`#188` added cbz and cbr as file extensions: `CFBundleTypeExtensions` (so the app opens them) and the catalog's zip/rar extension lists (so the engines read them). Neither gives macOS a *type* for the extension, so the file falls back to a dynamic UTI:

```
before   comic.cbz → dyn.ah62d4rv4ge80g2x4   conforms: public.data, public.item
after    comic.cbz → cx.c3.cbz-archive       conforms: public.zip-archive, public.archive, …
         comic.cbr → cx.c3.cbr-archive       conforms: com.rarlab.rar-archive, public.archive, …
```

`QLSupportedContentTypes` lists concrete identifiers, and a dynamic type conforms to none of them — hence no preview. cbz has never appeared in that list in any commit, so this is a gap rather than a regression.

- imported declarations for `cx.c3.cbz-archive` and `cx.c3.cbr-archive` — The Unarchiver's family, already referenced in the extension via `cx.c3.lzx-archive` — in `Info.plist` and `Info_Store.plist`
- `LSItemContentTypes` on the two document types, so the opener and the type agree
- both identifiers added to `QLSupportedContentTypes`

Imported rather than exported: the types are not ours, and other comic apps declare the same ones.

## Verification

Registered the build, then previewed through the real extension with `qlmanage`: `comic.cbz` lists `folder` and `hello world.txt` instead of an icon. Type resolution measured before and after, as above.

Changelog entry included so a beta is cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Quick Look previews for CBZ and CBR comic book archives.
  * Added support for recognizing and opening CBZ and CBR files.
  * Added localized titles for the new archive formats across 15 languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->