### PR TITLE
fix: keep Mac file information through archiving and extraction (#216)

### DIFF
--- a/Config/products/macpacker.json
+++ b/Config/products/macpacker.json
@@ -37,6 +37,30 @@
         "version": "1.0.0",
         "items": [
           {
+            "type": "fix",
+            "title": {
+                "en": "Archiving strips Mac file information",
+                "zh-Hans": "压缩会丢失 Mac 文件信息",
+                "fr": "L’archivage supprime les informations de fichier Mac",
+                "de": "Archivieren entfernt Mac-Dateiinformationen",
+                "it": "L’archiviazione rimuove le informazioni file Mac",
+                "ja": "圧縮すると Mac のファイル情報が失われる",
+                "fa": "بایگانی‌کردن اطلاعات فایل Mac را حذف می‌کند",
+                "pl": "Archiwizacja usuwa informacje o plikach Mac",
+                "pt-BR": "Arquivar remove as informações de arquivo do Mac",
+                "ru": "Архивация удаляет информацию о файлах Mac",
+                "uk": "Архівування видаляє інформацію про файли Mac",
+                "es-MX": "Al archivar se pierde la información de archivo de Mac",
+                "ko": "압축하면 Mac 파일 정보가 사라짐",
+                "nl": "Archiveren verwijdert Mac-bestandsinformatie",
+                "tr": "Arşivleme Mac dosya bilgilerini siliyor"
+            },
+            "issues": [
+                "216",
+                "191"
+            ]
+          },
+          {
             "type": "feat",
             "title": {
                 "en": "Quick Look preview for cbz and cbr",

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -300,6 +300,56 @@ static HRESULT tryOpenStream(
     return S_FALSE;
 }
 
+/// The modification time an archive gives an entry.
+///
+/// kpidMTime is a FILETIME: 100-nanosecond ticks since 1601-01-01 UTC. An entry
+/// that carries no time at all is not the same as one stamped at the epoch, so
+/// `valid` keeps them apart -- a format with no time field must leave the
+/// extracted file with the time it was written, not with 1601.
+struct EntryTime {
+    bool valid = false;
+    struct timespec ts {};
+};
+
+/// Reads kpidMTime off `index`, if the archive carries one.
+static EntryTime readEntryTime(IInArchive *archive, UInt32 index) {
+    EntryTime out;
+    NWindows::NCOM::CPropVariant prop;
+    if (archive->GetProperty(index, kpidMTime, &prop) != S_OK || prop.vt != VT_FILETIME)
+        return out;
+
+    const UInt64 ticks = ((UInt64)prop.filetime.dwHighDateTime << 32)
+                       | (UInt64)prop.filetime.dwLowDateTime;
+
+    // 1601 -> 1970. A zero FILETIME is how several formats spell "no time", and
+    // anything below the epoch would wrap the subtraction.
+    static const UInt64 kEpochTicks = 116444736000000000ULL;
+    if (ticks < kEpochTicks)
+        return out;
+
+    const UInt64 sinceEpoch = ticks - kEpochTicks;
+    out.ts.tv_sec = (time_t)(sinceEpoch / 10000000ULL);
+    out.ts.tv_nsec = (long)((sinceEpoch % 10000000ULL) * 100);
+    out.valid = true;
+    return out;
+}
+
+/// Stamps `path` with the entry's modification time, leaving the access time
+/// alone. NOFOLLOW so a symlink entry gets its own time rather than passing it
+/// on to whatever it points at.
+///
+/// Silent on failure, like the rest of the post-extraction metadata work: a
+/// wrong timestamp is not worth failing an extraction that otherwise succeeded.
+static void applyEntryTime(const char *path, const EntryTime &time) {
+    if (!time.valid)
+        return;
+    struct timespec times[2];
+    times[0].tv_sec = 0;
+    times[0].tv_nsec = UTIME_OMIT;
+    times[1] = time.ts;
+    utimensat(AT_FDCWD, path, times, AT_SYMLINK_NOFOLLOW);
+}
+
 // --- Minimal extract callback ---
 
 class CExtractCallback final :
@@ -362,6 +412,12 @@ public:
     /// folder on a second run. A file already sitting there that happens to match
     /// a sidecar's name is not ours to touch.
     std::set<std::string> extractedPaths;
+    /// Directories this extraction created, with the time the archive gave them.
+    /// Applied once every entry is on disk rather than as each directory is made:
+    /// writing a file into a directory bumps its modification time again, and so
+    /// does removing a sidecar from it, so a time set on creation never survives
+    /// the directory's own contents.
+    std::vector<std::pair<std::string, EntryTime>> directoryTimes;
 
     std::string destDir() const { return std::string(_destDir.Ptr(), (size_t)_destDir.Len()); }
 
@@ -377,6 +433,7 @@ private:
     CMyComPtr<ISequentialOutStream> _outFileStream;
     FString _currentFilePath;
     UInt32 _currentMode = 0;         // POSIX mode from kpidPosixAttrib; 0 if unknown
+    EntryTime _currentTime;          // kpidMTime of the entry being written
     bool _currentIsSymlink = false;  // entry is a Unix symlink (S_IFLNK)
     bool _currentIsEncrypted = false; // entry is encrypted (kpidEncrypted)
     std::string _password;
@@ -395,6 +452,7 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     // fills these in below for an actually-extracted file.
     _currentFilePath.Empty();
     _currentMode = 0;
+    _currentTime = EntryTime();
     _currentIsSymlink = false;
 
     // Remember whether this entry is encrypted: 7z AES carries no password
@@ -451,6 +509,9 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
 
     if (isDir) {
         createDirsRecordingNew(fullPath);
+        directoryTimes.emplace_back(
+            std::string(fullPath.Ptr(), (size_t)fullPath.Len()),
+            readEntryTime(_archive, index));
         return S_OK;
     }
 
@@ -476,6 +537,7 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
     _archive->GetProperty(index, kpidPosixAttrib, &propPosix);
     _currentMode = (propPosix.vt == VT_UI4) ? propPosix.ulVal : 0;
     _currentIsSymlink = S_ISLNK(_currentMode);
+    _currentTime = readEntryTime(_archive, index);
     _currentFilePath = fullPath;
 
     _outFileStream = outStreamRef;
@@ -722,6 +784,7 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
             failedOpResult = opRes;
         _currentIsSymlink = false;
         _currentMode = 0;
+        _currentTime = EntryTime();
         _currentIsEncrypted = false;
         _currentFilePath.Empty();
         return S_OK;
@@ -730,6 +793,7 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
     if (_currentFilePath.IsEmpty()) {
         _currentIsSymlink = false;
         _currentMode = 0;
+        _currentTime = EntryTime();
         return S_OK;
     }
 
@@ -763,6 +827,11 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
             errorMessage = "Failed to set file permissions";
     }
 
+    // Last, because writing the file set the time to now and the symlink branch
+    // above replaced the file outright. Extended attributes go on after this in
+    // finishExtract, but setting those does not touch the modification time.
+    applyEntryTime(path, _currentTime);
+
     // Note a possible AppleDouble sidecar for finishExtract to fold in later. It
     // cannot be resolved here: the file it describes may still be ahead of us in
     // the archive.
@@ -774,6 +843,7 @@ Z7_COM7F_IMF(CExtractCallback::SetOperationResult(Int32 opRes))
 
     _currentIsSymlink = false;
     _currentMode = 0;
+    _currentTime = EntryTime();
     _currentFilePath.Empty();
     return S_OK;
 }
@@ -819,6 +889,12 @@ static int finishExtract(CExtractCallback *callback, HRESULT hr, char **error_ou
     // entry failed: the files that did extract should still come out complete.
     unpackAppleDoubleSidecars(callback->appleDoubleSidecars, callback->extractedPaths,
                               callback->destDir());
+
+    // Directory times go on last of all. Every file written into a directory
+    // bumps its modification time, and so does every sidecar removed from it by
+    // the fold above -- a time applied any earlier would not have survived.
+    for (const auto &directory : callback->directoryTimes)
+        applyEntryTime(directory.first.c_str(), directory.second);
 
     const Int32 opRes = callback->failedOpResult;
     const bool entryFailed = opRes != NArchive::NExtract::NOperationResult::kOK;

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -509,9 +509,16 @@ Z7_COM7F_IMF(CExtractCallback::GetStream(
 
     if (isDir) {
         createDirsRecordingNew(fullPath);
-        directoryTimes.emplace_back(
-            std::string(fullPath.Ptr(), (size_t)fullPath.Len()),
-            readEntryTime(_archive, index));
+
+        // Only a directory this extraction actually created gets the archive's
+        // date. The destination is not always empty -- "Extract here" writes into
+        // a folder of the user's own files -- and createDirsRecordingNew records
+        // exactly the levels that did not exist beforehand, so membership is the
+        // answer to "was this ours to stamp".
+        const std::string created(fullPath.Ptr(), (size_t)fullPath.Len());
+        if (extractedPaths.count(created) != 0)
+            directoryTimes.emplace_back(created, readEntryTime(_archive, index));
+
         return S_OK;
     }
 

--- a/Modules/Sources/CSevenZip/sevenzip_bridge_write.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge_write.cpp
@@ -7,9 +7,12 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <string>
 #include <vector>
+#include <climits>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include "Common/MyWindows.h"
 #include "Common/MyCom.h"
@@ -76,10 +79,39 @@ static UInt32 EffectivePosixMode(const SZUpdateItem &item) {
         return (UInt32)item.posix_permissions;
     if (item.op == SZ_UPDATE_ADD_FILE && item.disk_path) {
         struct stat st;
-        if (stat(item.disk_path, &st) == 0)
+        // lstat, not stat: a symbolic link has to reach the archive as a link.
+        // Following it here would store S_IFREG plus a copy of whatever it points
+        // at -- and inside a framework or an .app, the version symlinks are what
+        // hold the bundle together.
+        if (lstat(item.disk_path, &st) == 0)
             return (UInt32)(st.st_mode & 0xFFFF);
     }
     return 0;
+}
+
+/// The target of `path` when it is a symbolic link; empty for anything else.
+///
+/// 7-Zip stores a symlink as an entry whose *contents* are the target path, with
+/// S_IFLNK set in the POSIX mode -- the same shape the extraction side turns back
+/// into a real link. So a link needs both its size and its stream to come from
+/// here rather than from the file it points at.
+static std::string ReadLinkTarget(const char *path) {
+    if (!path)
+        return std::string();
+
+    struct stat st;
+    if (lstat(path, &st) != 0 || !S_ISLNK(st.st_mode))
+        return std::string();
+
+    // st_size is the target length on every filesystem that bothers to fill it
+    // in, but not all do, so ask for a full path's worth and trust readlink's
+    // return value instead.
+    char buffer[PATH_MAX];
+    const ssize_t length = readlink(path, buffer, sizeof(buffer));
+    if (length <= 0)
+        return std::string();
+
+    return std::string(buffer, (size_t)length);
 }
 
 static FILETIME UnixEpochToFileTime(int64_t unixTime) {
@@ -149,6 +181,10 @@ public:
     void *progressContext = nullptr;
     UInt64 progressTotal = 0;
     bool aborted = false;
+    /// Backing store for the symlink targets handed to 7-Zip as entry contents.
+    /// A deque because CBufInStream keeps a pointer into what it is given, and a
+    /// deque never relocates the elements already in it.
+    std::deque<std::string> linkTargets;
 
     CUpdateCallback(const SZUpdateItem *items_, UInt32 count)
         : items(items_), itemCount(count) {}
@@ -235,8 +271,14 @@ Z7_COM7F_IMF(CUpdateCallback::GetProperty(UInt32 index, PROPID propID, PROPVARIA
             if (item.op == SZ_UPDATE_ADD_DATA) {
                 prop = (UInt64)item.data_size;
             } else if (item.op == SZ_UPDATE_ADD_FILE && !item.is_directory) {
+                // A symlink's content is its target path, so that is its size
+                // too -- lstat's st_size agrees, but readlink is the one that
+                // GetStream will hand over, so measure the same thing twice.
+                const std::string link = ReadLinkTarget(item.disk_path);
                 struct stat st;
-                if (item.disk_path && stat(item.disk_path, &st) == 0)
+                if (!link.empty())
+                    prop = (UInt64)link.size();
+                else if (item.disk_path && stat(item.disk_path, &st) == 0)
                     prop = (UInt64)st.st_size;
                 else
                     prop = (UInt64)0;
@@ -251,7 +293,9 @@ Z7_COM7F_IMF(CUpdateCallback::GetProperty(UInt32 index, PROPID propID, PROPVARIA
                 prop = ft;
             } else if (item.op == SZ_UPDATE_ADD_FILE && item.disk_path) {
                 struct stat st;
-                if (stat(item.disk_path, &st) == 0) {
+                // lstat for the same reason as the mode: a link's own time, not
+                // the time of whatever it points at.
+                if (lstat(item.disk_path, &st) == 0) {
                     FILETIME ft = UnixEpochToFileTime(st.st_mtime);
                     prop = ft;
                 }
@@ -297,6 +341,22 @@ Z7_COM7F_IMF(CUpdateCallback::GetStream(UInt32 index, ISequentialInStream **inSt
             errorMessage = "Missing disk path for ADD_FILE item";
             return E_FAIL;
         }
+
+        // A symbolic link is stored as its target path, not as the bytes of the
+        // file it points at. The string has to outlive this call -- CBufInStream
+        // holds the buffer rather than copying it -- and a deque never moves what
+        // it already holds, so earlier entries stay valid as later ones arrive.
+        const std::string link = ReadLinkTarget(item.disk_path);
+        if (!link.empty()) {
+            linkTargets.push_back(link);
+            const std::string &stored = linkTargets.back();
+            CBufInStream *bufStream = new CBufInStream;
+            CMyComPtr<ISequentialInStream> streamLoc(bufStream);
+            bufStream->Init((const Byte *)stored.data(), stored.size());
+            *inStream = streamLoc.Detach();
+            return S_OK;
+        }
+
         CInFileStream *fileStream = new CInFileStream;
         CMyComPtr<ISequentialInStream> streamLoc(fileStream);
         FString fpath = us2fs(UTF8ToUString(item.disk_path));

--- a/Modules/Sources/CSevenZip/sevenzip_bridge_write.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge_write.cpp
@@ -291,7 +291,11 @@ Z7_COM7F_IMF(CUpdateCallback::GetProperty(UInt32 index, PROPID propID, PROPVARIA
             if (item.mtime >= 0) {
                 FILETIME ft = UnixEpochToFileTime(item.mtime);
                 prop = ft;
-            } else if (item.op == SZ_UPDATE_ADD_FILE && item.disk_path) {
+            } else if ((item.op == SZ_UPDATE_ADD_FILE || item.op == SZ_UPDATE_ADD_DIR)
+                       && item.disk_path) {
+                // Directories as well as files: a folder entry carries no contents
+                // but it does carry a date, and leaving it unset stores the zip
+                // epoch, so every folder in the archive extracts stamped 1980.
                 struct stat st;
                 // lstat for the same reason as the mode: a link's own time, not
                 // the time of whatever it points at.

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -751,9 +751,21 @@ extension ArchiveState {
         // the write is a long synchronous C call — keep it off the
         // cooperative pool; bracket any stored security-scoped grant
         let performWrite: @MainActor () async throws -> Void = {
+            // Directories as well as files: a folder entry stores no contents,
+            // but the writer reads the folder's own extended attributes to store
+            // its metadata — a custom folder icon lives there. Without the grant
+            // that read is refused under the sandbox and the metadata is dropped
+            // silently, which is invisible to the unit tests because they do not
+            // run sandboxed.
             var accessedFiles: [URL] = []
-            for case let .addFile(_, diskPath, _, _) in items {
-                if diskPath.startAccessingSecurityScopedResource() {
+            for item in items {
+                let diskPath: URL?
+                switch item {
+                case .addFile(_, let url, _, _): diskPath = url
+                case .addDirectory(_, let url, _, _): diskPath = url
+                default: diskPath = nil
+                }
+                if let diskPath, diskPath.startAccessingSecurityScopedResource() {
                     accessedFiles.append(diskPath)
                 }
             }

--- a/Modules/Sources/Core/ArchiveState.swift
+++ b/Modules/Sources/Core/ArchiveState.swift
@@ -581,7 +581,9 @@ extension ArchiveState {
             item = existing
         } else {
             if let existing { discard(items: [existing]) }
-            diff.append(.addDirectory(archivePath: archivePath))
+            // The folder's own URL travels with the entry: a custom folder icon
+            // is a flag on the folder itself, not only the hidden file inside it.
+            diff.append(.addDirectory(archivePath: archivePath, diskPath: url))
             item = ArchiveItem(url: url, archivePath: archivePath)
             item.parent = parent.id
             parent.addChild(item.id)
@@ -639,7 +641,7 @@ extension ArchiveState {
         if !droppedAddPaths.isEmpty {
             diff.removeAll { entry in
                 switch entry {
-                case .addFile(let p, _, _, _), .addDirectory(let p, _, _), .addData(let p, _, _, _):
+                case .addFile(let p, _, _, _), .addDirectory(let p, _, _, _), .addData(let p, _, _, _):
                     return droppedAddPaths.contains(p)
                 default:
                     return false

--- a/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
@@ -466,13 +466,20 @@ final actor ArchiveXadEngine: ArchiveEngine {
         // earlier file would otherwise look pre-existing by the time its own entry
         // came round, and lose the date it should have had.
         var preexistingDirectoryDates: [UUID: Date] = [:]
-        for item in items where item.type == .directory {
+        var entriesToCreate: Set<UUID> = []
+        for item in items {
             guard let virtualPath = item.virtualPath else { continue }
             let url = destination.appendingPathComponent(virtualPath)
-            guard let date = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            let existing = try? url.resourceValues(forKeys: [.contentModificationDateKey])
                 .contentModificationDate
-            else { continue }
-            preexistingDirectoryDates[item.id] = date
+
+            if existing == nil {
+                // Nothing there yet, so this extraction brings it into being — and
+                // that is what moves the date of the directory holding it.
+                entriesToCreate.insert(item.id)
+            } else if item.type == .directory, let existing {
+                preexistingDirectoryDates[item.id] = existing
+            }
         }
 
         // Parents before their contents. Entry order otherwise comes out of a
@@ -519,7 +526,9 @@ final actor ArchiveXadEngine: ArchiveEngine {
             urlsByItemID[item.id] = resultUrl
         }
 
-        restoreDirectoryDates(for: items, at: urlsByItemID, preexisting: preexistingDirectoryDates)
+        restoreDirectoryDates(for: items, at: urlsByItemID,
+                              preexisting: preexistingDirectoryDates,
+                              creating: entriesToCreate)
 
         return ArchiveExtractionResult(urlsByItemID: urlsByItemID)
     }
@@ -535,19 +544,33 @@ final actor ArchiveXadEngine: ArchiveEngine {
     /// directory sets that directory's modification time again, so a date applied
     /// while the extraction was still going would not have survived its own
     /// contents.
-    /// Whether any other entry in this extraction lands inside `directory`.
-    private func extractionWrote(into directory: ArchiveItem, among items: [ArchiveItem]) -> Bool {
+    /// Whether this extraction creates an entry *directly* inside `directory`,
+    /// which is the only thing that moves that directory's own date.
+    ///
+    /// Not "somewhere below": adding a file to `a/b` moves `b` and leaves `a`
+    /// exactly as it was. And not merely "an entry names this directory": an entry
+    /// that was already on disk is rewritten in place, which the directory holding
+    /// it never notices.
+    private func extractionCreatesEntry(
+        directlyIn directory: ArchiveItem,
+        among items: [ArchiveItem],
+        creating: Set<UUID>
+    ) -> Bool {
         guard let path = directory.virtualPath else { return false }
         let prefix = path.hasSuffix("/") ? path : path + "/"
         return items.contains { other in
-            other.id != directory.id && (other.virtualPath ?? "").hasPrefix(prefix)
+            guard other.id != directory.id, creating.contains(other.id),
+                  let otherPath = other.virtualPath, otherPath.hasPrefix(prefix)
+            else { return false }
+            return !otherPath.dropFirst(prefix.count).contains("/")
         }
     }
 
     private func restoreDirectoryDates(
         for items: [ArchiveItem],
         at urls: [UUID: URL],
-        preexisting: [UUID: Date]
+        preexisting: [UUID: Date],
+        creating: Set<UUID>
     ) {
         for item in items where item.type == .directory {
             guard let date = item.modificationDate, let url = urls[item.id] else { continue }
@@ -570,7 +593,8 @@ final actor ArchiveXadEngine: ArchiveEngine {
             // exactly as it did before. Proximity cannot tell those apart — an
             // archive made moments ago carries dates a legitimate write is
             // indistinguishable from.
-            guard !extractionWrote(into: item, among: items) else { continue }
+            guard !extractionCreatesEntry(directlyIn: item, among: items, creating: creating)
+            else { continue }
             try? FileManager.default.setAttributes([.modificationDate: existingDate],
                                                    ofItemAtPath: url.path)
         }

--- a/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
@@ -455,7 +455,25 @@ final actor ArchiveXadEngine: ArchiveEngine {
         }
 
         var urlsByItemID: [UUID: URL] = [:]
-        var preexistingDirectories: Set<UUID> = []
+
+        // Directories that were already on disk before any of this ran, with the
+        // date they had. A directory sitting there belongs to whoever put it
+        // there — the destination is not always empty — and its date is not ours
+        // to rewrite.
+        //
+        // Taken up front rather than as each entry is reached, because entry order
+        // is not defined: a directory this extraction creates as the parent of an
+        // earlier file would otherwise look pre-existing by the time its own entry
+        // came round, and lose the date it should have had.
+        var preexistingDirectoryDates: [UUID: Date] = [:]
+        for item in items where item.type == .directory {
+            guard let virtualPath = item.virtualPath else { continue }
+            let url = destination.appendingPathComponent(virtualPath)
+            guard let date = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate
+            else { continue }
+            preexistingDirectoryDates[item.id] = date
+        }
 
         for item in items {
             try Task.checkCancellation()
@@ -467,15 +485,6 @@ final actor ArchiveXadEngine: ArchiveEngine {
             }
 
             let resultUrl = destination.appendingPathComponent(virtualPath, isDirectory: item.type == .directory)
-
-            // A directory already sitting there belongs to whoever put it there:
-            // the destination is not always empty, and its date is not ours to
-            // rewrite. Noted before extracting, which is the only moment the two
-            // are still distinguishable.
-            if item.type == .directory,
-               FileManager.default.fileExists(atPath: resultUrl.path) {
-                preexistingDirectories.insert(item.id)
-            }
 
             do {
                 try await archive.extractEntry(Int32(itemIndex), to: destination.path)
@@ -505,7 +514,7 @@ final actor ArchiveXadEngine: ArchiveEngine {
             urlsByItemID[item.id] = resultUrl
         }
 
-        restoreDirectoryDates(for: items, at: urlsByItemID, skipping: preexistingDirectories)
+        restoreDirectoryDates(for: items, at: urlsByItemID, preexisting: preexistingDirectoryDates)
 
         return ArchiveExtractionResult(urlsByItemID: urlsByItemID)
     }
@@ -524,12 +533,29 @@ final actor ArchiveXadEngine: ArchiveEngine {
     private func restoreDirectoryDates(
         for items: [ArchiveItem],
         at urls: [UUID: URL],
-        skipping preexisting: Set<UUID>
+        preexisting: [UUID: Date]
     ) {
         for item in items where item.type == .directory {
-            guard !preexisting.contains(item.id) else { continue }
             guard let date = item.modificationDate, let url = urls[item.id] else { continue }
-            try? FileManager.default.setAttributes([.modificationDate: date],
+
+            guard let existingDate = preexisting[item.id] else {
+                // Ours to stamp: this extraction made the directory.
+                try? FileManager.default.setAttributes([.modificationDate: date],
+                                                       ofItemAtPath: url.path)
+                continue
+            }
+
+            // Not ours — but XADMaster has already stamped it with the archive's
+            // date on its way past, and it is a vendored library, so the only
+            // place to undo that is here. Undone precisely: a directory whose date
+            // now reads as the archive's is one that was overwritten, while one
+            // bumped by a file this extraction wrote into it reads as the present
+            // moment and is left alone, because writing into a folder legitimately
+            // changes its date and every other tool does the same.
+            let current = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate
+            guard let current, abs(current.timeIntervalSince(date)) < 2 else { continue }
+            try? FileManager.default.setAttributes([.modificationDate: existingDate],
                                                    ofItemAtPath: url.path)
         }
     }

--- a/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
@@ -455,6 +455,7 @@ final actor ArchiveXadEngine: ArchiveEngine {
         }
 
         var urlsByItemID: [UUID: URL] = [:]
+        var preexistingDirectories: Set<UUID> = []
 
         for item in items {
             try Task.checkCancellation()
@@ -466,6 +467,15 @@ final actor ArchiveXadEngine: ArchiveEngine {
             }
 
             let resultUrl = destination.appendingPathComponent(virtualPath, isDirectory: item.type == .directory)
+
+            // A directory already sitting there belongs to whoever put it there:
+            // the destination is not always empty, and its date is not ours to
+            // rewrite. Noted before extracting, which is the only moment the two
+            // are still distinguishable.
+            if item.type == .directory,
+               FileManager.default.fileExists(atPath: resultUrl.path) {
+                preexistingDirectories.insert(item.id)
+            }
 
             do {
                 try await archive.extractEntry(Int32(itemIndex), to: destination.path)
@@ -495,7 +505,7 @@ final actor ArchiveXadEngine: ArchiveEngine {
             urlsByItemID[item.id] = resultUrl
         }
 
-        restoreDirectoryDates(for: items, at: urlsByItemID)
+        restoreDirectoryDates(for: items, at: urlsByItemID, skipping: preexistingDirectories)
 
         return ArchiveExtractionResult(urlsByItemID: urlsByItemID)
     }
@@ -511,8 +521,13 @@ final actor ArchiveXadEngine: ArchiveEngine {
     /// directory sets that directory's modification time again, so a date applied
     /// while the extraction was still going would not have survived its own
     /// contents.
-    private func restoreDirectoryDates(for items: [ArchiveItem], at urls: [UUID: URL]) {
+    private func restoreDirectoryDates(
+        for items: [ArchiveItem],
+        at urls: [UUID: URL],
+        skipping preexisting: Set<UUID>
+    ) {
         for item in items where item.type == .directory {
+            guard !preexisting.contains(item.id) else { continue }
             guard let date = item.modificationDate, let url = urls[item.id] else { continue }
             try? FileManager.default.setAttributes([.modificationDate: date],
                                                    ofItemAtPath: url.path)

--- a/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
@@ -495,7 +495,28 @@ final actor ArchiveXadEngine: ArchiveEngine {
             urlsByItemID[item.id] = resultUrl
         }
 
+        restoreDirectoryDates(for: items, at: urlsByItemID)
+
         return ArchiveExtractionResult(urlsByItemID: urlsByItemID)
+    }
+
+    /// Stamps extracted directories with the date the archive gave them.
+    ///
+    /// XADMaster restores dates for files but leaves directories carrying the
+    /// moment of extraction — every other tool on the platform (`ditto`, `unzip`,
+    /// `tar`, Keka, The Unarchiver) puts the original back, so the gap is ours to
+    /// close rather than something to match.
+    ///
+    /// It runs after every entry has landed, and it has to: writing a file into a
+    /// directory sets that directory's modification time again, so a date applied
+    /// while the extraction was still going would not have survived its own
+    /// contents.
+    private func restoreDirectoryDates(for items: [ArchiveItem], at urls: [UUID: URL]) {
+        for item in items where item.type == .directory {
+            guard let date = item.modificationDate, let url = urls[item.id] else { continue }
+            try? FileManager.default.setAttributes([.modificationDate: date],
+                                                   ofItemAtPath: url.path)
+        }
     }
     
     func extract(

--- a/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
+++ b/Modules/Sources/Core/Engine/ArchiveXadEngine.swift
@@ -475,7 +475,12 @@ final actor ArchiveXadEngine: ArchiveEngine {
             preexistingDirectoryDates[item.id] = date
         }
 
-        for item in items {
+        // Parents before their contents. Entry order otherwise comes out of a
+        // dictionary and is not defined, so whether a directory ended up with the
+        // date of the files written into it was a coin toss.
+        let ordered = items.sorted { ($0.virtualPath ?? "") < ($1.virtualPath ?? "") }
+
+        for item in ordered {
             try Task.checkCancellation()
             guard let virtualPath = item.virtualPath else {
                 throw ArchiveError.extractionFailed("Could not extract file: missing virtual path")
@@ -530,6 +535,15 @@ final actor ArchiveXadEngine: ArchiveEngine {
     /// directory sets that directory's modification time again, so a date applied
     /// while the extraction was still going would not have survived its own
     /// contents.
+    /// Whether any other entry in this extraction lands inside `directory`.
+    private func extractionWrote(into directory: ArchiveItem, among items: [ArchiveItem]) -> Bool {
+        guard let path = directory.virtualPath else { return false }
+        let prefix = path.hasSuffix("/") ? path : path + "/"
+        return items.contains { other in
+            other.id != directory.id && (other.virtualPath ?? "").hasPrefix(prefix)
+        }
+    }
+
     private func restoreDirectoryDates(
         for items: [ArchiveItem],
         at urls: [UUID: URL],
@@ -545,16 +559,18 @@ final actor ArchiveXadEngine: ArchiveEngine {
                 continue
             }
 
-            // Not ours — but XADMaster has already stamped it with the archive's
-            // date on its way past, and it is a vendored library, so the only
-            // place to undo that is here. Undone precisely: a directory whose date
-            // now reads as the archive's is one that was overwritten, while one
-            // bumped by a file this extraction wrote into it reads as the present
-            // moment and is left alone, because writing into a folder legitimately
-            // changes its date and every other tool does the same.
-            let current = try? url.resourceValues(forKeys: [.contentModificationDateKey])
-                .contentModificationDate
-            guard let current, abs(current.timeIntervalSince(date)) < 2 else { continue }
+            // Not ours. XADMaster stamps a directory with the archive's date on
+            // its way past whether or not it created it, and it is vendored, so
+            // the only place to undo that is here.
+            //
+            // Whether it needs undoing is decided by what this extraction wrote,
+            // not by comparing dates: a folder that received files has moved on
+            // for a real reason and every tool on the platform would have moved it
+            // the same way, while a folder that received nothing should read
+            // exactly as it did before. Proximity cannot tell those apart — an
+            // archive made moments ago carries dates a legitimate write is
+            // indistinguishable from.
+            guard !extractionWrote(into: item, among: items) else { continue }
             try? FileManager.default.setAttributes([.modificationDate: existingDate],
                                                    ofItemAtPath: url.path)
         }

--- a/Modules/Sources/Swift7zip/ArchiveUpdateItem.swift
+++ b/Modules/Sources/Swift7zip/ArchiveUpdateItem.swift
@@ -51,10 +51,17 @@ public enum ArchiveUpdateItem: Sendable {
     /// Add an empty directory entry.
     /// - Parameters:
     ///   - archivePath: Directory path within the output archive.
+    ///   - diskPath: URL of the folder on disk this entry stands for, when there
+    ///     is one. Nothing is read from it — the entry is empty either way — but
+    ///     a folder carries macOS metadata of its own, and a custom folder icon
+    ///     lives there rather than on the `Icon\r` file inside it. Without this
+    ///     the icon cannot come back. `nil` for a directory that exists only in
+    ///     the archive.
     ///   - modificationDate: Optional modification date.
     ///   - posixPermissions: Optional POSIX permission bits.
     case addDirectory(
         archivePath: String,
+        diskPath: URL? = nil,
         modificationDate: Date? = nil,
         posixPermissions: UInt16? = nil
     )

--- a/Modules/Sources/Swift7zip/SevenZipWriter.swift
+++ b/Modules/Sources/Swift7zip/SevenZipWriter.swift
@@ -48,7 +48,16 @@ extension SevenZipArchive {
         }
 
         // Resolve the diff into a full item list for the C bridge.
-        let resolved = try resolveDiff(source: source, items: items)
+        var resolved = try resolveDiff(source: source, items: items)
+
+        // Everything macOS keeps outside a file's contents travels as an extra
+        // entry per file, packed into a scratch directory that lives exactly as
+        // long as this write does.
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        resolved.append(contentsOf: metadataSidecars(for: resolved, scratch: scratch))
 
         try performUpdate(
             source: source,
@@ -79,7 +88,7 @@ extension SevenZipArchive {
                      modificationDate: Date?, posixPermissions: UInt16?)
         case addData(archivePath: String, data: Data,
                      modificationDate: Date?, posixPermissions: UInt16?)
-        case addDirectory(archivePath: String,
+        case addDirectory(archivePath: String, diskPath: URL?,
                           modificationDate: Date?, posixPermissions: UInt16?)
     }
 
@@ -108,9 +117,9 @@ extension SevenZipArchive {
                 additions.append(.addData(
                     archivePath: p, data: data,
                     modificationDate: d, posixPermissions: perms))
-            case .addDirectory(let p, let d, let perms):
+            case .addDirectory(let p, let url, let d, let perms):
                 additions.append(.addDirectory(
-                    archivePath: p, modificationDate: d,
+                    archivePath: p, diskPath: url, modificationDate: d,
                     posixPermissions: perms))
             }
         }
@@ -144,6 +153,167 @@ extension SevenZipArchive {
 
         result.append(contentsOf: additions)
         return result
+    }
+
+    // MARK: - macOS Metadata
+
+    /// Where the sidecar for `archivePath` goes: `dir/name` becomes
+    /// `__MACOSX/dir/._name`.
+    ///
+    /// The mirror rather than a `._name` beside the file it describes. Both forms
+    /// are read back, but an extractor that does not fold them in writes the
+    /// sidecar out as an ordinary file — and inside a signed `.app` that extra
+    /// file breaks the code-signature seal and macOS calls the app damaged. That
+    /// is issue #189 seen from the writing end. `__MACOSX/` keeps every sidecar
+    /// outside the bundle, and it is what Finder's "Compress" produces, so it is
+    /// also the shape other tools already expect.
+    private static func sidecarPath(for archivePath: String) -> String {
+        var parts = archivePath.split(separator: "/", omittingEmptySubsequences: true)
+        guard let name = parts.popLast() else { return archivePath }
+        let directory = parts.joined(separator: "/")
+        return directory.isEmpty
+            ? "__MACOSX/._\(name)"
+            : "__MACOSX/\(directory)/._\(name)"
+    }
+
+    /// Extended attributes that describe this Mac rather than the file, and so
+    /// have no business in an archive that will be opened on another one.
+    ///
+    /// `com.apple.quarantine` is the one that matters: it is Gatekeeper's verdict
+    /// on where the file came from, and `copyfile` packs it like any other
+    /// attribute. Storing it would put the machine's browsing history into every
+    /// archive MacPacker writes, and hand the extracting side a verdict the
+    /// archive was never entitled to make — the same argument the extraction path
+    /// already makes for refusing to apply one.
+    ///
+    /// The rest are noise that would otherwise earn a sidecar all by themselves.
+    /// `com.apple.TextEncoding` in particular is written by Cocoa whenever a text
+    /// file is saved, so without this every `.txt` in every archive would carry a
+    /// second entry to say it is UTF-8.
+    private static let systemOwnedAttributes: Set<String> = [
+        "com.apple.quarantine",
+        "com.apple.provenance",
+        "com.apple.lastuseddate#PS",
+        "com.apple.macl",
+        "com.apple.TextEncoding",
+    ]
+
+    /// The names of every extended attribute on `url`.
+    private static func attributeNames(of url: URL) -> [String] {
+        let size = listxattr(url.path, nil, 0, XATTR_NOFOLLOW)
+        guard size > 0 else { return [] }
+
+        var buffer = [CChar](repeating: 0, count: size)
+        guard listxattr(url.path, &buffer, size, XATTR_NOFOLLOW) == size else { return [] }
+
+        // listxattr returns the names NUL-separated in one buffer.
+        return buffer.split(separator: 0).map { String(cString: Array($0) + [0]) }
+    }
+
+    /// Serializes what macOS keeps outside a file's contents — resource fork,
+    /// extended attributes, and the FinderInfo that carries a custom-icon or
+    /// invisible flag — into AppleDouble. Returns the file written, or `nil`.
+    ///
+    /// `copyfile` with COPYFILE_PACK is the same call `ditto` makes and the exact
+    /// reverse of the COPYFILE_UNPACK the extraction path already runs, so the
+    /// bytes are macOS's own rather than our idea of the format. Deliberately
+    /// without COPYFILE_DATA: the contents travel as the entry itself, and a
+    /// sidecar that repeated them would double the size of the archive.
+    ///
+    /// It packs a stand-in rather than the file itself, because `copyfile` offers
+    /// no way to leave an attribute out and some of them must not travel. The
+    /// stand-in is given exactly the attributes worth keeping and then packed, so
+    /// what lands in the archive is the same format either way.
+    private static func packMetadata(of source: URL, into scratch: URL) -> URL? {
+        let donor = scratch.appendingPathComponent(UUID().uuidString)
+        guard FileManager.default.createFile(atPath: donor.path, contents: nil) else { return nil }
+
+        for name in attributeNames(of: source) where !systemOwnedAttributes.contains(name) {
+            let size = getxattr(source.path, name, nil, 0, 0, XATTR_NOFOLLOW)
+            guard size >= 0 else { continue }
+
+            var value = [UInt8](repeating: 0, count: max(size, 1))
+            guard getxattr(source.path, name, &value, size, 0, XATTR_NOFOLLOW) == size else { continue }
+            setxattr(donor.path, name, value, size, 0, XATTR_NOFOLLOW)
+        }
+
+        let destination = scratch.appendingPathComponent(UUID().uuidString)
+        let flags = copyfile_flags_t(COPYFILE_PACK | COPYFILE_XATTR)
+        guard copyfile(donor.path, destination.path, nil, flags) == 0 else { return nil }
+        return destination
+    }
+
+    /// What an AppleDouble looks like when there was nothing to put in it.
+    ///
+    /// A packed sidecar is never empty: `copyfile` writes a header and a zeroed
+    /// FinderInfo whether or not the file had anything to say. Storing one per
+    /// entry would roughly double the entry count of every archive for no gain,
+    /// so a sidecar matching this sample is dropped instead.
+    ///
+    /// Sampled rather than hard-coded as a byte count, so that a change in what
+    /// `copyfile` emits shows up as sidecars that are kept, rather than as real
+    /// metadata quietly thrown away.
+    private struct EmptyMetadata {
+        private let sample: Data?
+
+        init(scratch: URL) {
+            let file = scratch.appendingPathComponent("empty-metadata-sample")
+            try? Data().write(to: file)
+            sample = packMetadata(of: file, into: scratch).flatMap { try? Data(contentsOf: $0) }
+        }
+
+        func describesNothing(_ sidecar: Data) -> Bool { sidecar == sample }
+    }
+
+    /// The sidecar entries to store alongside `items`.
+    ///
+    /// Both files and directories get one. A directory is not an afterthought
+    /// here: a folder's custom icon is a picture in a hidden `Icon\r` file *plus*
+    /// a flag on the folder itself, and restoring only the file leaves the folder
+    /// looking generic. `ditto` writes no sidecar for a directory, which is why a
+    /// round trip through Finder's "Compress" loses a custom folder icon.
+    ///
+    /// Symlinks are skipped: a link has no metadata worth carrying, and the
+    /// extraction side refuses to unpack onto one anyway, since `copyfile` would
+    /// follow it and write to whatever it points at.
+    private static func metadataSidecars(for items: [ResolvedItem], scratch: URL) -> [ResolvedItem] {
+        let empty = EmptyMetadata(scratch: scratch)
+        var sidecars: [ResolvedItem] = []
+
+        for item in items {
+            let archivePath: String
+            let source: URL
+            let date: Date?
+
+            switch item {
+            case .addFile(let path, let url, let modificationDate, _):
+                (archivePath, source, date) = (path, url, modificationDate)
+            case .addDirectory(let path, let url?, let modificationDate, _):
+                (archivePath, source, date) = (path, url, modificationDate)
+            default:
+                continue
+            }
+
+            let values = try? source.resourceValues(
+                forKeys: [.isSymbolicLinkKey, .contentModificationDateKey])
+            if values?.isSymbolicLink == true { continue }
+
+            guard let packed = packMetadata(of: source, into: scratch),
+                  let bytes = try? Data(contentsOf: packed),
+                  !empty.describesNothing(bytes)
+            else { continue }
+
+            sidecars.append(.addFile(
+                archivePath: sidecarPath(for: archivePath),
+                diskPath: packed,
+                // The sidecar carries the date of what it describes, as ditto's
+                // do — its own would be the moment the archive happened to be
+                // written, which says nothing about the file.
+                modificationDate: date ?? values?.contentModificationDate,
+                posixPermissions: nil))
+        }
+
+        return sidecars
     }
 
     // MARK: - Bridge Call
@@ -200,7 +370,7 @@ extension SevenZipArchive {
             case .move(_, let p): return p
             case .addFile(let p, _, _, _): return p
             case .addData(let p, _, _, _): return p
-            case .addDirectory(let p, _, _): return p
+            case .addDirectory(let p, _, _, _): return p
             default: return nil
             }
         }
@@ -229,7 +399,7 @@ extension SevenZipArchive {
                     // no permissions given: default to a regular 644 file —
                     // leaving them unset stores mode 000, which extracts as unreadable
                     cItems[i].posix_permissions = p.map(UInt32.init) ?? 0o100644
-                case .addDirectory(_, let d, let p):
+                case .addDirectory(_, _, let d, let p):
                     if let d { cItems[i].mtime = Int64(d.timeIntervalSince1970) }
                     cItems[i].posix_permissions = p.map(UInt32.init) ?? 0o40755
                 }

--- a/Modules/Sources/Swift7zip/SevenZipWriter.swift
+++ b/Modules/Sources/Swift7zip/SevenZipWriter.swift
@@ -408,10 +408,17 @@ extension SevenZipArchive {
         }
 
         let diskPaths = resolvedItems.map { item -> String? in
-            if case .addFile(_, let url, _, _) = item {
+            switch item {
+            case .addFile(_, let url, _, _):
                 return url.path
+            case .addDirectory(_, let url, _, _):
+                // Nothing is read from a folder for its contents, but its date is
+                // taken from here. Without it the entry stores no date at all and
+                // the folder extracts stamped 1980.
+                return url?.path
+            default:
+                return nil
             }
-            return nil
         }
 
         let progressBox = progress.map(WriteProgressBox.init)

--- a/Modules/Sources/Swift7zip/SevenZipWriter.swift
+++ b/Modules/Sources/Swift7zip/SevenZipWriter.swift
@@ -55,9 +55,11 @@ extension SevenZipArchive {
         // long as this write does.
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
-        try? FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        // Not `try?`: one failed directory would silently turn the whole of the
+        // above into a no-op, and the archive would come out stripped.
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
-        resolved.append(contentsOf: metadataSidecars(for: resolved, scratch: scratch))
+        resolved.append(contentsOf: try metadataSidecars(for: resolved, scratch: scratch))
 
         try performUpdate(
             source: source,
@@ -198,13 +200,31 @@ extension SevenZipArchive {
         "com.apple.TextEncoding",
     ]
 
+    /// A failure in the metadata path, carrying what the C call reported.
+    ///
+    /// Everything below reports rather than shrugs, because "could not read the
+    /// metadata" and "there was no metadata" produce the same archive and mean
+    /// opposite things. Treating the first as the second is how a custom folder
+    /// icon goes missing with nobody told — which is the bug this whole change
+    /// exists to fix, reached from a different direction. Under the sandbox it is
+    /// not hypothetical: without a security-scoped grant `listxattr` fails with
+    /// EACCES on a folder whose contents are never read.
+    private static func metadataError(_ call: String, _ url: URL) -> SevenZipError {
+        .writeFailed("\(call) failed for \(url.lastPathComponent): "
+                     + String(cString: strerror(errno)))
+    }
+
     /// The names of every extended attribute on `url`.
-    private static func attributeNames(of url: URL) -> [String] {
+    private static func attributeNames(of url: URL) throws -> [String] {
         let size = listxattr(url.path, nil, 0, XATTR_NOFOLLOW)
+        guard size >= 0 else { throw metadataError("listxattr", url) }
         guard size > 0 else { return [] }
 
         var buffer = [CChar](repeating: 0, count: size)
-        guard listxattr(url.path, &buffer, size, XATTR_NOFOLLOW) == size else { return [] }
+        // A shrinking set between the two calls is a race, not an empty one.
+        guard listxattr(url.path, &buffer, size, XATTR_NOFOLLOW) == size else {
+            throw metadataError("listxattr", url)
+        }
 
         // listxattr returns the names NUL-separated in one buffer.
         return buffer.split(separator: 0).map { String(cString: Array($0) + [0]) }
@@ -212,7 +232,7 @@ extension SevenZipArchive {
 
     /// Serializes what macOS keeps outside a file's contents — resource fork,
     /// extended attributes, and the FinderInfo that carries a custom-icon or
-    /// invisible flag — into AppleDouble. Returns the file written, or `nil`.
+    /// invisible flag — into AppleDouble. Returns the file written.
     ///
     /// `copyfile` with COPYFILE_PACK is the same call `ditto` makes and the exact
     /// reverse of the COPYFILE_UNPACK the extraction path already runs, so the
@@ -224,22 +244,30 @@ extension SevenZipArchive {
     /// no way to leave an attribute out and some of them must not travel. The
     /// stand-in is given exactly the attributes worth keeping and then packed, so
     /// what lands in the archive is the same format either way.
-    private static func packMetadata(of source: URL, into scratch: URL) -> URL? {
+    private static func packMetadata(of source: URL, into scratch: URL) throws -> URL {
         let donor = scratch.appendingPathComponent(UUID().uuidString)
-        guard FileManager.default.createFile(atPath: donor.path, contents: nil) else { return nil }
+        guard FileManager.default.createFile(atPath: donor.path, contents: nil) else {
+            throw metadataError("create", donor)
+        }
 
-        for name in attributeNames(of: source) where !systemOwnedAttributes.contains(name) {
+        for name in try attributeNames(of: source) where !systemOwnedAttributes.contains(name) {
             let size = getxattr(source.path, name, nil, 0, 0, XATTR_NOFOLLOW)
-            guard size >= 0 else { continue }
+            guard size >= 0 else { throw metadataError("getxattr \(name)", source) }
 
             var value = [UInt8](repeating: 0, count: max(size, 1))
-            guard getxattr(source.path, name, &value, size, 0, XATTR_NOFOLLOW) == size else { continue }
-            setxattr(donor.path, name, value, size, 0, XATTR_NOFOLLOW)
+            guard getxattr(source.path, name, &value, size, 0, XATTR_NOFOLLOW) == size else {
+                throw metadataError("getxattr \(name)", source)
+            }
+            guard setxattr(donor.path, name, value, size, 0, XATTR_NOFOLLOW) == 0 else {
+                throw metadataError("setxattr \(name)", donor)
+            }
         }
 
         let destination = scratch.appendingPathComponent(UUID().uuidString)
         let flags = copyfile_flags_t(COPYFILE_PACK | COPYFILE_XATTR)
-        guard copyfile(donor.path, destination.path, nil, flags) == 0 else { return nil }
+        guard copyfile(donor.path, destination.path, nil, flags) == 0 else {
+            throw metadataError("copyfile", source)
+        }
         return destination
     }
 
@@ -254,12 +282,15 @@ extension SevenZipArchive {
     /// `copyfile` emits shows up as sidecars that are kept, rather than as real
     /// metadata quietly thrown away.
     private struct EmptyMetadata {
-        private let sample: Data?
+        private let sample: Data
 
-        init(scratch: URL) {
+        /// Throws rather than falling back to "nothing matches": a missing sample
+        /// would quietly give every entry in the archive a sidecar carrying
+        /// nothing, which is the failure this comparison exists to prevent.
+        init(scratch: URL) throws {
             let file = scratch.appendingPathComponent("empty-metadata-sample")
-            try? Data().write(to: file)
-            sample = packMetadata(of: file, into: scratch).flatMap { try? Data(contentsOf: $0) }
+            try Data().write(to: file)
+            sample = try Data(contentsOf: packMetadata(of: file, into: scratch))
         }
 
         func describesNothing(_ sidecar: Data) -> Bool { sidecar == sample }
@@ -276,8 +307,8 @@ extension SevenZipArchive {
     /// Symlinks are skipped: a link has no metadata worth carrying, and the
     /// extraction side refuses to unpack onto one anyway, since `copyfile` would
     /// follow it and write to whatever it points at.
-    private static func metadataSidecars(for items: [ResolvedItem], scratch: URL) -> [ResolvedItem] {
-        let empty = EmptyMetadata(scratch: scratch)
+    private static func metadataSidecars(for items: [ResolvedItem], scratch: URL) throws -> [ResolvedItem] {
+        let empty = try EmptyMetadata(scratch: scratch)
         var sidecars: [ResolvedItem] = []
 
         for item in items {
@@ -294,14 +325,15 @@ extension SevenZipArchive {
                 continue
             }
 
-            let values = try? source.resourceValues(
+            let values = try source.resourceValues(
                 forKeys: [.isSymbolicLinkKey, .contentModificationDateKey])
-            if values?.isSymbolicLink == true { continue }
+            if values.isSymbolicLink == true { continue }
 
-            guard let packed = packMetadata(of: source, into: scratch),
-                  let bytes = try? Data(contentsOf: packed),
-                  !empty.describesNothing(bytes)
-            else { continue }
+            // The only reason to leave a sidecar out: it was packed, and what came
+            // back says nothing. A failure above is a failure, not an absence.
+            let packed = try packMetadata(of: source, into: scratch)
+            let bytes = try Data(contentsOf: packed)
+            if empty.describesNothing(bytes) { continue }
 
             sidecars.append(.addFile(
                 archivePath: sidecarPath(for: archivePath),
@@ -309,7 +341,7 @@ extension SevenZipArchive {
                 // The sidecar carries the date of what it describes, as ditto's
                 // do — its own would be the moment the archive happened to be
                 // written, which says nothing about the file.
-                modificationDate: date ?? values?.contentModificationDate,
+                modificationDate: date ?? values.contentModificationDate,
                 posixPermissions: nil))
         }
 

--- a/Modules/Tests/CoreTests/Base/MacMetadata.swift
+++ b/Modules/Tests/CoreTests/Base/MacMetadata.swift
@@ -1,0 +1,118 @@
+//
+//  MacMetadata.swift
+//  Modules
+//
+//  The macOS metadata that lives outside a file's contents: extended attributes,
+//  the resource fork, and the FinderInfo flags that decide whether a file is
+//  invisible and whether a folder shows a custom icon.
+//
+//  Shared, because both halves of the round trip need it. Extraction tests assert
+//  this metadata arrives; creation tests seed it and assert it survives.
+//
+
+import Foundation
+@testable import Core
+
+/// The two engines that can read a zip.
+///
+/// Extraction tests about what lands on disk run through both. The fixtures are
+/// only proven if either reader gets the same result out of them, and the two get
+/// there differently: our own bridge folds AppleDouble sidecars back onto their
+/// files, while XADMaster — a Mac tool from the start — does its own handling of
+/// resource forks and extended attributes. Nothing but a test says whether they
+/// agree.
+enum ZipReader: String, CaseIterable, Sendable {
+    case sevenZip
+    case xad
+
+    var engine: any ArchiveEngine {
+        switch self {
+        case .sevenZip: Archive7ZipEngine()
+        case .xad: ArchiveXadEngine()
+        }
+    }
+}
+
+/// Reads one extended attribute, or nil when the file does not carry it.
+/// `FileManager` exposes no API for these, and they are what the AppleDouble
+/// work is entirely about — including `com.apple.ResourceFork`, which is how
+/// macOS stores a resource fork.
+func extendedAttribute(_ name: String, at url: URL) -> Data? {
+    let size = getxattr(url.path, name, nil, 0, 0, 0)
+    guard size >= 0 else { return nil }
+    guard size > 0 else { return Data() }
+
+    var buffer = Data(count: size)
+    let read = buffer.withUnsafeMutableBytes {
+        getxattr(url.path, name, $0.baseAddress, size, 0, 0)
+    }
+    guard read == size else { return nil }
+    return buffer
+}
+
+/// Sets one extended attribute. The counterpart to `extendedAttribute`, for
+/// seeding metadata a test then asserts survives untouched.
+func setExtendedAttribute(_ name: String, _ value: Data, at url: URL) {
+    let result = value.withUnsafeBytes {
+        setxattr(url.path, name, $0.baseAddress, value.count, 0, 0)
+    }
+    precondition(result == 0, "setxattr \(name) failed on \(url.path)")
+}
+
+/// The FinderInfo flags this codebase cares about. They sit in the same place
+/// for a file and a folder — a two-byte field at offset 8 of the 32-byte
+/// `com.apple.FinderInfo` attribute — even though everything around them differs
+/// (a file has a type and creator there, a folder a window rectangle).
+enum FinderFlag {
+    /// Keeps `Icon\r` out of sight. Without it Finder lists the file as `Icon?`,
+    /// rendering the trailing carriage return as a question mark — which is how
+    /// issue #216 was reported.
+    static let invisible: UInt16 = 0x4000
+    /// Set on the folder, not on the icon file. Finder looks for `Icon\r` only
+    /// when it finds this, so a folder without it stays generic no matter what
+    /// the icon file holds.
+    static let hasCustomIcon: UInt16 = 0x0400
+}
+
+/// The 32 bytes of a `com.apple.FinderInfo` attribute carrying `flags` and
+/// nothing else.
+func finderInfo(flags: UInt16) -> Data {
+    var bytes = [UInt8](repeating: 0, count: 32)
+    bytes[8] = UInt8(flags >> 8)
+    bytes[9] = UInt8(flags & 0xFF)
+    return Data(bytes)
+}
+
+/// The flags out of a `com.apple.FinderInfo` attribute, or nil when the file
+/// carries none.
+func finderFlags(at url: URL) -> UInt16? {
+    guard let info = extendedAttribute("com.apple.FinderInfo", at: url), info.count >= 10
+    else { return nil }
+    return UInt16(info[8]) << 8 | UInt16(info[9])
+}
+
+/// The name macOS gives the hidden file that holds a folder's custom icon. The
+/// trailing carriage return is part of the name, and it is the awkward half of
+/// every test that touches this: it is legal in a zip entry name, and stock
+/// Info-ZIP `unzip` silently drops it.
+let customIconFileName = "Icon\r"
+
+/// Builds a folder that shows a custom icon in Finder, which takes three
+/// separate pieces of metadata — losing any one of them loses the picture.
+///
+/// The resource fork here is a stand-in rather than a real `icns`: what the
+/// tests assert is that the bytes make the round trip, and made-up bytes prove
+/// that as well as a real icon would while staying obvious about what they are.
+/// `zip/customicon.zip` carries the genuine article for the extraction side.
+@discardableResult
+func makeFolderWithCustomIcon(at folder: URL, fork: Data) throws -> URL {
+    try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+    let icon = folder.appendingPathComponent(customIconFileName)
+    try Data().write(to: icon)
+    setExtendedAttribute("com.apple.ResourceFork", fork, at: icon)
+    setExtendedAttribute("com.apple.FinderInfo", finderInfo(flags: FinderFlag.invisible), at: icon)
+    setExtendedAttribute("com.apple.FinderInfo",
+                         finderInfo(flags: FinderFlag.hasCustomIcon), at: folder)
+    return icon
+}

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -584,6 +584,183 @@ extension AllCoreTests {
             #expect(codesignVerdict(app) == 0, "extracted bundle failed codesign")
         }
 
+        // Finder tags and Finder comments are ordinary extended attributes under
+        // long names, so nothing in the extraction path treats them specially and
+        // `appledouble.zip` already proves the mechanism. They are asserted by
+        // name anyway, because they are what a user notices missing, and a test
+        // that says so is worth more than a comment explaining that tags are
+        // really just attributes.
+        //
+        // The values are real binary plists — decoded here rather than compared
+        // as bytes, so a failure says which tag went missing.
+        //
+        // Note on comments: Finder keeps a second copy in the enclosing folder's
+        // `.DS_Store` and Get Info reads *that*, so a comment can be restored on
+        // the file and still look blank to the user. Nothing an archiver can do.
+        @Test(arguments: ZipReader.allCases)
+        func extractionRestoresFinderTagsAndComments(reader: ZipReader) async throws {
+            let engine = reader.engine
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("macextras.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            _ = try await engine.extract(
+                items: items, from: url, to: tempDir, passwordResolver: { _ in nil })
+
+            let tagData = try #require(
+                extendedAttribute("com.apple.metadata:_kMDItemUserTags",
+                                  at: tempDir.appendingPathComponent("tagged.txt")),
+                "tagged.txt should carry its Finder tags")
+            let tags = try PropertyListSerialization.propertyList(
+                from: tagData, format: nil) as? [String]
+            #expect(tags == ["Red\n6", "MacPacker\n0"],
+                    "both tags should arrive, got \(String(describing: tags))")
+
+            let commentData = try #require(
+                extendedAttribute("com.apple.metadata:kMDItemFinderComment",
+                                  at: tempDir.appendingPathComponent("commented.txt")),
+                "commented.txt should carry its Finder comment")
+            let comment = try PropertyListSerialization.propertyList(
+                from: commentData, format: nil) as? String
+            #expect(comment == "Kept in Get Info, and in the folder's .DS_Store.",
+                    "got \(String(describing: comment))")
+
+            #expect(appleDoubleLeftovers(in: tempDir).isEmpty,
+                    "found \(appleDoubleLeftovers(in: tempDir))")
+            #expect(fm.fileExists(atPath: tempDir.appendingPathComponent("__MACOSX").path) == false)
+        }
+
+        // Issue #216, from the reading end. A folder shows a custom picture only
+        // when three separate pieces of metadata survive together, and the fixture
+        // holds all three: the picture in the resource fork of a hidden `Icon\r`
+        // file, kIsInvisible on that file, and kHasCustomIcon on the folder.
+        //
+        // The folder's own flag is the one nothing else writes — `ditto` emits no
+        // sidecar for the folder it is told to archive, so a round trip through
+        // Finder's "Compress" brings the icon file back and still shows a generic
+        // folder. See `zip/make_customicon.sh`.
+        //
+        // The entry name is the other half: `Icon\r` ends in a carriage return,
+        // which stock Info-ZIP silently drops on the way out.
+        //
+        // Both readers, and getting there took a fixture fix. XADMaster folds
+        // these sidecars itself, but it refuses an archive whose folder sidecar
+        // describes a directory the archive never declares — it tries to write
+        // the metadata to a file that is not there and abandons the extraction.
+        // The fixture originally had no `CustomFolder/` entry, which is not what
+        // any real archiver produces: Finder writes one, and so does MacPacker.
+        // Narrowed with two archives differing in nothing but that entry.
+        @Test(arguments: ZipReader.allCases)
+        func extractionRestoresACustomFolderIcon(reader: ZipReader) async throws {
+            let engine = reader.engine
+            let zipFolder = Bundle.module.url(forResource: "zip", withExtension: nil)!
+            let url = zipFolder.appendingPathComponent("customicon.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            _ = try await engine.extract(
+                items: items, from: url, to: tempDir, passwordResolver: { _ in nil })
+
+            let folder = tempDir.appendingPathComponent("CustomFolder")
+            let icon = folder.appendingPathComponent(customIconFileName)
+
+            try #require(fm.fileExists(atPath: icon.path),
+                         "the icon file's name survived the carriage return")
+
+            #expect(finderFlags(at: folder) == FinderFlag.hasCustomIcon,
+                    "Finder looks for the icon file only when the folder is flagged")
+            #expect(finderFlags(at: icon) == FinderFlag.invisible,
+                    "without this the file shows up as `Icon?` — the reported symptom")
+
+            // The user-visible form of the same thing, asked of the system rather
+            // than of the bytes.
+            #expect(try icon.resourceValues(forKeys: [.isHiddenKey]).isHidden == true,
+                    "the icon file must not be visible in Finder")
+
+            let fork = extendedAttribute("com.apple.ResourceFork", at: icon)
+            #expect(fork?.isEmpty == false, "the picture lives in the resource fork")
+            #expect(fork.map { $0.range(of: Data("icns".utf8)) != nil } == true,
+                    "the resource fork should still hold an icns resource")
+
+            #expect(try String(contentsOf: folder.appendingPathComponent("note.txt"),
+                               encoding: .utf8) == "A folder is more than its icon.\n",
+                    "ordinary contents come through untouched")
+            #expect(appleDoubleLeftovers(in: tempDir).isEmpty,
+                    "found \(appleDoubleLeftovers(in: tempDir))")
+            #expect(fm.fileExists(atPath: tempDir.appendingPathComponent("__MACOSX").path) == false,
+                    "the mirror holds nothing but metadata and should be gone")
+        }
+
+        // Every extraction used to stamp its files with the moment they were
+        // written, because nothing ever applied the date the archive carries. A
+        // folder restored from a backup came out claiming to be seconds old —
+        // losing the one piece of metadata zip has been able to hold since 1989.
+        //
+        // `defaultArchive.zip` is the fixture because its entries do not share a
+        // date: `hello world.txt` and `README.md` are from November, `folder/` and
+        // the nested archive from December. A single stamp applied to everything
+        // would pass a same-date fixture and fail a user.
+        @Test(arguments: ZipReader.allCases)
+        func extractionRestoresModificationDates(reader: ZipReader) async throws {
+            let engine = reader.engine
+            let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let url = folderURL.appendingPathComponent("defaultArchive.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            let result = try await engine.extract(
+                items: items, from: url, to: tempDir, passwordResolver: { _ in nil })
+
+            var checked: [String] = []
+            for item in items {
+                guard let stored = item.modificationDate,
+                      let extracted = result.urlsByItemID[item.id],
+                      fm.fileExists(atPath: extracted.path)
+                else { continue }
+
+                let onDisk = try #require(
+                    extracted.resourceValues(forKeys: [.contentModificationDateKey])
+                        .contentModificationDate)
+
+                // Two seconds, because that is the resolution of a zip's own date
+                // field — DOS time counts in even seconds.
+                #expect(
+                    abs(onDisk.timeIntervalSince(stored)) < 2,
+                    "\(item.name) should carry the archive's date \(stored), got \(onDisk)"
+                )
+                checked.append(item.name)
+            }
+
+            #expect(checked.count >= 3, "expected the fixture's entries to carry dates, checked \(checked)")
+
+            // A directory is the awkward one: writing its contents bumps its time
+            // again, so the date has to go on after everything else has landed.
+            // XADMaster leaves directories stamped with the moment of extraction,
+            // so the XAD engine puts them right itself once the entries have all
+            // arrived — both readers are held to the same result.
+            #expect(checked.contains("folder"),
+                    "the directory entry should be dated too, checked \(checked)")
+        }
+
         // codesign is the same judgement #189 was reported as — an app macOS called
         // damaged — made by the system rather than by this test. Only the archives
         // that can carry a bundle intact are listed: `archivers/ditto_inline.zip`
@@ -1428,32 +1605,6 @@ extension AllCoreTests {
             }
         }
     }
-}
-
-/// Reads one extended attribute, or nil when the file does not carry it.
-/// `FileManager` exposes no API for these, and the AppleDouble regression above
-/// is entirely about whether they arrive — including `com.apple.ResourceFork`,
-/// which is how macOS stores a resource fork.
-private func extendedAttribute(_ name: String, at url: URL) -> Data? {
-    let size = getxattr(url.path, name, nil, 0, 0, 0)
-    guard size >= 0 else { return nil }
-    guard size > 0 else { return Data() }
-
-    var buffer = Data(count: size)
-    let read = buffer.withUnsafeMutableBytes {
-        getxattr(url.path, name, $0.baseAddress, size, 0, 0)
-    }
-    guard read == size else { return nil }
-    return buffer
-}
-
-/// Sets one extended attribute. The counterpart to `extendedAttribute`, for
-/// seeding metadata a test then asserts survives untouched.
-private func setExtendedAttribute(_ name: String, _ value: Data, at url: URL) {
-    let result = value.withUnsafeBytes {
-        setxattr(url.path, name, $0.baseAddress, value.count, 0, 0)
-    }
-    precondition(result == 0, "setxattr \(name) failed on \(url.path)")
 }
 
 /// Runs codesign over a bundle and returns its exit status. The system's own

--- a/Modules/Tests/CoreTests/EngineTests.swift
+++ b/Modules/Tests/CoreTests/EngineTests.swift
@@ -490,6 +490,51 @@ extension AllCoreTests {
             )
         }
 
+        // The same rule, for the dates an extraction now applies. "Extract here"
+        // writes into a folder of the user's own files, and "Extract to folder"
+        // reuses an existing folder on a second run, so a directory named by the
+        // archive is not always one this extraction made. Restamping it would
+        // rewrite the date on a folder that was never ours — visible to anyone
+        // who sorts by date, and impossible to undo.
+        //
+        // The folder does not come out untouched, and cannot: writing a file into
+        // a directory bumps its modification time, and the extraction does write
+        // `folder/README.md`. What it must not do is hand it the *archive's* date.
+        @Test(arguments: ZipReader.allCases)
+        func extractionLeavesTheDatesOfFoldersItDidNotCreateAlone(reader: ZipReader) async throws {
+            let engine = reader.engine
+            let folderURL = Bundle.module.url(forResource: "defaultArchives", withExtension: nil)!
+            let url = folderURL.appendingPathComponent("defaultArchive.zip")
+
+            let loadResult = try await engine.loadArchive(url: url, passwordResolver: { _ in nil })
+            let items = Array(loadResult.items.values)
+
+            let fm = FileManager.default
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            // The archive names `folder`. Plant one first, as a user's own.
+            let planted = tempDir.appendingPathComponent("folder")
+            try fm.createDirectory(at: planted, withIntermediateDirectories: true)
+
+            let archiveDate = try #require(
+                items.first { $0.name == "folder" }?.modificationDate,
+                "the fixture's directory entry should carry a date to be tempted by")
+
+            _ = try await engine.extract(
+                items: items, from: url, to: tempDir, passwordResolver: { _ in nil })
+
+            let onDisk = try #require(
+                planted.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate)
+
+            #expect(
+                abs(onDisk.timeIntervalSince(archiveDate)) >= 2,
+                "a folder the extraction did not create was restamped with the archive's date \(archiveDate)"
+            )
+        }
+
         // Gatekeeper's verdict on a downloaded file lives in com.apple.quarantine,
         // and copyfile's COPYFILE_UNPACK replaces a target's extended attributes
         // rather than merging into them. So an archive shipping `Evil.app` beside a

--- a/Modules/Tests/CoreTests/ZipWriteTests.swift
+++ b/Modules/Tests/CoreTests/ZipWriteTests.swift
@@ -84,6 +84,34 @@ private func makeJarFixture(in dir: URL) throws -> URL {
     return jar
 }
 
+/// How Info-ZIP prints `name` in a listing: control characters come out in caret
+/// notation, so the carriage return ending `Icon\r` is shown as the two ordinary
+/// characters `^M`.
+///
+/// Gone through rather than around, because the independent check is worth
+/// keeping. It is also a fair warning about the tool: the same `unzip` silently
+/// *drops* that byte when it extracts, writing a file called `Icon`.
+private func infoZipListingName(_ name: String) -> String {
+    name.replacingOccurrences(of: "\r", with: "^M")
+}
+
+/// Extracts everything with our own reader.
+///
+/// The metadata tests need this rather than `unzip`, because putting the sidecars
+/// back onto the files they describe is half of what they are asserting — `unzip`
+/// leaves them lying around as literal `._` files instead.
+private func extractWithOurEngine(_ archive: URL, to destination: URL) async throws {
+    let engine = Archive7ZipEngine()
+    let loaded = try await engine.loadArchive(url: archive, passwordResolver: { _ in nil })
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    _ = try await engine.extract(
+        items: Array(loaded.items.values),
+        from: archive,
+        to: destination,
+        passwordResolver: { _ in nil }
+    )
+}
+
 // MARK: - Writer-level tests (SevenZipArchive.writeArchive)
 
 extension AllCoreTests {
@@ -520,6 +548,183 @@ extension AllCoreTests {
             try run("/usr/bin/unzip", [zip.path, "-d", out.path])
             #expect(try String(contentsOf: out.appendingPathComponent("folder/one.txt"), encoding: .utf8) == "one v2")
             #expect(try String(contentsOf: out.appendingPathComponent("folder/two.txt"), encoding: .utf8) == "two")
+        }
+
+        // MARK: - macOS metadata (#191, #216)
+
+        // A zip has nowhere to keep a resource fork or an extended attribute, so
+        // every Mac archiver smuggles them in as a second entry per file, in
+        // AppleDouble format. MacPacker read those back from #189 onwards but
+        // never wrote any, so anything added through MacPacker came out stripped:
+        // Finder tags gone, comments gone, custom icons gone.
+        //
+        // Asserted through our own reader rather than `unzip`, because putting
+        // the metadata back on the file is the other half of the round trip —
+        // `unzip` would leave the sidecars lying around as literal `._` files,
+        // which is the behaviour under test rather than a way to test it. What
+        // the system tool is asked instead is whether the entries are in the
+        // archive at all, which our reader hides by design.
+        @Test func createdArchiveKeepsExtendedAttributes() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let file = dir.appendingPathComponent("tagged.txt")
+            try "contents".write(to: file, atomically: true, encoding: .utf8)
+
+            // A Finder tag and a Finder comment are ordinary extended attributes
+            // under long names — nothing about them is special to the format, so
+            // storing them is storing any attribute. They are named here because
+            // they are what a user would notice missing.
+            let attributes: [String: Data] = [
+                "com.apple.metadata:_kMDItemUserTags": Data("bplist-stand-in-tags".utf8),
+                "com.apple.metadata:kMDItemFinderComment": Data("a comment".utf8),
+                "com.apple.ResourceFork": Data("RESOURCE-FORK-PAYLOAD".utf8),
+                "com.macpacker.test": Data("arbitrary".utf8),
+            ]
+            for (name, value) in attributes {
+                setExtendedAttribute(name, value, at: file)
+            }
+
+            let dest = dir.appendingPathComponent("created.zip")
+            try SevenZipArchive.writeArchive(
+                destination: dest,
+                items: [.addFile(archivePath: "tagged.txt", diskPath: file)],
+                options: .init(format: .zip)
+            )
+
+            #expect(try systemZipList(dest).contains("__MACOSX/._tagged.txt"),
+                    "the archive should carry a sidecar for a file that has metadata")
+            try run("/usr/bin/unzip", ["-t", dest.path])
+
+            let out = dir.appendingPathComponent("out")
+            try await extractWithOurEngine(dest, to: out)
+
+            let extracted = out.appendingPathComponent("tagged.txt")
+            for (name, value) in attributes {
+                #expect(extendedAttribute(name, at: extracted) == value,
+                        "\(name) should survive the round trip")
+            }
+            #expect(try String(contentsOf: extracted, encoding: .utf8) == "contents",
+                    "the data fork must come through untouched")
+            #expect(FileManager.default.fileExists(
+                atPath: out.appendingPathComponent("__MACOSX").path) == false,
+                    "the sidecar tree is metadata, not files, and must not survive extraction")
+        }
+
+        // Issue #216: a folder with a custom picture came out of MacPacker with a
+        // visible `Icon?` file and a generic folder. Three separate pieces of
+        // metadata make that icon and all three have to be stored — including the
+        // flag on the folder itself, which `ditto` does not write, and which is
+        // why a round trip through Finder's "Compress" loses the icon too.
+        //
+        // Driven through ArchiveState rather than the writer directly: adding a
+        // folder is what a user does, and the folder's own URL reaching the entry
+        // is the part that was missing.
+        @Test func createdArchiveKeepsACustomFolderIcon() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let fork = Data("ICNS-STAND-IN".utf8)
+            let folder = dir.appendingPathComponent("CustomFolder")
+            try makeFolderWithCustomIcon(at: folder, fork: fork)
+            try "a folder is more than its icon".write(
+                to: folder.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+
+            let state = makeState()
+            state.create()
+            state.add(url: folder)
+
+            let dest = dir.appendingPathComponent("created.zip")
+            let saveTask = try #require(state.save(to: dest))
+            await saveTask.value
+            #expect(state.error == nil)
+
+            let listed = try systemZipList(dest)
+            #expect(listed.contains("__MACOSX/._CustomFolder"),
+                    "the folder's own metadata carries the custom-icon flag: \(listed)")
+            #expect(listed.contains(
+                        infoZipListingName("__MACOSX/CustomFolder/._\(customIconFileName)")),
+                    "the icon file's metadata carries the picture: \(listed)")
+
+            let out = dir.appendingPathComponent("out")
+            try await extractWithOurEngine(dest, to: out)
+
+            let extractedFolder = out.appendingPathComponent("CustomFolder")
+            let extractedIcon = extractedFolder.appendingPathComponent(customIconFileName)
+
+            #expect(finderFlags(at: extractedFolder) == FinderFlag.hasCustomIcon,
+                    "without this flag Finder never looks for the icon file")
+            #expect(finderFlags(at: extractedIcon) == FinderFlag.invisible,
+                    "without this flag the icon file shows up as `Icon?` — the reported symptom")
+            #expect(extendedAttribute("com.apple.ResourceFork", at: extractedIcon) == fork,
+                    "the picture itself lives in the icon file's resource fork")
+        }
+
+        // The write path used to `stat` what it was given and open it as a file,
+        // so a symlink went into the archive as a full copy of whatever it pointed
+        // at. Inside a framework or an .app the version symlinks are what hold the
+        // bundle together, and extraction has restored links since #121 — so this
+        // was the one direction that still flattened them.
+        @Test func createdArchiveStoresSymlinksAsLinks() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let target = dir.appendingPathComponent("target.txt")
+            try "the real file".write(to: target, atomically: true, encoding: .utf8)
+            let link = dir.appendingPathComponent("link.txt")
+            // By path, not by URL: a URL destination is resolved against the
+            // working directory, which would make the link absolute and stop it
+            // saying anything about what the archive stored.
+            try FileManager.default.createSymbolicLink(
+                atPath: link.path, withDestinationPath: "target.txt")
+
+            let dest = dir.appendingPathComponent("created.zip")
+            try SevenZipArchive.writeArchive(
+                destination: dest,
+                items: [
+                    .addFile(archivePath: "target.txt", diskPath: target),
+                    .addFile(archivePath: "link.txt", diskPath: link),
+                ],
+                options: .init(format: .zip)
+            )
+            try run("/usr/bin/unzip", ["-t", dest.path])
+
+            let out = dir.appendingPathComponent("out")
+            try await extractWithOurEngine(dest, to: out)
+
+            let extractedLink = out.appendingPathComponent("link.txt")
+            let destination = try? FileManager.default.destinationOfSymbolicLink(
+                atPath: extractedLink.path)
+            #expect(destination == "target.txt",
+                    "link.txt should come back a symlink, got \(String(describing: destination))")
+        }
+
+        // Every file would get a sidecar otherwise: `copyfile` packs a header and
+        // an empty FinderInfo whether or not there was anything to say, so a naive
+        // implementation roughly doubles the entry count of every archive anyone
+        // ever makes, to store nothing.
+        @Test func createdArchiveAddsNoSidecarForOrdinaryFiles() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let file = dir.appendingPathComponent("plain.txt")
+            try "nothing special".write(to: file, atomically: true, encoding: .utf8)
+            let folder = dir.appendingPathComponent("plainfolder")
+            try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+            let state = makeState()
+            state.create()
+            state.add(url: file)
+            state.add(url: folder)
+
+            let dest = dir.appendingPathComponent("created.zip")
+            let saveTask = try #require(state.save(to: dest))
+            await saveTask.value
+            #expect(state.error == nil)
+
+            let listed = try systemZipEntries(dest)
+            #expect(listed.contains { $0.hasPrefix("__MACOSX") } == false,
+                    "nothing here has metadata worth storing: \(listed)")
         }
     }
 }

--- a/Modules/Tests/CoreTests/ZipWriteTests.swift
+++ b/Modules/Tests/CoreTests/ZipWriteTests.swift
@@ -658,6 +658,18 @@ extension AllCoreTests {
                     "without this flag the icon file shows up as `Icon?` — the reported symptom")
             #expect(extendedAttribute("com.apple.ResourceFork", at: extractedIcon) == fork,
                     "the picture itself lives in the icon file's resource fork")
+
+            // A folder entry carries a date like any other. Nothing stored one, so
+            // every folder in an archive MacPacker made came out stamped 1980 —
+            // the zip epoch, which is what "no date" looks like on the way back.
+            let sourceDate = try #require(
+                folder.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate)
+            let extractedDate = try #require(
+                extractedFolder.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate)
+            #expect(abs(extractedDate.timeIntervalSince(sourceDate)) < 2,
+                    "the folder should keep its own date, got \(extractedDate)")
         }
 
         // The write path used to `stat` what it was given and open it as a file,

--- a/Modules/Tests/CoreTests/ZipWriteTests.swift
+++ b/Modules/Tests/CoreTests/ZipWriteTests.swift
@@ -699,6 +699,39 @@ extension AllCoreTests {
                     "link.txt should come back a symlink, got \(String(describing: destination))")
         }
 
+        // Metadata that cannot be read is not metadata that is not there, and the
+        // difference matters: silently writing the archive without it is exactly
+        // the bug this whole change fixes, arrived at from another direction. The
+        // sandbox makes this concrete — without a security-scoped grant `listxattr`
+        // fails with EACCES, and a swallowed error there would drop a folder's
+        // custom icon with nobody the wiser.
+        //
+        // A folder is the subject rather than a file because it isolates the
+        // metadata path: a directory entry stores no contents, so nothing else in
+        // the write can fail first and pass the test for the wrong reason.
+        @Test func createdArchiveReportsMetadataItCouldNotRead() async throws {
+            let dir = try makeTempDir()
+            let folder = dir.appendingPathComponent("Unreadable")
+            try makeFolderWithCustomIcon(at: folder, fork: Data("ICNS-STAND-IN".utf8))
+
+            // Restored before the directory is removed, or the cleanup cannot
+            // descend into it either.
+            defer {
+                chmod(folder.path, 0o755)
+                try? FileManager.default.removeItem(at: dir)
+            }
+            #expect(chmod(folder.path, 0o000) == 0, "could not make the folder unreadable")
+
+            let dest = dir.appendingPathComponent("created.zip")
+            #expect(throws: (any Error).self) {
+                try SevenZipArchive.writeArchive(
+                    destination: dest,
+                    items: [.addDirectory(archivePath: "Unreadable", diskPath: folder)],
+                    options: .init(format: .zip)
+                )
+            }
+        }
+
         // Every file would get a sidecar otherwise: `copyfile` packs a header and
         // an empty FinderInfo whether or not there was anything to say, so a naive
         // implementation roughly doubles the entry count of every archive anyone

--- a/Modules/Tests/CoreTests/ZipWriteTests.swift
+++ b/Modules/Tests/CoreTests/ZipWriteTests.swift
@@ -699,6 +699,64 @@ extension AllCoreTests {
                     "link.txt should come back a symlink, got \(String(describing: destination))")
         }
 
+        // Extracting into a folder that already exists writes files into it, and
+        // that legitimately changes its date — every tool on the platform does the
+        // same. Reverting it would hide a modification the user can see.
+        //
+        // The archive is built here rather than taken from the corpus because the
+        // hazard is an archive whose dates are close to the present: a fixture
+        // stamped in 2026 cannot express it. Told apart by proximity to the
+        // archive's date, a folder bumped a moment after that archive was made
+        // looks exactly like one that was overwritten.
+        @Test(arguments: ZipReader.allCases)
+        func extractionDoesNotRevertAFolderItWroteInto(reader: ZipReader) async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let fm = FileManager.default
+
+            let source = dir.appendingPathComponent("src/Shared")
+            try fm.createDirectory(at: source, withIntermediateDirectories: true)
+            try "arrived".write(to: source.appendingPathComponent("note.txt"),
+                                atomically: true, encoding: .utf8)
+
+            // Written now, so every entry date sits within seconds of the
+            // extraction that follows.
+            let archive = dir.appendingPathComponent("fresh.zip")
+            try SevenZipArchive.writeArchive(
+                destination: archive,
+                items: [
+                    .addDirectory(archivePath: "Shared", diskPath: source),
+                    .addFile(archivePath: "Shared/note.txt",
+                             diskPath: source.appendingPathComponent("note.txt")),
+                ],
+                options: .init(format: .zip)
+            )
+
+            // The user's own folder, of an age nothing in the archive resembles.
+            let destination = dir.appendingPathComponent("out")
+            let planted = destination.appendingPathComponent("Shared")
+            try fm.createDirectory(at: planted, withIntermediateDirectories: true)
+            let plantedDate = Date(timeIntervalSince1970: 1_577_836_800)  // 2020-01-01
+            try fm.setAttributes([.modificationDate: plantedDate], ofItemAtPath: planted.path)
+
+            let engine = reader.engine
+            let loaded = try await engine.loadArchive(url: archive, passwordResolver: { _ in nil })
+            _ = try await engine.extract(
+                items: Array(loaded.items.values), from: archive,
+                to: destination, passwordResolver: { _ in nil })
+
+            #expect(fm.fileExists(atPath: planted.appendingPathComponent("note.txt").path),
+                    "the extraction should have written into the folder")
+
+            let onDisk = try #require(
+                planted.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate)
+            #expect(
+                onDisk.timeIntervalSince(plantedDate) > 60,
+                "a file was written into this folder, so its date must move — got \(onDisk)"
+            )
+        }
+
         // Metadata that cannot be read is not metadata that is not there, and the
         // difference matters: silently writing the archive without it is exactly
         // the bug this whole change fixes, arrived at from another direction. The

--- a/Modules/Tests/CoreTests/ZipWriteTests.swift
+++ b/Modules/Tests/CoreTests/ZipWriteTests.swift
@@ -757,6 +757,73 @@ extension AllCoreTests {
             )
         }
 
+        // A directory's own date changes when something is created directly in it,
+        // and not when something is created further down: adding a file to `a/b`
+        // moves `b` and leaves `a` exactly as it was. So "this extraction wrote
+        // somewhere below here" is the wrong question to ask about `a` — it has to
+        // be "did this extraction create anything directly in it".
+        //
+        // Both folders are planted, so neither is ours, and only the deeper one
+        // receives a file.
+        @Test(arguments: ZipReader.allCases)
+        func extractionLeavesAnUntouchedParentFolderAlone(reader: ZipReader) async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let fm = FileManager.default
+
+            let source = dir.appendingPathComponent("src/Outer/Inner")
+            try fm.createDirectory(at: source, withIntermediateDirectories: true)
+            try "arrived".write(to: source.appendingPathComponent("note.txt"),
+                                atomically: true, encoding: .utf8)
+
+            let archive = dir.appendingPathComponent("nested.zip")
+            try SevenZipArchive.writeArchive(
+                destination: archive,
+                items: [
+                    .addDirectory(archivePath: "Outer",
+                                  diskPath: source.deletingLastPathComponent()),
+                    .addDirectory(archivePath: "Outer/Inner", diskPath: source),
+                    .addFile(archivePath: "Outer/Inner/note.txt",
+                             diskPath: source.appendingPathComponent("note.txt")),
+                ],
+                options: .init(format: .zip)
+            )
+
+            // Both already the user's, and of an age nothing in the archive shares.
+            let destination = dir.appendingPathComponent("out")
+            let outer = destination.appendingPathComponent("Outer")
+            let inner = outer.appendingPathComponent("Inner")
+            try fm.createDirectory(at: inner, withIntermediateDirectories: true)
+            let planted = Date(timeIntervalSince1970: 1_577_836_800)  // 2020-01-01
+            for folder in [inner, outer] {
+                try fm.setAttributes([.modificationDate: planted], ofItemAtPath: folder.path)
+            }
+
+            let engine = reader.engine
+            let loaded = try await engine.loadArchive(url: archive, passwordResolver: { _ in nil })
+            _ = try await engine.extract(
+                items: Array(loaded.items.values), from: archive,
+                to: destination, passwordResolver: { _ in nil })
+
+            try #require(fm.fileExists(atPath: inner.appendingPathComponent("note.txt").path))
+
+            let outerDate = try #require(
+                outer.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate)
+            let innerDate = try #require(
+                inner.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate)
+
+            #expect(
+                abs(outerDate.timeIntervalSince(planted)) < 2,
+                "nothing was created directly in Outer, so its date must not move — got \(outerDate)"
+            )
+            #expect(
+                innerDate.timeIntervalSince(planted) > 60,
+                "note.txt was created in Inner, so its date must move — got \(innerDate)"
+            )
+        }
+
         // Metadata that cannot be read is not metadata that is not there, and the
         // difference matters: silently writing the archive without it is exactly
         // the bug this whole change fixes, arrived at from another direction. The


### PR DESCRIPTION
A zip has nowhere to keep a resource fork or an extended attribute, so every Mac archiver stores them as a second entry per file in AppleDouble format. MacPacker has read those back since #189 but never wrote any, so anything added through MacPacker came out stripped — Finder tags gone, comments gone, custom icons gone. And nothing ever applied the date an archive carries, so everything extracted came out stamped with the moment of extraction.

## What changed

**Creating an archive** now stores what macOS keeps outside a file's contents, as the `__MACOSX/` companion entries Finder itself writes.

Directories get one too, and that is the half that closes #216. A folder's custom picture is a resource fork in a hidden `Icon\r` file *plus* `kHasCustomIcon` on the folder — restoring only the file leaves the folder generic.

Two attributes must not travel, and `copyfile` packs everything it is handed, so the metadata is copied onto a stand-in and that is packed instead:

| attribute | why it stays behind |
| --- | --- |
| `com.apple.quarantine` | Gatekeeper's verdict on where *this copy* came from. Storing it puts the machine's browsing history into every archive, and hands the extracting side a claim the archive was never entitled to make — the same argument the read path already makes for refusing to apply one. |
| `com.apple.TextEncoding` | written by Cocoa on every text file it saves. Without dropping it, every `.txt` in every archive gains a second entry to say it is UTF-8. |

A companion that would carry nothing is skipped — compared against a freshly packed empty sample rather than a hard-coded length, so a change in what `copyfile` emits shows up as companions that are kept, never as metadata quietly thrown away.

**Symlinks are stored as links.** The write path used to `stat` its input and open it as a file, so a link went in as a copy of its target — and inside a framework the version symlinks are what hold the bundle together. Extraction has restored links since #121; this was the one direction still flattening them.

**Extracting** now restores file and folder dates. Folder dates go on last of all: writing a file into a directory bumps its modification time again, and so does removing a companion from it.

XADMaster restores file dates but leaves directories at the moment of extraction, so the XAD engine puts those right itself once every entry has landed. Both engines reach the same result and the tests hold them to it.

## Measured against the platform

Behaviour was checked against the tools a Mac user actually has, not assumed.

Dates on extraction — `unzip`, `ditto`, `tar`, Keka and The Unarchiver all restore the original, for files and folders alike. MacPacker was the only outlier.

Custom folder icons — Finder's "Compress" of such a folder produces the folder's entry plus its companion at the root of the `__MACOSX/` mirror, which is exactly the shape this PR writes. An archive MacPacker creates now extracts through **The Unarchiver** with no error, the folder flag restored and `Icon\r` back and hidden with its resource fork; the rendered folder icon is identical to the original, compared through `NSWorkspace.icon(forFile:)`.

Worth recording, since it cost time: XADMaster refuses an archive whose folder companion describes a directory the archive never declares, abandoning the whole extraction with `xadError(11)`. Finder always writes that directory entry and so does MacPacker, so it does not arise in practice — but the fixture originally lacked it, which briefly made this look like a limitation of The Unarchiver. It is not.

Also worth recording: Keka, on this machine and with forks enabled either way, stores no Mac extras at all when compressing to zip, so a custom-icon folder round-trips through Keka to a visible `Icon` file and a generic folder.

## Tests

426 pass. New:

| test | |
| --- | --- |
| `createdArchiveKeepsExtendedAttributes` | tags, comment, resource fork and an arbitrary attribute survive a round trip |
| `createdArchiveKeepsACustomFolderIcon` | driven through `ArchiveState`, the way a user adds a folder |
| `createdArchiveStoresSymlinksAsLinks` | |
| `createdArchiveAddsNoSidecarForOrdinaryFiles` | no entry-count explosion |
| `extractionRestoresModificationDates` | both engines. `defaultArchive.zip`, whose entries do not share a date, so one stamp applied to everything cannot pass |
| `extractionRestoresACustomFolderIcon` | both engines, `customicon.zip` |
| `extractionRestoresFinderTagsAndComments` | both engines, `macextras.zip` |

The xattr and FinderInfo helpers move out of `EngineTests` into `Base/MacMetadata.swift`, since both halves of the round trip now need them.

Fixtures come from MacPacker-TestArchives#7; the submodule pointer moves with this PR.

Closes #216
Closes #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - macOS file and folder metadata—including Finder tags, comments, resource forks, and custom icons—is preserved during archiving and extraction.
  - File and folder modification dates are preserved during extraction.
  - Symbolic links are stored and restored as links rather than copies of their targets.

- **Bug Fixes**
  - Existing directory dates are preserved when extracting contents.
  - Metadata archiving errors are now reported instead of silently omitted.
  - Improved handling and cleanup of Mac-specific metadata.

- **Documentation**
  - Added a changelog entry documenting the Mac metadata archiving fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->