### PR TITLE
fix: state that a locked archive belongs in the app (#218)

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -104,30 +104,6 @@
             "issues": [
                 "212"
             ]
-          },
-          {
-            "type": "feat",
-            "title": {
-                "en": "Quick Look opens locked archives in MacPacker",
-                "zh-Hans": "Quick Look 在 MacPacker 中打开加密压缩包",
-                "fr": "Quick Look ouvre les archives protégées dans MacPacker",
-                "de": "Quick Look öffnet geschützte Archive in MacPacker",
-                "it": "Quick Look apre gli archivi protetti in MacPacker",
-                "ja": "Quick Look がパスワード付きアーカイブを MacPacker で開く",
-                "fa": "Quick Look آرشیوهای قفل‌شده را در MacPacker باز می‌کند",
-                "pl": "Quick Look otwiera zabezpieczone archiwa w MacPacker",
-                "pt-BR": "O Quick Look abre arquivos protegidos no MacPacker",
-                "ru": "Quick Look открывает защищённые архивы в MacPacker",
-                "uk": "Quick Look відкриває захищені архіви в MacPacker",
-                "es-MX": "Quick Look abre archivos protegidos en MacPacker",
-                "ko": "Quick Look이 암호로 보호된 압축 파일을 MacPacker에서 엽니다",
-                "nl": "Quick Look opent beveiligde archieven in MacPacker",
-                "tr": "Quick Look korumalı arşivleri MacPacker’da açar"
-            },
-            "issues": [
-                "149",
-                "218"
-            ]
           }
         ]
       },

--- a/MacPackerUITests/MacPackerUITests.swift
+++ b/MacPackerUITests/MacPackerUITests.swift
@@ -488,14 +488,15 @@ final class MacPackerUITests: XCTestCase {
     }
 
     /// Reading a nested archive means unpacking it first, so an encrypted outer
-    /// archive needs its password — which the preview cannot take. Finder's Quick
-    /// Look panel keeps key focus, so a text field there never sees a keystroke;
-    /// the preview says so and offers to hand the archive to MacPacker instead.
+    /// archive needs its password — which the preview can neither take nor pass
+    /// on. Finder's Quick Look panel keeps key focus, so a text field there never
+    /// sees a keystroke, and the extension's sandbox denies it the LaunchServices
+    /// call that would hand the archive to the app. All it can do is say so.
     ///
     /// The zip *listing* needs no password (only 7z `-mhe`/rar `-hp` headers do,
     /// and neither tool is guaranteed on a CI runner), which is why the notice is
     /// triggered here by opening the nested archive.
-    func testQuickLookPreviewOffersToOpenALockedArchiveInMacPacker() throws {
+    func testQuickLookPreviewSaysWhenAnArchiveIsLocked() throws {
         let dir = try makeWorkDir("ql-password")
         defer { try? FileManager.default.removeItem(at: dir) }
         try "inner".write(to: dir.appendingPathComponent("inner.txt"), atomically: true, encoding: .utf8)
@@ -508,12 +509,14 @@ final class MacPackerUITests: XCTestCase {
 
         expandRow(app, "inner.zip")
 
-        XCTAssertTrue(app.staticTexts["This archive is password protected."].waitForExistence(timeout: 20),
+        let notice = app.staticTexts.containing(
+            NSPredicate(format: "value CONTAINS %@", "password protected")).firstMatch
+        XCTAssertTrue(notice.waitForExistence(timeout: 20),
                       "no locked-archive notice for the encrypted archive")
-        XCTAssertTrue(app.buttons["Open in MacPacker"].firstMatch.exists,
-                      "the notice does not offer the hand-off to MacPacker")
         XCTAssertEqual(app.secureTextFields.count, 0,
                        "a password field cannot be typed into inside the Quick Look panel")
+        XCTAssertFalse(app.buttons["Open in MacPacker"].firstMatch.exists,
+                       "the extension cannot launch the app, so it must not offer to")
         app.terminate()
     }
 }

--- a/MacPackerUITests/MacPackerUITests.swift
+++ b/MacPackerUITests/MacPackerUITests.swift
@@ -509,7 +509,7 @@ final class MacPackerUITests: XCTestCase {
 
         expandRow(app, "inner.zip")
 
-        let notice = app.staticTexts.containing(
+        let notice = app.staticTexts.matching(
             NSPredicate(format: "value CONTAINS %@", "password protected")).firstMatch
         XCTAssertTrue(notice.waitForExistence(timeout: 20),
                       "no locked-archive notice for the encrypted archive")

--- a/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
+++ b/Modules/Sources/ArchivePreviewUI/ArchivePreviewViewController.swift
@@ -31,8 +31,6 @@ public final class ArchivePreviewViewController: NSViewController {
     /// callbacks must not touch the UI the newer load owns, and must not resume
     /// the newer load's continuations.
     private var loadGeneration = 0
-    /// The archive being previewed, for handing it over to MacPacker.
-    private var previewedURL: URL?
     /// Set once the locked-archive notice is up, so the finished load does not
     /// replace it with the engine's "could not read this" message.
     private var showsLockedNotice = false
@@ -59,15 +57,8 @@ public final class ArchivePreviewViewController: NSViewController {
     /// A locked archive is handed to MacPacker rather than unlocked here: the
     /// Quick Look panel keeps key focus, so a password field in this view never
     /// receives a keystroke. Clicks do arrive, so a button works.
-    private lazy var openInAppButton: PreviewButton = {
-        PreviewButton(
-            title: String(localized: "Open in MacPacker", bundle: .module, comment: "Button in the Quick Look preview that opens a password protected archive in the MacPacker app"),
-            target: self,
-            action: #selector(openInMacPacker))
-    }()
-
     private lazy var lockedNotice: NSStackView = {
-        let stack = NSStackView(views: [lockedLabel, openInAppButton])
+        let stack = NSStackView(views: [lockedLabel])
         stack.orientation = .vertical
         stack.alignment = .centerX
         stack.spacing = 8
@@ -142,7 +133,6 @@ public final class ArchivePreviewViewController: NSViewController {
         readyContinuation?.resume()
         readyContinuation = nil
         hideLockedNotice()
-        previewedURL = url
 
         loadGeneration += 1
         let generation = loadGeneration
@@ -226,77 +216,20 @@ public final class ArchivePreviewViewController: NSViewController {
             localized: "This archive is password protected.",
             bundle: .module,
             comment: "Shown in the Quick Look preview when an archive needs a password to be read")
+            + "\n"
+            + String(
+                localized: "Open this archive in MacPacker to enter the password.",
+                bundle: .module,
+                comment: "Shown in the Quick Look preview below the notice that an archive is password protected")
         showsLockedNotice = true
-        openInAppButton.isHidden = false
         lockedNotice.isHidden = false
         messageLabel.isHidden = true
         contentViewController.view.isHidden = true
     }
 
-    /// Neither route could start the app, so stop offering a button that does
-    /// nothing and say what to do instead.
-    private func showHandOffUnavailable() {
-        openInAppButton.isHidden = true
-        lockedLabel.stringValue = String(
-            localized: "Open this archive in MacPacker to enter the password.",
-            bundle: .module,
-            comment: "Shown in the Quick Look preview when a password protected archive cannot be handed to the app")
-    }
-
     private func hideLockedNotice() {
         showsLockedNotice = false
         lockedNotice.isHidden = true
-    }
-
-    /// Hands the archive to MacPacker through the app's url scheme, the same way
-    /// the Finder extension does, so the password can be entered there.
-    @objc private func openInMacPacker() {
-        guard let url = previewedURL,
-              let scheme = Bundle.main.object(forInfoDictionaryKey: "MacPackerURLScheme") as? String,
-              !scheme.isEmpty else {
-            PreviewLog.general.error("Cannot hand over: no url scheme in the extension's Info.plist")
-            return
-        }
-
-        // Encoded here and again by URLComponents, because the app decodes twice:
-        // once out of the query item, once with removingPercentEncoding. A path
-        // holding a literal % would otherwise arrive as nonsense — or as nil,
-        // which reads as "no files" and opens nothing. Same as FinderSync does.
-        guard let files = url.path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let target = url.deletingLastPathComponent().path
-                  .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-            PreviewLog.general.error("Could not encode the archive path for the hand-off")
-            return
-        }
-
-        var components = URLComponents()
-        components.scheme = scheme
-        components.host = "open"
-        components.queryItems = [
-            URLQueryItem(name: "files", value: files),
-            URLQueryItem(name: "target", value: target)
-        ]
-        guard let appURL = components.url else { return }
-
-        PreviewLog.general.info("Handing the archive to MacPacker", context: ["file": url.lastPathComponent])
-        if NSWorkspace.shared.open(appURL) { return }
-
-        // Expected path in the extension: its sandbox denies LaunchServices
-        // (`deny(1) lsopen`), so the host is asked to open the url instead.
-        // There is no host in the in-app harness, where NSWorkspace works.
-        guard let extensionContext else {
-            PreviewLog.general.error("MacPacker did not open and there is no host to ask",
-                                     context: ["scheme": scheme])
-            showHandOffUnavailable()
-            return
-        }
-
-        PreviewLog.general.notice("NSWorkspace refused the hand-off, asking the host")
-        extensionContext.open(appURL) { [weak self] opened in
-            guard !opened else { return }
-            PreviewLog.general.error("MacPacker did not open", context: ["scheme": scheme])
-            Task { @MainActor in self?.showHandOffUnavailable() }
-        }
     }
 
     // MARK: - Helpers

--- a/Modules/Sources/ArchivePreviewUI/Localizable.xcstrings
+++ b/Modules/Sources/ArchivePreviewUI/Localizable.xcstrings
@@ -117,11 +117,8 @@
         }
       }
     },
-    "Open in MacPacker" : {
-      "comment" : "Button in the Quick Look preview that opens a password protected archive in the MacPacker app"
-    },
     "Open this archive in MacPacker to enter the password." : {
-      "comment" : "Shown in the Quick Look preview when a password protected archive cannot be handed to the app"
+      "comment" : "Shown in the Quick Look preview below the notice that an archive is password protected"
     },
     "Packed Size" : {
       "comment" : "Column that shows the packed size of the archive files",

--- a/QuickLookExtension/Info.plist
+++ b/QuickLookExtension/Info.plist
@@ -8,8 +8,6 @@
     <string>0.0</string>
     <key>MPAppGroupIdentifier</key>
     <string>$(APP_GROUP_ID)</string>
-    <key>MacPackerURLScheme</key>
-    <string>$(APP_URL_SCHEME)</string>
     <key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
The hand-off cannot be made to work from a Quick Look extension, so the button goes.

What was tried, in order:

1. an inline password field — Finder's panel keeps key focus, so it never receives a keystroke
2. `NSWorkspace.open` to hand the archive to MacPacker — the sandbox denies it: `Sandbox: QuickLookExtension deny(1) lsopen`
3. `extensionContext.open` so the host performs the launch — in v1.0.0-beta.3 this produced Finder's *"Apple could not verify 'defaultArchive 2.zip' is free of malware"* warning instead of opening MacPacker, and still needed a double click

So the preview now states the situation and stops there: **"This archive is password protected. Open this archive in MacPacker to enter the password."** No button that fails in a different way each release.

- the notice is label-only; the button, the hand-off and the url building are gone
- the extension's Info.plist no longer declares `MacPackerURLScheme` — it has nothing left to open
- the changelog item about password protected archives is removed, since the preview does not support them
- `testQuickLookPreviewSaysWhenAnArchiveIsLocked` replaces the hand-off test: it asserts the notice, no secure field, and no button

Both Quick Look UI tests pass; the app builds.

Password support in the preview would need a different mechanism — MacPacker remembering an archive's password in the app group, so the preview never has to ask or launch anything. Worth its own issue if you want it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Quick Look previews for password-protected archives now display a clear notice with instructions to open the archive in MacPacker.
  * Removed the “Open in MacPacker” hand-off button from locked-archive previews.
  * Updated Quick Look messaging and localization to reflect the revised locked-archive experience.
  * Locked archives can no longer be handed off directly from the Quick Look extension.
* **Documentation**
  * Updated the MacPacker 1.0.0 changelog to remove the entry describing Quick Look opening locked archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->