### PR TITLE
ci: fail a pull request when a bundled binary has no arm64 slice

### DIFF
--- a/.github/workflows/guard-architectures.yml
+++ b/.github/workflows/guard-architectures.yml
@@ -1,0 +1,49 @@
+# ── Architecture guard ────────────────────────────────────────────────────────
+# macOS 27 is the last release that runs Intel-only apps under Rosetta on Apple
+# silicon, so everything shipped inside MacPacker.app needs an arm64 slice.
+#
+# Linked code cannot regress unnoticed — a dependency without arm64 fails the
+# link. This job covers what is only copied into the bundle: helper tools, XPC
+# services and nested apps inside a binary dependency, whose slices nothing
+# looks at today.
+#
+# Only triggers when a pull request touches the dependency pins or the project
+# file, since nothing else changes which binaries get bundled. Because of that
+# paths filter this workflow does not report on most pull requests, so it must
+# NOT be configured as a required status check — required checks that never
+# report block merging.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Guard Architectures
+
+on:
+  pull_request:
+    paths:
+      - 'Modules/Package.swift'
+      - 'Modules/Package.resolved'
+      - 'MacPacker.xcodeproj/project.pbxproj'
+      - 'MacPacker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'
+      - 'scripts/check-architectures.sh'
+      - '.github/workflows/guard-architectures.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      # Unsigned, so a pull request from a fork needs no secrets.
+      - name: Build the app
+        run: |
+          xcodebuild -scheme MacPacker -configuration Release \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" \
+            -quiet build
+
+      - name: Check every bundled binary for an arm64 slice
+        run: scripts/check-architectures.sh build/Build/Products/Release/MacPacker.app

--- a/scripts/check-architectures.sh
+++ b/scripts/check-architectures.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# ── Architecture guard ───────────────────────────────────────────────────────
+# macOS 27 is the last release that runs Intel-only apps under Rosetta on Apple
+# silicon, so every executable MacPacker ships needs an arm64 slice.
+#
+# Code that is *linked* cannot regress unnoticed: a dependency without arm64
+# fails the link and the build goes red. The gap this closes is code that is
+# only *copied* into the bundle — helper tools, XPC services and nested apps
+# inside a binary dependency. Sparkle alone contributes four of those
+# (Autoupdate, Updater.app, Downloader.xpc, Installer.xpc). Nothing examines
+# their slices today, so a dependency update could swap in an Intel-only build
+# and ship it.
+#
+# Requires an arm64 slice rather than a universal binary, so it holds for a
+# local Debug build (arm64 only, ONLY_ACTIVE_ARCH) as well as for Release.
+#
+# Usage:
+#   scripts/check-architectures.sh <path> [<path> …]
+#
+#   # a built app bundle
+#   scripts/check-architectures.sh build/Build/Products/Release/MacPacker.app
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: $(basename "$0") <path> [<path> …]" >&2
+    exit 2
+fi
+
+table=$(mktemp)
+trap 'rm -f "$table"' EXIT
+
+checked=0
+offenders=""
+offender_count=0
+
+for root in "$@"; do
+    root="${root%/}"
+    if [ ! -e "$root" ]; then
+        echo "::error::$root does not exist" >&2
+        exit 1
+    fi
+
+    # Paths are reported relative to the parent, so the bundle name stays in.
+    base=$(dirname "$root")
+
+    # -type f skips the symlinks a framework uses for its Versions/Current
+    # layout, which would otherwise report the same binary several times.
+    while IFS= read -r -d '' file; do
+        # The only Mach-O test that needs no parsing: lipo fails on anything
+        # else. Thin binaries report their one slice, fat binaries all of them.
+        archs=$(lipo -archs "$file" 2>/dev/null) || continue
+
+        checked=$((checked + 1))
+        rel="${file#"$base"/}"
+        printf '%-24s %s\n' "$archs" "$rel" >>"$table"
+
+        case " $archs " in
+            *" arm64 "* | *" arm64e "*) ;;
+            *)
+                offenders="${offenders}${rel} (${archs})"$'\n'
+                offender_count=$((offender_count + 1))
+                ;;
+        esac
+    done < <(find "$root" -type f -print0)
+done
+
+sort -k2 "$table"
+echo
+
+if [ "$checked" -eq 0 ]; then
+    echo "::error::no Mach-O files found under $* — check the path" >&2
+    exit 1
+fi
+
+if [ "$offender_count" -gt 0 ]; then
+    printf '%s' "$offenders" | while IFS= read -r line; do
+        echo "::error::no arm64 slice, so this needs Rosetta: $line"
+    done
+    echo "$checked Mach-O files checked, $offender_count without an arm64 slice." >&2
+    exit 1
+fi
+
+echo "$checked Mach-O files checked, every one has an arm64 slice."


### PR DESCRIPTION
## What & why

macOS 27 is the last release that runs Intel-only apps under Rosetta on Apple silicon, so every executable shipped inside `MacPacker.app` needs an `arm64` slice.

**The audit came back clean.** All ten Mach-O files in a Release build are universal (`x86_64 arm64`) — the app, both extensions, XADMaster, UniversalDetector and all five of Sparkle's binaries. Nothing in MacPacker depends on Rosetta today, and there is nothing to fix.

What isn't covered is the future, which is the part of the issue this PR actually changes. Linked code can't regress unnoticed: a dependency without `arm64` fails the link and the build goes red. The gap is code that is only *copied* into the bundle — helper tools, XPC services and nested apps inside a binary dependency. Sparkle contributes four of those (`Autoupdate`, `Updater.app`, `Downloader.xpc`, `Installer.xpc`); nothing looks at their slices, so a dependency update could swap in an Intel-only build and ship it.

So this adds two files:

- **`scripts/check-architectures.sh`** — walks any path, finds every Mach-O (`lipo -archs` is the whole test; it fails on anything that isn't one), prints the slice table, and exits non-zero with a `::error::` annotation per binary missing `arm64`.
- **`.github/workflows/guard-architectures.yml`** — builds the app unsigned, then runs that script over the bundle.

Two judgement calls, both easy to change if you'd rather have them another way:

- **It requires an `arm64` slice, not a universal binary.** That keeps the same check valid for a local Debug build, which is `arm64`-only under `ONLY_ACTIVE_ARCH`. Demanding universal would make it Release-only and would fail on every developer machine.
- **It's a paths-filtered guard workflow, not a step in the orchestrator or an Xcode build phase.** It copies Guard Version's shape, and triggers only on the dependency pins and the project file, since nothing else changes which binaries get bundled. The same caveat therefore applies, and I put it in the file's header comment too: **it does not report on most pull requests, so it must not be configured as a required status check.** A `Run Script` phase in `project.pbxproj` would instead cover every build including the orchestrator's, at the cost of adding the first shell phase to the project — say the word and I'll switch it over.

No changelog entry, since nothing changes for users: the audit found nothing to fix and the guard is CI-only. Happy to add one if you'd like it recorded anyway.

Closes #205

## How it was verified

**1. The audit — Release bundle, the configuration that ships.** This is also exactly what the CI job runs:

```
$ xcodebuild -scheme MacPacker -configuration Release -derivedDataPath build \
    CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" -quiet build
$ scripts/check-architectures.sh build/Build/Products/Release/MacPacker.app
x86_64 arm64             MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate
x86_64 arm64             MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle
x86_64 arm64             MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app/Contents/MacOS/Updater
x86_64 arm64             MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader
x86_64 arm64             MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer
x86_64 arm64             MacPacker.app/Contents/Frameworks/UniversalDetector.framework/Versions/A/UniversalDetector
x86_64 arm64             MacPacker.app/Contents/Frameworks/XADMaster.framework/Versions/A/XADMaster
x86_64 arm64             MacPacker.app/Contents/MacOS/MacPacker
x86_64 arm64             MacPacker.app/Contents/PlugIns/FinderExtension.appex/Contents/MacOS/FinderExtension
x86_64 arm64             MacPacker.app/Contents/PlugIns/QuickLookExtension.appex/Contents/MacOS/QuickLookExtension

10 Mach-O files checked, every one has an arm64 slice.
$ echo $?
0
```

**2. The check actually catches a regression.** A passing check proves nothing on its own, so I planted an Intel-only binary where a dependency update would put one — over Sparkle's `Autoupdate` helper, one of the copied-not-linked binaries this is meant to protect:

```
$ cp -R build/Build/Products/Release/MacPacker.app /tmp/neg/MacPacker.app
$ printf 'int main(void){return 0;}\n' > /tmp/neg/helper.c
$ clang -arch x86_64 -o /tmp/neg/MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate /tmp/neg/helper.c
$ lipo -archs /tmp/neg/MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate
x86_64

$ scripts/check-architectures.sh /tmp/neg/MacPacker.app
...
x86_64                   MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate
...
::error::no arm64 slice, so this needs Rosetta: MacPacker.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate (x86_64)
10 Mach-O files checked, 1 without an arm64 slice.
$ echo $?
1
```

**3. No false failure on a Debug build.** Debug is `arm64`-only for first-party code under `ONLY_ACTIVE_ARCH`, and includes the `.debug.dylib` / `__preview.dylib` / `libswiftCompatibilitySpan.dylib` files Release doesn't — 17 Mach-O files instead of 10, still green:

```
$ xcodebuild -scheme MacPacker -configuration Debug -derivedDataPath build-debug \
    CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" build
$ scripts/check-architectures.sh build-debug/Build/Products/Debug/MacPacker.app
...
x86_64 arm64 arm64e      MacPacker.app/Contents/Frameworks/libswiftCompatibilitySpan.dylib

17 Mach-O files checked, every one has an arm64 slice.
$ echo $?
0
```

**4. Other exit paths**, so a mistyped path can't pass silently as "nothing wrong":

| invocation | exit |
| --- | --- |
| clean bundle | 0 |
| bundle with an Intel-only binary | 1 |
| path that doesn't exist | 1 |
| path containing no Mach-O at all | 1 |
| no arguments (prints usage) | 2 |

**5. Existing tests still pass** — no Swift code changed, but for completeness:

```
$ swift test --package-path Modules
✔ Test run with 449 tests in 121 suites passed after 14.197 seconds.
```

Written against `/bin/bash` 3.2 (what macOS ships), so no bash 4 features — no associative or `set -u`-unsafe empty arrays.

## Checklist

- [x] Verification evidence is included above
- [ ] Changelog entry added to `Config/products/macpacker.json` — intentionally omitted, no user-visible change (see above)
- [x] AI involvement disclosed, if AI was the primary author — see [AI_CONTRIBUTING.md](../AI_CONTRIBUTING.md)

---

**AI disclosure:** the script, the workflow and this description were written by Claude Opus 5 (Claude Code), pointed at `AGENTS.md`. Every command above was really run on an M-series Mac and the output is what it produced, negative test included; the only edits are shortened temporary paths and the elided `...` lines. I'm accountable for the contents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build and Compatibility**
  - Improved macOS build validation to verify required Apple Silicon and Intel architectures.
  - Added Apple Silicon–only validation for local Debug builds.
  - Reports now provide clearer, platform-specific diagnostics when architectures are missing.

- **Continuous Integration**
  - Pull request builds validate bundled application binaries across supported configurations.
  - Store builds now use the Release Store configuration.
  - Updated macOS workflow tooling to improve post-build validation reliability.

- **Documentation**
  - Clarified the distinction between unit tests and pull request build checks, including architecture validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->