### PR TITLE
fix: send only the files of a mixed selection to Open and Extract (#240)

### DIFF
--- a/FinderExtension/FinderSync.swift
+++ b/FinderExtension/FinderSync.swift
@@ -270,8 +270,13 @@ class FinderSync: FIFinderSync {
             log.error("MacPackerURLScheme missing from the extension's Info.plist — cannot reach the main app")
         }
 
-        guard let items = FIFinderSyncController.default().selectedItemURLs() else {
+        guard let selection = FIFinderSyncController.default().selectedItemURLs() else {
             log.error("No items selected for action '\(action)'")
+            return
+        }
+        let items = item.items(from: selection, isDirectory: isDirectory)
+        guard !items.isEmpty else {
+            log.error("Nothing in the selection for action '\(action)'")
             return
         }
         guard let target = FIFinderSyncController.default().targetedURL() else {

--- a/Modules/Sources/FinderMenu/FinderMenuItem.swift
+++ b/Modules/Sources/FinderMenu/FinderMenuItem.swift
@@ -73,6 +73,24 @@ public enum FinderMenuItem: String, CaseIterable, Sendable {
         }
     }
 
+    /// Whether the entry works on archives, which are files.
+    public var actsOnArchives: Bool {
+        switch self {
+        case .open, .extractHere, .extractToFolder, .extractToChosenFolder:
+            true
+        case .addToArchive, .compressToZip, .compressToDatedZip, .compressTo7z,
+             .compressEachSeparately, .compressFolderContents:
+            false
+        }
+    }
+
+    /// The part of a Finder selection this entry sends to the app: archive
+    /// entries leave out the folders of a mixed selection, the compress entries
+    /// take all of it.
+    public func items(from selection: [URL], isDirectory: (URL) -> Bool) -> [URL] {
+        actsOnArchives ? selection.filter { !isDirectory($0) } : selection
+    }
+
     /// What this item asks the main app to do.
     public var action: AppUrlAction {
         switch self {

--- a/Modules/Tests/CoreTests/FinderMenuSettingsTests.swift
+++ b/Modules/Tests/CoreTests/FinderMenuSettingsTests.swift
@@ -104,6 +104,22 @@ extension AllCoreTests {
             }
         }
 
+        @Test("Archive entries send only the files of a mixed selection; compress entries send all of it")
+        func mixedSelection() {
+            let archive = URL(fileURLWithPath: "/Users/me/a.zip")
+            let folder = URL(fileURLWithPath: "/Users/me/photos")
+            let other = URL(fileURLWithPath: "/Users/me/b.7z")
+            let selection = [archive, folder, other]
+            let isDirectory: (URL) -> Bool = { $0 == folder }
+
+            for item in [FinderMenuItem.open, .extractHere, .extractToFolder, .extractToChosenFolder] {
+                #expect(item.items(from: selection, isDirectory: isDirectory) == [archive, other])
+            }
+            for item in [FinderMenuItem.addToArchive, .compressToZip, .compressToDatedZip, .compressTo7z, .compressEachSeparately] {
+                #expect(item.items(from: selection, isDirectory: isDirectory) == selection)
+            }
+        }
+
         @Test("Only the compress entries name an output format")
         func onlyCompressItemsCarryAnExtension() {
             #expect(FinderMenuItem.compressToZip.archiveExtension == "zip")


### PR DESCRIPTION
With a file and a folder selected in Finder, Open and the Extract entries also sent the folder to the app, which then treated it as an archive (seen in v1.0.0-beta.7).

- `FinderMenuItem` now knows which entries act on archives, and `items(from:isDirectory:)` returns the part of a selection each entry sends: archive entries leave the folders out, the compress entries keep all of it.
- The Finder extension sends only that part, and sends nothing if nothing is left.

## Testing

- New `mixedSelection` test: the four archive entries send only the two files of a file–folder–file selection, and the compress entries send all three. It failed against the old behaviour before the fix.
- `swift test`: 449 tests pass; the app builds.

No changelog line: the Finder options are still unreleased in the 1.0.0 block, so the final release never has this bug.

Closes #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archive-related Finder actions now ignore selected folders and process only applicable files.
  * Compression actions continue to include all selected files and folders.
  * Actions now handle unavailable or empty selections without attempting to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->