### PR TITLE
fix: Save As writes the chosen format and compression (#242)

### DIFF
--- a/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
+++ b/Modules/Sources/CSevenZip/include/sevenzip_bridge.h
@@ -42,6 +42,12 @@ int32_t sz_entry_count(SZArchiveRef archive);
 /// metadata for something it no longer holds.
 int32_t sz_sidecar_target(SZArchiveRef archive, uint32_t index);
 
+/// The path `index` is stored under, UTF-8, for every entry -- including the
+/// AppleDouble sidecars and `__MACOSX/` mirror entries that `sz_get_entry`
+/// leaves out of the listing. NULL when there is none. Lives as long as the
+/// archive handle.
+const char *sz_entry_path(SZArchiveRef archive, uint32_t index);
+
 typedef struct {
     uint32_t index;
     const char *path;        // UTF-8; pointer valid until sz_close()

--- a/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
+++ b/Modules/Sources/CSevenZip/sevenzip_bridge.cpp
@@ -1220,6 +1220,21 @@ int32_t sz_sidecar_target(SZArchiveRef archive, uint32_t index) {
     return -1;
 }
 
+const char *sz_entry_path(SZArchiveRef archive, uint32_t index) {
+    if (!archive) return nullptr;
+    try {
+        auto *handle = static_cast<SZArchiveHandle *>(archive);
+        if (index >= handle->numItems) return nullptr;
+        NWindows::NCOM::CPropVariant prop;
+        if (handle->activeArchive()->GetProperty(index, kpidPath, &prop) != S_OK
+            || prop.vt != VT_BSTR || !prop.bstrVal)
+            return nullptr;
+        return handle->storeString(UStringToUTF8(UString(prop.bstrVal)));
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 bool sz_get_entry(SZArchiveRef archive, uint32_t index, SZEntry *entry_out) {
     if (!archive || !entry_out) return false;
     try {

--- a/Modules/Sources/Swift7zip/SevenZipWriter.swift
+++ b/Modules/Sources/Swift7zip/SevenZipWriter.swift
@@ -14,7 +14,11 @@ extension SevenZipArchive {
     /// variants are valid (there are no source entries to remove or move).
     ///
     /// If `source` and `destination` are the same URL, the archive
-    /// is written to a temporary file and atomically replaced.
+    /// is written to a temporary file and atomically replaced. If they
+    /// differ (Save As), the archive is written again from its contents,
+    /// so every entry takes `options` and the result is in their format —
+    /// except for an encrypted source, which is copied as it is and cannot
+    /// change format until a password can be given.
     ///
     /// - Parameters:
     ///   - source: URL of the source archive, or `nil` to create new.
@@ -47,26 +51,56 @@ extension SevenZipArchive {
             actualDest = destination
         }
 
-        // Resolve the diff into a full item list for the C bridge.
-        var resolved = try resolveDiff(source: source, items: items)
-
         // Everything macOS keeps outside a file's contents travels as an extra
         // entry per file, packed into a scratch directory that lives exactly as
-        // long as this write does.
+        // long as this write does. A Save As extracts the source into it too.
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         // Not `try?`: one failed directory would silently turn the whole of the
         // above into a no-op, and the archive would come out stripped.
         try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
+
+        // A Save As writes the archive again from its contents: an update copies
+        // what it keeps byte for byte, in the source's format and with its old
+        // method, whatever `options` say. Not for an encrypted source yet — with
+        // no password to give the copy, a rebuild would write it out in plain.
+        var resolved: [ResolvedItem]
+        let rebuild: Bool
+        do {
+            // scoped, so the handle is closed again before anything is written
+            let sourceArchive = try source.map { try SevenZipArchive(url: $0) }
+            let encrypted = try sourceArchive?.entries.contains(where: \.isEncrypted) ?? false
+            if let source, !inPlace, encrypted, writableFormat(of: source) != options.format {
+                throw SevenZipError.writeFailed(
+                    "An encrypted archive can't be saved as \(options.format.rawValue) yet: it would lose its encryption")
+            }
+            rebuild = sourceArchive != nil && !inPlace && !encrypted
+
+            // Resolve the diff into a full item list for the C bridge.
+            resolved = try resolveDiff(sourceArchive: sourceArchive, items: items)
+            if rebuild, let sourceArchive {
+                // extracting is the first half of the work, writing the second
+                let firstHalf = progress.map { report in
+                    { (done: UInt64, total: UInt64) in report(done, total * 2) }
+                }
+                resolved = try materializeKeptEntries(
+                    resolved, from: sourceArchive, into: scratch, progress: firstHalf)
+            }
+        }
         resolved.append(contentsOf: try metadataSidecars(for: resolved, scratch: scratch))
 
+        let writeProgress = rebuild
+            ? progress.map { report in
+                { (done: UInt64, total: UInt64) in report(total + done, total * 2) }
+            }
+            : progress
         try performUpdate(
-            source: source,
+            source: rebuild ? nil : source,
             destination: actualDest,
             resolvedItems: resolved,
             options: options,
-            progress: progress
+            progress: writeProgress
         )
 
         if inPlace {
@@ -97,7 +131,7 @@ extension SevenZipArchive {
     /// Resolves a user-facing diff into the full list the C bridge expects.
     /// All source entries are kept unless explicitly removed or moved.
     private static func resolveDiff(
-        source: URL?,
+        sourceArchive: SevenZipArchive?,
         items: [ArchiveUpdateItem]
     ) throws -> [ResolvedItem] {
         // Collect removals and moves from the diff.
@@ -129,8 +163,7 @@ extension SevenZipArchive {
         var result: [ResolvedItem] = []
 
         // Build keeps/moves from source entries.
-        if let source {
-            let archive = try SevenZipArchive(url: source)
+        if let archive = sourceArchive {
             let entryCount = sz_entry_count(archive.handle.ref)
             guard entryCount >= 0 else {
                 throw SevenZipError.writeFailed(
@@ -155,6 +188,134 @@ extension SevenZipArchive {
 
         result.append(contentsOf: additions)
         return result
+    }
+
+    // MARK: - Save As
+
+    /// Turns every entry kept from the source into an addition read back from a
+    /// scratch extraction, for a Save As that writes the archive again.
+    ///
+    /// Extraction folds each file's AppleDouble sidecar back onto it, and the
+    /// additions then get fresh sidecars from what landed on disk — the same way
+    /// the metadata travels for files added from Finder.
+    private static func materializeKeptEntries(
+        _ items: [ResolvedItem],
+        from archive: SevenZipArchive,
+        into scratch: URL,
+        progress: SevenZipArchive.ProgressHandler?
+    ) throws -> [ResolvedItem] {
+        let fm = FileManager.default
+        var byIndex: [UInt32: SevenZipEntry] = [:]
+        for entry in try archive.entries { byIndex[entry.index] = entry }
+
+        // Kept and moved entries in source order, with the path each one gets.
+        // Hidden ones (AppleDouble sidecars, the `__MACOSX/` mirror) have no entry
+        // of their own: extracting what they describe brings them along.
+        var kept: [(entry: SevenZipEntry, path: String)] = []
+        var hidden: [UInt32] = []
+        var additions: [ResolvedItem] = []
+        for item in items {
+            switch item {
+            case .keep(let index):
+                if let entry = byIndex[index] { kept.append((entry, entry.path)) } else { hidden.append(index) }
+            case .move(let index, let path):
+                if let entry = byIndex[index] { kept.append((entry, path)) } else { hidden.append(index) }
+            default:
+                additions.append(item)
+            }
+        }
+
+        // The scratch disk ignores case and Unicode normalization; archive names
+        // don't, so "Readme.txt" and "README.txt" would land on one file. Entries
+        // that collide are extracted one by one, each into a folder of its own.
+        var firstWithName: [String: UInt32] = [:]
+        var loners: Set<UInt32> = []
+        for (entry, _) in kept where !entry.isDirectory {
+            let key = entry.path.precomposedStringWithCanonicalMapping.lowercased()
+            if let first = firstWithName[key] {
+                loners.formUnion([first, entry.index])
+            } else {
+                firstWithName[key] = entry.index
+            }
+        }
+
+        let shared = scratch.appendingPathComponent("rebuild")
+        try fm.createDirectory(at: shared, withIntermediateDirectories: true)
+        let together = kept.map(\.entry.index).filter { !loners.contains($0) }.sorted()
+        var onDisk = try archive.extract(indices: together, to: shared, progress: progress)
+        for index in loners.sorted() {
+            let own = scratch.appendingPathComponent("rebuild-\(index)")
+            try fm.createDirectory(at: own, withIntermediateDirectories: true)
+            onDisk.merge(try archive.extract(index: index, to: own)) { _, new in new }
+        }
+
+        var rebuilt: [ResolvedItem] = []
+        for (entry, path) in kept {
+            // A missing file is a lost entry, so the save fails rather than drop it.
+            guard let disk = onDisk[entry.index],
+                  (try? fm.attributesOfItem(atPath: disk.path)) != nil else {
+                throw SevenZipError.writeFailed("\(entry.path) could not be read back from the archive")
+            }
+            if entry.isDirectory {
+                rebuilt.append(.addDirectory(
+                    archivePath: path, diskPath: disk,
+                    modificationDate: entry.modificationDate,
+                    posixPermissions: entry.posixPermissions.map { 0o040000 | $0 }))
+            } else {
+                // No mode given: the bridge reads it off the extracted file. A
+                // symlink's mode alone would store the link as an ordinary file.
+                rebuilt.append(.addFile(
+                    archivePath: path, diskPath: disk,
+                    modificationDate: entry.modificationDate,
+                    posixPermissions: nil))
+            }
+        }
+
+        // A hidden entry still on disk afterwards was named like a sidecar without
+        // being one, so folding it failed and it came out as itself. Looked up by
+        // its stored path: the listing leaves it out, and so do Foundation's
+        // directory listings whenever a `._name` stands beside `name`.
+        for index in hidden {
+            guard let stored = sz_entry_path(archive.handle.ref, index) else { continue }
+            // sanitized the way the extraction does: no empty, "." or ".." parts
+            let relative = String(cString: stored).split(separator: "/")
+                .filter { $0 != "." && $0 != ".." }.joined(separator: "/")
+            let file = shared.appendingPathComponent(relative)
+            guard !relative.isEmpty,
+                  let attributes = try? fm.attributesOfItem(atPath: file.path),
+                  attributes[.type] as? FileAttributeType != .typeDirectory else { continue }
+            rebuilt.append(.addFile(
+                archivePath: relative, diskPath: file,
+                modificationDate: nil, posixPermissions: nil))
+        }
+
+        // A folder the archive only implies still gets its sidecar folded onto it,
+        // and with no entry of its own it would drop that metadata here.
+        let listedFolders = Set(kept.filter(\.entry.isDirectory).map {
+            $0.entry.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        })
+        for relative in fm.subpaths(atPath: shared.path) ?? [] where !listedFolders.contains(relative) {
+            let folder = shared.appendingPathComponent(relative)
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: folder.path, isDirectory: &isDirectory), isDirectory.boolValue,
+                  try attributeNames(of: folder).contains(where: { !systemOwnedAttributes.contains($0) })
+            else { continue }
+            rebuilt.append(.addDirectory(
+                archivePath: relative, diskPath: folder,
+                modificationDate: nil, posixPermissions: nil))
+        }
+
+        return rebuilt + additions
+    }
+
+    /// The writable format a file is in, by its signature.
+    private static func writableFormat(of url: URL) -> SevenZipCompressionOptions.Format? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        let head = (try? handle.read(upToCount: 6)) ?? Data()
+        if head.starts(with: [0x50, 0x4B]) { return .zip }
+        if head.starts(with: [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C]) { return .sevenZ }
+        return nil
     }
 
     // MARK: - macOS Metadata

--- a/Modules/Tests/CoreTests/ZipWriteTests.swift
+++ b/Modules/Tests/CoreTests/ZipWriteTests.swift
@@ -229,7 +229,8 @@ extension AllCoreTests {
             try SevenZipArchive.writeArchive(
                 source: zip,
                 destination: dest,
-                items: [.move(sourceIndex: orig.index, newPath: "renamed.txt")]
+                items: [.move(sourceIndex: orig.index, newPath: "renamed.txt")],
+                options: .init(format: .zip)
             )
 
             // the renamed entry must still carry 0o750, not 000
@@ -895,6 +896,395 @@ extension AllCoreTests {
             let listed = try systemZipEntries(dest)
             #expect(listed.contains { $0.hasPrefix("__MACOSX") } == false,
                     "nothing here has metadata worth storing: \(listed)")
+        }
+    }
+}
+
+// MARK: - Save As rebuilds the archive
+
+/// What a file is by its first bytes: `zip`, `7z`, or the bytes in hex.
+private func archiveFormat(of url: URL) throws -> String {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+    let head = try handle.read(upToCount: 6) ?? Data()
+    if head.starts(with: [0x50, 0x4B, 0x03, 0x04]) { return "zip" }
+    if head.starts(with: [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C]) { return "7z" }
+    return head.map { String(format: "%02x", $0) }.joined(separator: " ")
+}
+
+/// Each entry's compression method as the independent `zipinfo` records it
+/// (`defN`, `lzma`, `stor`, …), by entry name.
+private func zipMethods(_ zip: URL) throws -> [String: String] {
+    var methods: [String: String] = [:]
+    for line in try run("/usr/bin/zipinfo", [zip.path]).split(separator: "\n") {
+        // entry lines: mode, version, host, size, flags, method, date, time, name
+        let fields = line.split(separator: " ")
+        guard fields.count >= 9, fields[1].contains(".") else { continue }
+        methods[String(fields[fields.count - 1])] = String(fields[5])
+    }
+    return methods
+}
+
+/// Extracts everything with the given engine.
+private func extractEverything(_ archive: URL, with reader: ZipReader, to out: URL) async throws {
+    let engine = reader.engine
+    let loaded = try await engine.loadArchive(url: archive, passwordResolver: { _ in nil })
+    try FileManager.default.createDirectory(at: out, withIntermediateDirectories: true)
+    _ = try await engine.extract(
+        items: Array(loaded.items.values), from: archive, to: out, passwordResolver: { _ in nil })
+}
+
+private func passwordFixture(_ name: String) -> URL {
+    Bundle.module.url(forResource: "password", withExtension: nil)!.appendingPathComponent(name)
+}
+
+extension AllCoreTests {
+    /// Save As to another file writes the archive again from its contents, in the
+    /// format and with the options it was asked for. An update copies what it
+    /// keeps byte for byte — right for Save, wrong here: a zip saved as 7z came out
+    /// a zip under a `.7z` name, and a Deflate zip saved with LZMA kept Deflate for
+    /// everything it already held.
+    struct SaveAsRebuildTests {
+
+        /// Big and repetitive enough that every method beats storing: 7-Zip stores an
+        /// entry its method would not shrink, and `zipinfo` then says `stor`.
+        private static let alpha = String(repeating: "alpha alpha alpha alpha\n", count: 200)
+        private static let bravo = String(repeating: "bravo bravo bravo bravo\n", count: 200)
+
+        /// a.txt, folder/b.txt and an empty folder, in the format's default method.
+        private func makeSource(_ format: SevenZipCompressionOptions.Format, in dir: URL) throws -> URL {
+            let source = dir.appendingPathComponent("source.\(format.rawValue)")
+            try SevenZipArchive.writeArchive(
+                destination: source,
+                items: [
+                    .addData(archivePath: "a.txt", data: Data(Self.alpha.utf8)),
+                    .addDirectory(archivePath: "folder"),
+                    .addData(archivePath: "folder/b.txt", data: Data(Self.bravo.utf8)),
+                    .addDirectory(archivePath: "empty"),
+                ],
+                options: .init(format: format)
+            )
+            return source
+        }
+
+        @Test(arguments: zip([SevenZipCompressionOptions.Format.zip, .sevenZ],
+                             [SevenZipCompressionOptions.Format.sevenZ, .zip]))
+        func saveAsWritesTheFormatItWasAskedFor(
+            from: SevenZipCompressionOptions.Format,
+            to: SevenZipCompressionOptions.Format
+        ) async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = try makeSource(from, in: dir)
+            let saved = dir.appendingPathComponent("saved.\(to.rawValue)")
+
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved, items: [], options: .init(format: to))
+
+            let format = try archiveFormat(of: saved)
+            #expect(format == to.rawValue, "saved as \(to.rawValue), but the file is \(format)")
+
+            // XAD shares no code with the writer, so its reading counts for more
+            for reader in ZipReader.allCases {
+                let out = dir.appendingPathComponent("out-\(reader.rawValue)")
+                try await extractEverything(saved, with: reader, to: out)
+                #expect(try String(contentsOf: out.appendingPathComponent("a.txt"), encoding: .utf8)
+                        == Self.alpha, "a.txt through \(reader)")
+                #expect(try String(contentsOf: out.appendingPathComponent("folder/b.txt"), encoding: .utf8)
+                        == Self.bravo, "folder/b.txt through \(reader)")
+            }
+            let paths = try SevenZipArchive(url: saved).entries
+                .filter(\.isDirectory)
+                .map { $0.path.trimmingCharacters(in: CharacterSet(charactersIn: "/")) }
+            #expect(paths.contains("empty"), "the empty folder must survive: \(paths)")
+        }
+
+        @Test func saveAsCompressesCarriedOverEntriesWithTheNewOptions() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = try makeSource(.zip, in: dir)
+            #expect(try zipMethods(source)["a.txt"] == "defN", "the source should start out Deflate")
+
+            let saved = dir.appendingPathComponent("saved.zip")
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved, items: [],
+                options: .init(format: .zip, level: 9, method: .lzma))
+
+            let methods = try zipMethods(saved)
+            for name in ["a.txt", "folder/b.txt"] {
+                #expect(methods[name] == "lzma",
+                        "\(name) came out \(methods[name] ?? "missing"): the new options never reached it")
+            }
+            let out = dir.appendingPathComponent("out")
+            try await extractEverything(saved, with: .xad, to: out)
+            #expect(try String(contentsOf: out.appendingPathComponent("folder/b.txt"), encoding: .utf8)
+                    == Self.bravo)
+        }
+
+        @Test(arguments: [SevenZipCompressionOptions.Format.zip, .sevenZ])
+        func saveAsKeepsWhatTheEntriesCarry(into format: SevenZipCompressionOptions.Format) async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let fm = FileManager.default
+            let files = dir.appendingPathComponent("files")
+            let dated = files.appendingPathComponent("dated")
+            try fm.createDirectory(at: dated, withIntermediateDirectories: true)
+
+            let script = files.appendingPathComponent("run.sh")
+            try "#!/bin/sh\necho hi\n".write(to: script, atomically: true, encoding: .utf8)
+            try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+            let target = files.appendingPathComponent("target.txt")
+            try "pointed at".write(to: target, atomically: true, encoding: .utf8)
+            let link = files.appendingPathComponent("link.txt")
+            try fm.createSymbolicLink(atPath: link.path, withDestinationPath: "target.txt")
+            let tagged = files.appendingPathComponent("tagged.txt")
+            try "tagged".write(to: tagged, atomically: true, encoding: .utf8)
+            setExtendedAttribute("com.macpacker.test", Data("kept".utf8), at: tagged)
+            // the folder's date goes on after the file inside it, which would bump it
+            let old = Date(timeIntervalSince1970: 1_577_836_800)  // 2020-01-01
+            let oldFile = dated.appendingPathComponent("old.txt")
+            try "old".write(to: oldFile, atomically: true, encoding: .utf8)
+            try fm.setAttributes([.modificationDate: old], ofItemAtPath: oldFile.path)
+            try fm.setAttributes([.modificationDate: old], ofItemAtPath: dated.path)
+
+            let source = dir.appendingPathComponent("source.zip")
+            try SevenZipArchive.writeArchive(
+                destination: source,
+                items: [
+                    .addFile(archivePath: "run.sh", diskPath: script),
+                    .addFile(archivePath: "target.txt", diskPath: target),
+                    .addFile(archivePath: "link.txt", diskPath: link),
+                    .addFile(archivePath: "tagged.txt", diskPath: tagged),
+                    .addDirectory(archivePath: "dated", diskPath: dated),
+                    .addFile(archivePath: "dated/old.txt", diskPath: oldFile),
+                ],
+                options: .init(format: .zip)
+            )
+
+            let saved = dir.appendingPathComponent("saved.\(format.rawValue)")
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved, items: [], options: .init(format: format))
+
+            let out = dir.appendingPathComponent("out")
+            try await extractWithOurEngine(saved, to: out)
+
+            // MacPacker's 7z reader only asks for kpidPosixAttrib, which the 7z
+            // handler does not report — the mode sits in kpidAttrib's high bits —
+            // so any 7z extracts without execute bits or links, however it was
+            // written. 7zz, below, shows the archive itself is right.
+            try withKnownIssue("7z extraction drops unix modes and symlinks") {
+                let mode = try fm.attributesOfItem(atPath: out.appendingPathComponent("run.sh").path)[.posixPermissions] as? Int
+                #expect(mode == 0o755, "the execute bit must survive, got \(String(mode ?? 0, radix: 8))")
+                #expect(try fm.destinationOfSymbolicLink(atPath: out.appendingPathComponent("link.txt").path)
+                        == "target.txt", "link.txt must stay a link")
+            } when: { format == .sevenZ }
+
+            if format == .sevenZ,
+               let sevenZip = ["/opt/homebrew/bin/7zz", "/usr/local/bin/7zz"].first(where: fm.isExecutableFile(atPath:)) {
+                let blocks = try run(sevenZip, ["l", "-slt", saved.path]).components(separatedBy: "\n\n")
+                func attributes(_ path: String) -> String {
+                    blocks.first { $0.contains("Path = \(path)\n") }?
+                        .components(separatedBy: "\n").first { $0.hasPrefix("Attributes = ") } ?? "none"
+                }
+                #expect(attributes("run.sh").hasSuffix("-rwxr-xr-x"), "7zz sees \(attributes("run.sh"))")
+                #expect(attributes("link.txt").contains("lrwx"), "7zz sees \(attributes("link.txt"))")
+            }
+            #expect(extendedAttribute("com.macpacker.test", at: out.appendingPathComponent("tagged.txt"))
+                    == Data("kept".utf8), "the Mac metadata must survive")
+            for path in ["dated/old.txt", "dated"] {
+                let date = try out.appendingPathComponent(path)
+                    .resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+                #expect(abs(date?.timeIntervalSince(old) ?? .infinity) <= 2,
+                        "\(path) should keep its 2020 date, got \(String(describing: date))")
+            }
+        }
+
+        @Test func saveAsAppliesPendingChanges() throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let a = dir.appendingPathComponent("a.txt")
+            let b = dir.appendingPathComponent("b.txt")
+            try "a".write(to: a, atomically: true, encoding: .utf8)
+            try "b".write(to: b, atomically: true, encoding: .utf8)
+            setExtendedAttribute("com.macpacker.test", Data("b's".utf8), at: b)
+            let source = dir.appendingPathComponent("source.zip")
+            try SevenZipArchive.writeArchive(
+                destination: source,
+                items: [
+                    .addFile(archivePath: "a.txt", diskPath: a),
+                    .addFile(archivePath: "b.txt", diskPath: b),
+                ],
+                options: .init(format: .zip)
+            )
+            #expect(try systemZipList(source).contains("__MACOSX/._b.txt"))
+
+            let bIndex = try #require(try SevenZipArchive(url: source).entries.first { $0.path == "b.txt" }?.index)
+            let saved = dir.appendingPathComponent("saved.zip")
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved,
+                items: [
+                    .remove(sourceIndex: bIndex),
+                    .addData(archivePath: "c.txt", data: Data("c".utf8)),
+                ],
+                options: .init(format: .zip, method: .lzma))
+
+            #expect(try systemZipEntries(saved).sorted() == ["a.txt", "c.txt"],
+                    "b.txt goes, and its sidecar goes with it")
+        }
+
+        // A real file named `._x.txt` beside `x.txt` is hidden from the listing like
+        // a sidecar would be, and extraction writes it out as itself — so a rebuild
+        // that only follows the listing would drop it.
+        @Test func saveAsKeepsAFileThatOnlyLooksLikeASidecar() throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = dir.appendingPathComponent("source.zip")
+            try SevenZipArchive.writeArchive(
+                destination: source,
+                items: [
+                    .addData(archivePath: "x.txt", data: Data("real".utf8)),
+                    .addData(archivePath: "._x.txt", data: Data("not AppleDouble, just a file".utf8)),
+                ],
+                options: .init(format: .zip)
+            )
+
+            let saved = dir.appendingPathComponent("saved.zip")
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved, items: [], options: .init(format: .zip, level: 9))
+
+            let listed = try systemZipList(saved)
+            #expect(listed.contains("x.txt") && listed.contains("._x.txt"), "\(listed)")
+            #expect(try run("/usr/bin/unzip", ["-p", saved.path, "._x.txt"]) == "not AppleDouble, just a file")
+        }
+
+        // The disk under the rebuild is case-insensitive; the archive is not.
+        @Test func saveAsKeepsNamesThatDifferOnlyInCase() throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = dir.appendingPathComponent("source.zip")
+            try SevenZipArchive.writeArchive(
+                destination: source,
+                items: [
+                    .addData(archivePath: "Readme.txt", data: Data("quiet".utf8)),
+                    .addData(archivePath: "README.txt", data: Data("SHOUTING".utf8)),
+                ],
+                options: .init(format: .zip)
+            )
+
+            let saved = dir.appendingPathComponent("saved.zip")
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved, items: [], options: .init(format: .zip, level: 9))
+
+            #expect(try run("/usr/bin/unzip", ["-p", saved.path, "Readme.txt"]) == "quiet")
+            #expect(try run("/usr/bin/unzip", ["-p", saved.path, "README.txt"]) == "SHOUTING")
+        }
+
+        // Save (in place) is an update on purpose: what it doesn't touch it copies as is.
+        @Test func saveInPlaceLeavesUntouchedEntriesAsTheyWere() throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = try makeSource(.zip, in: dir)
+
+            try SevenZipArchive.writeArchive(
+                source: source, destination: source,
+                items: [.addData(archivePath: "new.txt", data: Data(Self.alpha.utf8))],
+                options: .init(format: .zip, method: .lzma))
+
+            let methods = try zipMethods(source)
+            #expect(methods["a.txt"] == "defN", "an untouched entry keeps its bytes on Save")
+            #expect(methods["new.txt"] == "lzma")
+        }
+
+        // Until the sheet can set a password, rebuilding would write an encrypted
+        // archive out in plain. Keeping its format keeps it as it was.
+        @Test func saveAsKeepsAnEncryptedSourceEncrypted() throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = dir.appendingPathComponent("source.zip")
+            try FileManager.default.copyItem(at: passwordFixture("zip_aes256.zip"), to: source)
+            let before = try SevenZipArchive(url: source).entries.filter(\.isEncrypted).count
+            #expect(before > 0)
+
+            let saved = dir.appendingPathComponent("saved.zip")
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved, items: [], options: .init(format: .zip))
+
+            let after = try SevenZipArchive(url: saved).entries.filter(\.isEncrypted).count
+            #expect(after == before, "Save As must never turn an encrypted archive into a plain one")
+            let out = dir.appendingPathComponent("out")
+            try FileManager.default.createDirectory(at: out, withIntermediateDirectories: true)
+            try SevenZipArchive(url: saved, password: "password").extractAll(to: out)
+        }
+
+        @Test func saveAsRefusesToConvertAnEncryptedSource() throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = dir.appendingPathComponent("source.zip")
+            try FileManager.default.copyItem(at: passwordFixture("zip_aes256.zip"), to: source)
+
+            let saved = dir.appendingPathComponent("saved.7z")
+            #expect(throws: SevenZipError.self) {
+                try SevenZipArchive.writeArchive(
+                    source: source, destination: saved, items: [], options: .init(format: .sevenZ))
+            }
+            #expect(!FileManager.default.fileExists(atPath: saved.path),
+                    "nothing may be left behind under the new name")
+        }
+
+        // Made by `zip`, not by us: sidecars beside their files and under the
+        // `__MACOSX/` mirror, one for a folder the archive only implies, a real file
+        // named like a sidecar, and a sidecar with nothing to describe.
+        @Test(arguments: [SevenZipCompressionOptions.Format.zip, .sevenZ])
+        func saveAsKeepsTheMacMetadataOfAFinderStyleArchive(
+            into format: SevenZipCompressionOptions.Format
+        ) async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let source = Bundle.module.url(forResource: "zip", withExtension: nil)!
+                .appendingPathComponent("appledouble.zip")
+            let saved = dir.appendingPathComponent("saved.\(format.rawValue)")
+            try SevenZipArchive.writeArchive(
+                source: source, destination: saved, items: [], options: .init(format: format))
+
+            let out = dir.appendingPathComponent("out")
+            try await extractWithOurEngine(saved, to: out)
+            let payload = out.appendingPathComponent("payload")
+            for target in ["Contents/Resources/icon.png", "Contents/MacOS/helper"] {
+                let file = payload.appendingPathComponent(target)
+                #expect(extendedAttribute("com.apple.ResourceFork", at: file)
+                        == Data("RESOURCE-FORK-PAYLOAD".utf8), "\(target) keeps its resource fork")
+                #expect(extendedAttribute("com.macpacker.test", at: file)
+                        == Data("appledouble-fixture".utf8), "\(target) keeps its attribute")
+            }
+            #expect(extendedAttribute("com.macpacker.dir", at: payload.appendingPathComponent("Contents/Resources"))
+                    == Data("appledouble-fixture".utf8), "the implied Resources folder keeps its metadata")
+            #expect(extendedAttribute("com.macpacker.sequestered", at: payload.appendingPathComponent("Contents/Info.plist"))
+                    == Data("appledouble-fixture".utf8), "the sidecar from the __MACOSX mirror still applies")
+            #expect((try? Data(contentsOf: payload.appendingPathComponent("._notadouble.txt")))
+                    == Data("A real file that merely starts with dot-underscore.\n".utf8),
+                    "a real file named like a sidecar survives")
+            #expect(FileManager.default.fileExists(atPath: payload.appendingPathComponent("._orphan.bin").path),
+                    "a sidecar with nothing to describe stays a file")
+            #expect(!FileManager.default.fileExists(atPath: out.appendingPathComponent("__MACOSX").path))
+        }
+
+        @MainActor @Test func saveAsThroughTheWindowWritesTheChosenFormat() async throws {
+            let dir = try makeTempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let zip = try makeSystemZipFixture(in: dir)
+
+            let state = ArchiveState(catalog: ArchiveTypeCatalog(), engineSelector: ArchiveEngineSelector7zip())
+            state.open(url: zip)
+            try await state.openTask?.value
+
+            let saved = dir.appendingPathComponent("copy.7z")
+            await state.save(to: saved)?.value
+
+            #expect(state.error == nil, "\(state.error ?? "")")
+            let format = try archiveFormat(of: saved)
+            #expect(format == "7z", "Save As .7z wrote a \(format)")
+            #expect(state.url == saved)
+            #expect(state.entries.values.contains { $0.virtualPath == "folder/one.txt" })
         }
     }
 }


### PR DESCRIPTION
Save As on an archive that is already open now writes the archive again from its contents, in the format and with the compression the save panel asked for.

Before, it ran an update: 7-Zip reused the source's format handler and copied every unchanged entry byte for byte. A zip saved as 7z came out a zip named `.7z` (and the reverse), and the compression picked in the panel only reached newly added files.

## What changes

- **Save As to a new file rebuilds.** Kept entries are extracted to scratch and added back with their paths, dates and modes, then written in the target format with the chosen options.
- **Mac metadata survives the rebuild.** Extraction folds AppleDouble sidecars onto their files and the writer packs fresh ones, the path #216 added. Files named like sidecars without being AppleDouble come back as themselves, found through the new `sz_entry_path` because both the listing and Foundation's directory listings hide them. A folder the archive only implies gets an entry when it carries metadata.
- **Nothing is dropped silently.** Names that differ only in case are extracted apart, and an entry that cannot be read back fails the save.
- **Save in place is unchanged.** It is still an update, and untouched entries stay byte-identical.
- **Encrypted sources:** a same-format Save As still copies them as they are, so they stay encrypted. Converting to the other format is refused with an error: with no password option yet, a rebuild would write them out unencrypted.

## Tests

11 new tests in `ZipWriteTests.swift` (`SaveAsRebuildTests`), written to fail first. Results are read back by XAD as well as the 7-Zip engine, and by `zipinfo`, `unzip` and `7zz` where they apply. One rebuilds `appledouble.zip` from TestArchives — made by `zip`, not by us — into zip and 7z and checks every kind of sidecar it holds.

`swift test`: 460 passing, 2 known issues. Both are the 7z case of `saveAsKeepsWhatTheEntriesCarry` and come from #243, found while testing this: MacPacker's 7z reader ignores Unix modes. The rebuilt 7z itself is correct according to `7zz`.

## Worth knowing

- `writeArchive(source:destination:)` with default options now writes the documented default format, 7z, instead of silently keeping the source's. The app always passes the format; `moveKeepsPosixMode` relied on the old behaviour and now asks for zip.
- A Save As now needs temporary disk space about the size of the unpacked archive, plus decompress and recompress time. Progress shows the extraction as the first half.
- No changelog entry yet: the wording gets approved first.

Closes #242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Save As support for rebuilding archives in a different format.
  * Preserved archive contents, metadata, pending changes, compression settings, and special filenames during Save As operations.
  * Added support for retrieving paths of archive entries that may not appear in standard listings.

* **Bug Fixes**
  * Improved handling of in-place archive updates and format detection.
  * Added clear failure handling when attempting unsupported operations with encrypted archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->